### PR TITLE
Added "...ToString" functions for all SPIRV/1.2 enums.

### DIFF
--- a/include/spirv/1.2/spirv_strings.h
+++ b/include/spirv/1.2/spirv_strings.h
@@ -1,0 +1,1284 @@
+/*
+** Copyright (c) 2014-2017 The Khronos Group Inc.
+** 
+** Permission is hereby granted, free of charge, to any person obtaining a copy
+** of this software and/or associated documentation files (the "Materials"),
+** to deal in the Materials without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Materials, and to permit persons to whom the
+** Materials are furnished to do so, subject to the following conditions:
+** 
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Materials.
+** 
+** MODIFICATIONS TO THIS FILE MAY MEAN IT NO LONGER ACCURATELY REFLECTS KHRONOS
+** STANDARDS. THE UNMODIFIED, NORMATIVE VERSIONS OF KHRONOS SPECIFICATIONS AND
+** HEADER INFORMATION ARE LOCATED AT https://www.khronos.org/registry/ 
+** 
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+** OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+** THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM,OUT OF OR IN CONNECTION WITH THE MATERIALS OR THE USE OR OTHER DEALINGS
+** IN THE MATERIALS.
+*/
+
+#ifndef spirv_strings_H
+#define spirv_strings_H
+
+#include "spirv.h"
+
+#ifndef SPIRV_DEF
+#   ifdef SPIRV_STRINGS_IMPLEMENT
+#       define SPIRV_DEF
+#   else
+#       define SPIRV_DEF extern
+#   endif
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+SPIRV_DEF const char* SpvSourceLanguageToString(SpvSourceLanguage e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case SpvSourceLanguageUnknown: return "Unknown";
+        case SpvSourceLanguageESSL: return "ESSL";
+        case SpvSourceLanguageGLSL: return "GLSL";
+        case SpvSourceLanguageOpenCL_C: return "OpenCL_C";
+        case SpvSourceLanguageOpenCL_CPP: return "OpenCL_CPP";
+        case SpvSourceLanguageHLSL: return "HLSL";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* SpvExecutionModelToString(SpvExecutionModel e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case SpvExecutionModelVertex: return "Vertex";
+        case SpvExecutionModelTessellationControl: return "TessellationControl";
+        case SpvExecutionModelTessellationEvaluation: return "TessellationEvaluation";
+        case SpvExecutionModelGeometry: return "Geometry";
+        case SpvExecutionModelFragment: return "Fragment";
+        case SpvExecutionModelGLCompute: return "GLCompute";
+        case SpvExecutionModelKernel: return "Kernel";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* SpvAddressingModelToString(SpvAddressingModel e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case SpvAddressingModelLogical: return "Logical";
+        case SpvAddressingModelPhysical32: return "Physical32";
+        case SpvAddressingModelPhysical64: return "Physical64";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* SpvMemoryModelToString(SpvMemoryModel e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case SpvMemoryModelSimple: return "Simple";
+        case SpvMemoryModelGLSL450: return "GLSL450";
+        case SpvMemoryModelOpenCL: return "OpenCL";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* SpvExecutionModeToString(SpvExecutionMode e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case SpvExecutionModeInvocations: return "Invocations";
+        case SpvExecutionModeSpacingEqual: return "SpacingEqual";
+        case SpvExecutionModeSpacingFractionalEven: return "SpacingFractionalEven";
+        case SpvExecutionModeSpacingFractionalOdd: return "SpacingFractionalOdd";
+        case SpvExecutionModeVertexOrderCw: return "VertexOrderCw";
+        case SpvExecutionModeVertexOrderCcw: return "VertexOrderCcw";
+        case SpvExecutionModePixelCenterInteger: return "PixelCenterInteger";
+        case SpvExecutionModeOriginUpperLeft: return "OriginUpperLeft";
+        case SpvExecutionModeOriginLowerLeft: return "OriginLowerLeft";
+        case SpvExecutionModeEarlyFragmentTests: return "EarlyFragmentTests";
+        case SpvExecutionModePointMode: return "PointMode";
+        case SpvExecutionModeXfb: return "Xfb";
+        case SpvExecutionModeDepthReplacing: return "DepthReplacing";
+        case SpvExecutionModeDepthGreater: return "DepthGreater";
+        case SpvExecutionModeDepthLess: return "DepthLess";
+        case SpvExecutionModeDepthUnchanged: return "DepthUnchanged";
+        case SpvExecutionModeLocalSize: return "LocalSize";
+        case SpvExecutionModeLocalSizeHint: return "LocalSizeHint";
+        case SpvExecutionModeInputPoints: return "InputPoints";
+        case SpvExecutionModeInputLines: return "InputLines";
+        case SpvExecutionModeInputLinesAdjacency: return "InputLinesAdjacency";
+        case SpvExecutionModeTriangles: return "Triangles";
+        case SpvExecutionModeInputTrianglesAdjacency: return "InputTrianglesAdjacency";
+        case SpvExecutionModeQuads: return "Quads";
+        case SpvExecutionModeIsolines: return "Isolines";
+        case SpvExecutionModeOutputVertices: return "OutputVertices";
+        case SpvExecutionModeOutputPoints: return "OutputPoints";
+        case SpvExecutionModeOutputLineStrip: return "OutputLineStrip";
+        case SpvExecutionModeOutputTriangleStrip: return "OutputTriangleStrip";
+        case SpvExecutionModeVecTypeHint: return "VecTypeHint";
+        case SpvExecutionModeContractionOff: return "ContractionOff";
+        case SpvExecutionModeInitializer: return "Initializer";
+        case SpvExecutionModeFinalizer: return "Finalizer";
+        case SpvExecutionModeSubgroupSize: return "SubgroupSize";
+        case SpvExecutionModeSubgroupsPerWorkgroup: return "SubgroupsPerWorkgroup";
+        case SpvExecutionModeSubgroupsPerWorkgroupId: return "SubgroupsPerWorkgroupId";
+        case SpvExecutionModeLocalSizeId: return "LocalSizeId";
+        case SpvExecutionModeLocalSizeHintId: return "LocalSizeHintId";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* SpvStorageClassToString(SpvStorageClass e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case SpvStorageClassUniformConstant: return "UniformConstant";
+        case SpvStorageClassInput: return "Input";
+        case SpvStorageClassUniform: return "Uniform";
+        case SpvStorageClassOutput: return "Output";
+        case SpvStorageClassWorkgroup: return "Workgroup";
+        case SpvStorageClassCrossWorkgroup: return "CrossWorkgroup";
+        case SpvStorageClassPrivate: return "Private";
+        case SpvStorageClassFunction: return "Function";
+        case SpvStorageClassGeneric: return "Generic";
+        case SpvStorageClassPushConstant: return "PushConstant";
+        case SpvStorageClassAtomicCounter: return "AtomicCounter";
+        case SpvStorageClassImage: return "Image";
+        case SpvStorageClassStorageBuffer: return "StorageBuffer";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* SpvDimToString(SpvDim e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case SpvDim1D: return "1D";
+        case SpvDim2D: return "2D";
+        case SpvDim3D: return "3D";
+        case SpvDimCube: return "Cube";
+        case SpvDimRect: return "Rect";
+        case SpvDimBuffer: return "Buffer";
+        case SpvDimSubpassData: return "SubpassData";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* SpvSamplerAddressingModeToString(SpvSamplerAddressingMode e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case SpvSamplerAddressingModeNone: return "None";
+        case SpvSamplerAddressingModeClampToEdge: return "ClampToEdge";
+        case SpvSamplerAddressingModeClamp: return "Clamp";
+        case SpvSamplerAddressingModeRepeat: return "Repeat";
+        case SpvSamplerAddressingModeRepeatMirrored: return "RepeatMirrored";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* SpvSamplerFilterModeToString(SpvSamplerFilterMode e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case SpvSamplerFilterModeNearest: return "Nearest";
+        case SpvSamplerFilterModeLinear: return "Linear";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* SpvImageFormatToString(SpvImageFormat e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case SpvImageFormatUnknown: return "Unknown";
+        case SpvImageFormatRgba32f: return "Rgba32f";
+        case SpvImageFormatRgba16f: return "Rgba16f";
+        case SpvImageFormatR32f: return "R32f";
+        case SpvImageFormatRgba8: return "Rgba8";
+        case SpvImageFormatRgba8Snorm: return "Rgba8Snorm";
+        case SpvImageFormatRg32f: return "Rg32f";
+        case SpvImageFormatRg16f: return "Rg16f";
+        case SpvImageFormatR11fG11fB10f: return "R11fG11fB10f";
+        case SpvImageFormatR16f: return "R16f";
+        case SpvImageFormatRgba16: return "Rgba16";
+        case SpvImageFormatRgb10A2: return "Rgb10A2";
+        case SpvImageFormatRg16: return "Rg16";
+        case SpvImageFormatRg8: return "Rg8";
+        case SpvImageFormatR16: return "R16";
+        case SpvImageFormatR8: return "R8";
+        case SpvImageFormatRgba16Snorm: return "Rgba16Snorm";
+        case SpvImageFormatRg16Snorm: return "Rg16Snorm";
+        case SpvImageFormatRg8Snorm: return "Rg8Snorm";
+        case SpvImageFormatR16Snorm: return "R16Snorm";
+        case SpvImageFormatR8Snorm: return "R8Snorm";
+        case SpvImageFormatRgba32i: return "Rgba32i";
+        case SpvImageFormatRgba16i: return "Rgba16i";
+        case SpvImageFormatRgba8i: return "Rgba8i";
+        case SpvImageFormatR32i: return "R32i";
+        case SpvImageFormatRg32i: return "Rg32i";
+        case SpvImageFormatRg16i: return "Rg16i";
+        case SpvImageFormatRg8i: return "Rg8i";
+        case SpvImageFormatR16i: return "R16i";
+        case SpvImageFormatR8i: return "R8i";
+        case SpvImageFormatRgba32ui: return "Rgba32ui";
+        case SpvImageFormatRgba16ui: return "Rgba16ui";
+        case SpvImageFormatRgba8ui: return "Rgba8ui";
+        case SpvImageFormatR32ui: return "R32ui";
+        case SpvImageFormatRgb10a2ui: return "Rgb10a2ui";
+        case SpvImageFormatRg32ui: return "Rg32ui";
+        case SpvImageFormatRg16ui: return "Rg16ui";
+        case SpvImageFormatRg8ui: return "Rg8ui";
+        case SpvImageFormatR16ui: return "R16ui";
+        case SpvImageFormatR8ui: return "R8ui";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* SpvImageChannelOrderToString(SpvImageChannelOrder e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case SpvImageChannelOrderR: return "R";
+        case SpvImageChannelOrderA: return "A";
+        case SpvImageChannelOrderRG: return "RG";
+        case SpvImageChannelOrderRA: return "RA";
+        case SpvImageChannelOrderRGB: return "RGB";
+        case SpvImageChannelOrderRGBA: return "RGBA";
+        case SpvImageChannelOrderBGRA: return "BGRA";
+        case SpvImageChannelOrderARGB: return "ARGB";
+        case SpvImageChannelOrderIntensity: return "Intensity";
+        case SpvImageChannelOrderLuminance: return "Luminance";
+        case SpvImageChannelOrderRx: return "Rx";
+        case SpvImageChannelOrderRGx: return "RGx";
+        case SpvImageChannelOrderRGBx: return "RGBx";
+        case SpvImageChannelOrderDepth: return "Depth";
+        case SpvImageChannelOrderDepthStencil: return "DepthStencil";
+        case SpvImageChannelOrdersRGB: return "sRGB";
+        case SpvImageChannelOrdersRGBx: return "sRGBx";
+        case SpvImageChannelOrdersRGBA: return "sRGBA";
+        case SpvImageChannelOrdersBGRA: return "sBGRA";
+        case SpvImageChannelOrderABGR: return "ABGR";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* SpvImageChannelDataTypeToString(SpvImageChannelDataType e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case SpvImageChannelDataTypeSnormInt8: return "SnormInt8";
+        case SpvImageChannelDataTypeSnormInt16: return "SnormInt16";
+        case SpvImageChannelDataTypeUnormInt8: return "UnormInt8";
+        case SpvImageChannelDataTypeUnormInt16: return "UnormInt16";
+        case SpvImageChannelDataTypeUnormShort565: return "UnormShort565";
+        case SpvImageChannelDataTypeUnormShort555: return "UnormShort555";
+        case SpvImageChannelDataTypeUnormInt101010: return "UnormInt101010";
+        case SpvImageChannelDataTypeSignedInt8: return "SignedInt8";
+        case SpvImageChannelDataTypeSignedInt16: return "SignedInt16";
+        case SpvImageChannelDataTypeSignedInt32: return "SignedInt32";
+        case SpvImageChannelDataTypeUnsignedInt8: return "UnsignedInt8";
+        case SpvImageChannelDataTypeUnsignedInt16: return "UnsignedInt16";
+        case SpvImageChannelDataTypeUnsignedInt32: return "UnsignedInt32";
+        case SpvImageChannelDataTypeHalfFloat: return "HalfFloat";
+        case SpvImageChannelDataTypeFloat: return "Float";
+        case SpvImageChannelDataTypeUnormInt24: return "UnormInt24";
+        case SpvImageChannelDataTypeUnormInt101010_2: return "UnormInt101010_2";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* SpvImageOperandsShiftToString(SpvImageOperandsShift e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case SpvImageOperandsBiasShift: return "Bias";
+        case SpvImageOperandsLodShift: return "Lod";
+        case SpvImageOperandsGradShift: return "Grad";
+        case SpvImageOperandsConstOffsetShift: return "ConstOffset";
+        case SpvImageOperandsOffsetShift: return "Offset";
+        case SpvImageOperandsConstOffsetsShift: return "ConstOffsets";
+        case SpvImageOperandsSampleShift: return "Sample";
+        case SpvImageOperandsMinLodShift: return "MinLod";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* SpvImageOperandsMaskToString(SpvImageOperandsMask e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case SpvImageOperandsMaskNone: return "None";
+        case SpvImageOperandsBiasMask: return "Bias";
+        case SpvImageOperandsLodMask: return "Lod";
+        case SpvImageOperandsGradMask: return "Grad";
+        case SpvImageOperandsConstOffsetMask: return "ConstOffset";
+        case SpvImageOperandsOffsetMask: return "Offset";
+        case SpvImageOperandsConstOffsetsMask: return "ConstOffsets";
+        case SpvImageOperandsSampleMask: return "Sample";
+        case SpvImageOperandsMinLodMask: return "MinLod";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* SpvFPFastMathModeShiftToString(SpvFPFastMathModeShift e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case SpvFPFastMathModeNotNaNShift: return "NotNaN";
+        case SpvFPFastMathModeNotInfShift: return "NotInf";
+        case SpvFPFastMathModeNSZShift: return "NSZ";
+        case SpvFPFastMathModeAllowRecipShift: return "AllowRecip";
+        case SpvFPFastMathModeFastShift: return "Fast";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* SpvFPFastMathModeMaskToString(SpvFPFastMathModeMask e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case SpvFPFastMathModeMaskNone: return "None";
+        case SpvFPFastMathModeNotNaNMask: return "NotNaN";
+        case SpvFPFastMathModeNotInfMask: return "NotInf";
+        case SpvFPFastMathModeNSZMask: return "NSZ";
+        case SpvFPFastMathModeAllowRecipMask: return "AllowRecip";
+        case SpvFPFastMathModeFastMask: return "Fast";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* SpvFPRoundingModeToString(SpvFPRoundingMode e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case SpvFPRoundingModeRTE: return "RTE";
+        case SpvFPRoundingModeRTZ: return "RTZ";
+        case SpvFPRoundingModeRTP: return "RTP";
+        case SpvFPRoundingModeRTN: return "RTN";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* SpvLinkageTypeToString(SpvLinkageType e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case SpvLinkageTypeExport: return "Export";
+        case SpvLinkageTypeImport: return "Import";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* SpvAccessQualifierToString(SpvAccessQualifier e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case SpvAccessQualifierReadOnly: return "ReadOnly";
+        case SpvAccessQualifierWriteOnly: return "WriteOnly";
+        case SpvAccessQualifierReadWrite: return "ReadWrite";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* SpvFunctionParameterAttributeToString(SpvFunctionParameterAttribute e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case SpvFunctionParameterAttributeZext: return "Zext";
+        case SpvFunctionParameterAttributeSext: return "Sext";
+        case SpvFunctionParameterAttributeByVal: return "ByVal";
+        case SpvFunctionParameterAttributeSret: return "Sret";
+        case SpvFunctionParameterAttributeNoAlias: return "NoAlias";
+        case SpvFunctionParameterAttributeNoCapture: return "NoCapture";
+        case SpvFunctionParameterAttributeNoWrite: return "NoWrite";
+        case SpvFunctionParameterAttributeNoReadWrite: return "NoReadWrite";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* SpvDecorationToString(SpvDecoration e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case SpvDecorationRelaxedPrecision: return "RelaxedPrecision";
+        case SpvDecorationSpecId: return "SpecId";
+        case SpvDecorationBlock: return "Block";
+        case SpvDecorationBufferBlock: return "BufferBlock";
+        case SpvDecorationRowMajor: return "RowMajor";
+        case SpvDecorationColMajor: return "ColMajor";
+        case SpvDecorationArrayStride: return "ArrayStride";
+        case SpvDecorationMatrixStride: return "MatrixStride";
+        case SpvDecorationGLSLShared: return "GLSLShared";
+        case SpvDecorationGLSLPacked: return "GLSLPacked";
+        case SpvDecorationCPacked: return "CPacked";
+        case SpvDecorationBuiltIn: return "BuiltIn";
+        case SpvDecorationNoPerspective: return "NoPerspective";
+        case SpvDecorationFlat: return "Flat";
+        case SpvDecorationPatch: return "Patch";
+        case SpvDecorationCentroid: return "Centroid";
+        case SpvDecorationSample: return "Sample";
+        case SpvDecorationInvariant: return "Invariant";
+        case SpvDecorationRestrict: return "Restrict";
+        case SpvDecorationAliased: return "Aliased";
+        case SpvDecorationVolatile: return "Volatile";
+        case SpvDecorationConstant: return "Constant";
+        case SpvDecorationCoherent: return "Coherent";
+        case SpvDecorationNonWritable: return "NonWritable";
+        case SpvDecorationNonReadable: return "NonReadable";
+        case SpvDecorationUniform: return "Uniform";
+        case SpvDecorationSaturatedConversion: return "SaturatedConversion";
+        case SpvDecorationStream: return "Stream";
+        case SpvDecorationLocation: return "Location";
+        case SpvDecorationComponent: return "Component";
+        case SpvDecorationIndex: return "Index";
+        case SpvDecorationBinding: return "Binding";
+        case SpvDecorationDescriptorSet: return "DescriptorSet";
+        case SpvDecorationOffset: return "Offset";
+        case SpvDecorationXfbBuffer: return "XfbBuffer";
+        case SpvDecorationXfbStride: return "XfbStride";
+        case SpvDecorationFuncParamAttr: return "FuncParamAttr";
+        case SpvDecorationFPRoundingMode: return "FPRoundingMode";
+        case SpvDecorationFPFastMathMode: return "FPFastMathMode";
+        case SpvDecorationLinkageAttributes: return "LinkageAttributes";
+        case SpvDecorationNoContraction: return "NoContraction";
+        case SpvDecorationInputAttachmentIndex: return "InputAttachmentIndex";
+        case SpvDecorationAlignment: return "Alignment";
+        case SpvDecorationMaxByteOffset: return "MaxByteOffset";
+        case SpvDecorationAlignmentId: return "AlignmentId";
+        case SpvDecorationMaxByteOffsetId: return "MaxByteOffsetId";
+        case SpvDecorationOverrideCoverageNV: return "OverrideCoverageNV";
+        case SpvDecorationPassthroughNV: return "PassthroughNV";
+        case SpvDecorationViewportRelativeNV: return "ViewportRelativeNV";
+        case SpvDecorationSecondaryViewportRelativeNV: return "SecondaryViewportRelativeNV";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* SpvBuiltInToString(SpvBuiltIn e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case SpvBuiltInPosition: return "Position";
+        case SpvBuiltInPointSize: return "PointSize";
+        case SpvBuiltInClipDistance: return "ClipDistance";
+        case SpvBuiltInCullDistance: return "CullDistance";
+        case SpvBuiltInVertexId: return "VertexId";
+        case SpvBuiltInInstanceId: return "InstanceId";
+        case SpvBuiltInPrimitiveId: return "PrimitiveId";
+        case SpvBuiltInInvocationId: return "InvocationId";
+        case SpvBuiltInLayer: return "Layer";
+        case SpvBuiltInViewportIndex: return "ViewportIndex";
+        case SpvBuiltInTessLevelOuter: return "TessLevelOuter";
+        case SpvBuiltInTessLevelInner: return "TessLevelInner";
+        case SpvBuiltInTessCoord: return "TessCoord";
+        case SpvBuiltInPatchVertices: return "PatchVertices";
+        case SpvBuiltInFragCoord: return "FragCoord";
+        case SpvBuiltInPointCoord: return "PointCoord";
+        case SpvBuiltInFrontFacing: return "FrontFacing";
+        case SpvBuiltInSampleId: return "SampleId";
+        case SpvBuiltInSamplePosition: return "SamplePosition";
+        case SpvBuiltInSampleMask: return "SampleMask";
+        case SpvBuiltInFragDepth: return "FragDepth";
+        case SpvBuiltInHelperInvocation: return "HelperInvocation";
+        case SpvBuiltInNumWorkgroups: return "NumWorkgroups";
+        case SpvBuiltInWorkgroupSize: return "WorkgroupSize";
+        case SpvBuiltInWorkgroupId: return "WorkgroupId";
+        case SpvBuiltInLocalInvocationId: return "LocalInvocationId";
+        case SpvBuiltInGlobalInvocationId: return "GlobalInvocationId";
+        case SpvBuiltInLocalInvocationIndex: return "LocalInvocationIndex";
+        case SpvBuiltInWorkDim: return "WorkDim";
+        case SpvBuiltInGlobalSize: return "GlobalSize";
+        case SpvBuiltInEnqueuedWorkgroupSize: return "EnqueuedWorkgroupSize";
+        case SpvBuiltInGlobalOffset: return "GlobalOffset";
+        case SpvBuiltInGlobalLinearId: return "GlobalLinearId";
+        case SpvBuiltInSubgroupSize: return "SubgroupSize";
+        case SpvBuiltInSubgroupMaxSize: return "SubgroupMaxSize";
+        case SpvBuiltInNumSubgroups: return "NumSubgroups";
+        case SpvBuiltInNumEnqueuedSubgroups: return "NumEnqueuedSubgroups";
+        case SpvBuiltInSubgroupId: return "SubgroupId";
+        case SpvBuiltInSubgroupLocalInvocationId: return "SubgroupLocalInvocationId";
+        case SpvBuiltInVertexIndex: return "VertexIndex";
+        case SpvBuiltInInstanceIndex: return "InstanceIndex";
+        case SpvBuiltInSubgroupEqMaskKHR: return "SubgroupEqMaskKHR";
+        case SpvBuiltInSubgroupGeMaskKHR: return "SubgroupGeMaskKHR";
+        case SpvBuiltInSubgroupGtMaskKHR: return "SubgroupGtMaskKHR";
+        case SpvBuiltInSubgroupLeMaskKHR: return "SubgroupLeMaskKHR";
+        case SpvBuiltInSubgroupLtMaskKHR: return "SubgroupLtMaskKHR";
+        case SpvBuiltInBaseVertex: return "BaseVertex";
+        case SpvBuiltInBaseInstance: return "BaseInstance";
+        case SpvBuiltInDrawIndex: return "DrawIndex";
+        case SpvBuiltInDeviceIndex: return "DeviceIndex";
+        case SpvBuiltInViewIndex: return "ViewIndex";
+        case SpvBuiltInViewportMaskNV: return "ViewportMaskNV";
+        case SpvBuiltInSecondaryPositionNV: return "SecondaryPositionNV";
+        case SpvBuiltInSecondaryViewportMaskNV: return "SecondaryViewportMaskNV";
+        case SpvBuiltInPositionPerViewNV: return "PositionPerViewNV";
+        case SpvBuiltInViewportMaskPerViewNV: return "ViewportMaskPerViewNV";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* SpvSelectionControlShiftToString(SpvSelectionControlShift e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case SpvSelectionControlFlattenShift: return "Flatten";
+        case SpvSelectionControlDontFlattenShift: return "DontFlatten";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* SpvSelectionControlMaskToString(SpvSelectionControlMask e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case SpvSelectionControlMaskNone: return "None";
+        case SpvSelectionControlFlattenMask: return "Flatten";
+        case SpvSelectionControlDontFlattenMask: return "DontFlatten";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* SpvLoopControlShiftToString(SpvLoopControlShift e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case SpvLoopControlUnrollShift: return "Unroll";
+        case SpvLoopControlDontUnrollShift: return "DontUnroll";
+        case SpvLoopControlDependencyInfiniteShift: return "DependencyInfinite";
+        case SpvLoopControlDependencyLengthShift: return "DependencyLength";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* SpvLoopControlMaskToString(SpvLoopControlMask e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case SpvLoopControlMaskNone: return "None";
+        case SpvLoopControlUnrollMask: return "Unroll";
+        case SpvLoopControlDontUnrollMask: return "DontUnroll";
+        case SpvLoopControlDependencyInfiniteMask: return "DependencyInfinite";
+        case SpvLoopControlDependencyLengthMask: return "DependencyLength";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* SpvFunctionControlShiftToString(SpvFunctionControlShift e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case SpvFunctionControlInlineShift: return "Inline";
+        case SpvFunctionControlDontInlineShift: return "DontInline";
+        case SpvFunctionControlPureShift: return "Pure";
+        case SpvFunctionControlConstShift: return "Const";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* SpvFunctionControlMaskToString(SpvFunctionControlMask e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case SpvFunctionControlMaskNone: return "None";
+        case SpvFunctionControlInlineMask: return "Inline";
+        case SpvFunctionControlDontInlineMask: return "DontInline";
+        case SpvFunctionControlPureMask: return "Pure";
+        case SpvFunctionControlConstMask: return "Const";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* SpvMemorySemanticsShiftToString(SpvMemorySemanticsShift e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case SpvMemorySemanticsAcquireShift: return "Acquire";
+        case SpvMemorySemanticsReleaseShift: return "Release";
+        case SpvMemorySemanticsAcquireReleaseShift: return "AcquireRelease";
+        case SpvMemorySemanticsSequentiallyConsistentShift: return "SequentiallyConsistent";
+        case SpvMemorySemanticsUniformMemoryShift: return "UniformMemory";
+        case SpvMemorySemanticsSubgroupMemoryShift: return "SubgroupMemory";
+        case SpvMemorySemanticsWorkgroupMemoryShift: return "WorkgroupMemory";
+        case SpvMemorySemanticsCrossWorkgroupMemoryShift: return "CrossWorkgroupMemory";
+        case SpvMemorySemanticsAtomicCounterMemoryShift: return "AtomicCounterMemory";
+        case SpvMemorySemanticsImageMemoryShift: return "ImageMemory";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* SpvMemorySemanticsMaskToString(SpvMemorySemanticsMask e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case SpvMemorySemanticsMaskNone: return "None";
+        case SpvMemorySemanticsAcquireMask: return "Acquire";
+        case SpvMemorySemanticsReleaseMask: return "Release";
+        case SpvMemorySemanticsAcquireReleaseMask: return "AcquireRelease";
+        case SpvMemorySemanticsSequentiallyConsistentMask: return "SequentiallyConsistent";
+        case SpvMemorySemanticsUniformMemoryMask: return "UniformMemory";
+        case SpvMemorySemanticsSubgroupMemoryMask: return "SubgroupMemory";
+        case SpvMemorySemanticsWorkgroupMemoryMask: return "WorkgroupMemory";
+        case SpvMemorySemanticsCrossWorkgroupMemoryMask: return "CrossWorkgroupMemory";
+        case SpvMemorySemanticsAtomicCounterMemoryMask: return "AtomicCounterMemory";
+        case SpvMemorySemanticsImageMemoryMask: return "ImageMemory";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* SpvMemoryAccessShiftToString(SpvMemoryAccessShift e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case SpvMemoryAccessVolatileShift: return "Volatile";
+        case SpvMemoryAccessAlignedShift: return "Aligned";
+        case SpvMemoryAccessNontemporalShift: return "Nontemporal";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* SpvMemoryAccessMaskToString(SpvMemoryAccessMask e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case SpvMemoryAccessMaskNone: return "None";
+        case SpvMemoryAccessVolatileMask: return "Volatile";
+        case SpvMemoryAccessAlignedMask: return "Aligned";
+        case SpvMemoryAccessNontemporalMask: return "Nontemporal";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* SpvScopeToString(SpvScope e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case SpvScopeCrossDevice: return "CrossDevice";
+        case SpvScopeDevice: return "Device";
+        case SpvScopeWorkgroup: return "Workgroup";
+        case SpvScopeSubgroup: return "Subgroup";
+        case SpvScopeInvocation: return "Invocation";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* SpvGroupOperationToString(SpvGroupOperation e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case SpvGroupOperationReduce: return "Reduce";
+        case SpvGroupOperationInclusiveScan: return "InclusiveScan";
+        case SpvGroupOperationExclusiveScan: return "ExclusiveScan";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* SpvKernelEnqueueFlagsToString(SpvKernelEnqueueFlags e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case SpvKernelEnqueueFlagsNoWait: return "NoWait";
+        case SpvKernelEnqueueFlagsWaitKernel: return "WaitKernel";
+        case SpvKernelEnqueueFlagsWaitWorkGroup: return "WaitWorkGroup";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* SpvKernelProfilingInfoShiftToString(SpvKernelProfilingInfoShift e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case SpvKernelProfilingInfoCmdExecTimeShift: return "CmdExecTime";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* SpvKernelProfilingInfoMaskToString(SpvKernelProfilingInfoMask e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case SpvKernelProfilingInfoMaskNone: return "None";
+        case SpvKernelProfilingInfoCmdExecTimeMask: return "CmdExecTime";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* SpvCapabilityToString(SpvCapability e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case SpvCapabilityMatrix: return "Matrix";
+        case SpvCapabilityShader: return "Shader";
+        case SpvCapabilityGeometry: return "Geometry";
+        case SpvCapabilityTessellation: return "Tessellation";
+        case SpvCapabilityAddresses: return "Addresses";
+        case SpvCapabilityLinkage: return "Linkage";
+        case SpvCapabilityKernel: return "Kernel";
+        case SpvCapabilityVector16: return "Vector16";
+        case SpvCapabilityFloat16Buffer: return "Float16Buffer";
+        case SpvCapabilityFloat16: return "Float16";
+        case SpvCapabilityFloat64: return "Float64";
+        case SpvCapabilityInt64: return "Int64";
+        case SpvCapabilityInt64Atomics: return "Int64Atomics";
+        case SpvCapabilityImageBasic: return "ImageBasic";
+        case SpvCapabilityImageReadWrite: return "ImageReadWrite";
+        case SpvCapabilityImageMipmap: return "ImageMipmap";
+        case SpvCapabilityPipes: return "Pipes";
+        case SpvCapabilityGroups: return "Groups";
+        case SpvCapabilityDeviceEnqueue: return "DeviceEnqueue";
+        case SpvCapabilityLiteralSampler: return "LiteralSampler";
+        case SpvCapabilityAtomicStorage: return "AtomicStorage";
+        case SpvCapabilityInt16: return "Int16";
+        case SpvCapabilityTessellationPointSize: return "TessellationPointSize";
+        case SpvCapabilityGeometryPointSize: return "GeometryPointSize";
+        case SpvCapabilityImageGatherExtended: return "ImageGatherExtended";
+        case SpvCapabilityStorageImageMultisample: return "StorageImageMultisample";
+        case SpvCapabilityUniformBufferArrayDynamicIndexing: return "UniformBufferArrayDynamicIndexing";
+        case SpvCapabilitySampledImageArrayDynamicIndexing: return "SampledImageArrayDynamicIndexing";
+        case SpvCapabilityStorageBufferArrayDynamicIndexing: return "StorageBufferArrayDynamicIndexing";
+        case SpvCapabilityStorageImageArrayDynamicIndexing: return "StorageImageArrayDynamicIndexing";
+        case SpvCapabilityClipDistance: return "ClipDistance";
+        case SpvCapabilityCullDistance: return "CullDistance";
+        case SpvCapabilityImageCubeArray: return "ImageCubeArray";
+        case SpvCapabilitySampleRateShading: return "SampleRateShading";
+        case SpvCapabilityImageRect: return "ImageRect";
+        case SpvCapabilitySampledRect: return "SampledRect";
+        case SpvCapabilityGenericPointer: return "GenericPointer";
+        case SpvCapabilityInt8: return "Int8";
+        case SpvCapabilityInputAttachment: return "InputAttachment";
+        case SpvCapabilitySparseResidency: return "SparseResidency";
+        case SpvCapabilityMinLod: return "MinLod";
+        case SpvCapabilitySampled1D: return "Sampled1D";
+        case SpvCapabilityImage1D: return "Image1D";
+        case SpvCapabilitySampledCubeArray: return "SampledCubeArray";
+        case SpvCapabilitySampledBuffer: return "SampledBuffer";
+        case SpvCapabilityImageBuffer: return "ImageBuffer";
+        case SpvCapabilityImageMSArray: return "ImageMSArray";
+        case SpvCapabilityStorageImageExtendedFormats: return "StorageImageExtendedFormats";
+        case SpvCapabilityImageQuery: return "ImageQuery";
+        case SpvCapabilityDerivativeControl: return "DerivativeControl";
+        case SpvCapabilityInterpolationFunction: return "InterpolationFunction";
+        case SpvCapabilityTransformFeedback: return "TransformFeedback";
+        case SpvCapabilityGeometryStreams: return "GeometryStreams";
+        case SpvCapabilityStorageImageReadWithoutFormat: return "StorageImageReadWithoutFormat";
+        case SpvCapabilityStorageImageWriteWithoutFormat: return "StorageImageWriteWithoutFormat";
+        case SpvCapabilityMultiViewport: return "MultiViewport";
+        case SpvCapabilitySubgroupDispatch: return "SubgroupDispatch";
+        case SpvCapabilityNamedBarrier: return "NamedBarrier";
+        case SpvCapabilityPipeStorage: return "PipeStorage";
+        case SpvCapabilitySubgroupBallotKHR: return "SubgroupBallotKHR";
+        case SpvCapabilityDrawParameters: return "DrawParameters";
+        case SpvCapabilitySubgroupVoteKHR: return "SubgroupVoteKHR";
+        case SpvCapabilityStorageBuffer16BitAccess: return "StorageBuffer16BitAccess";
+        //case SpvCapabilityStorageUniformBufferBlock16: return "StorageUniformBufferBlock16";
+        case SpvCapabilityStorageUniform16: return "StorageUniform16";
+        //case SpvCapabilityUniformAndStorageBuffer16BitAccess: return "UniformAndStorageBuffer16BitAccess";
+        case SpvCapabilityStoragePushConstant16: return "StoragePushConstant16";
+        case SpvCapabilityStorageInputOutput16: return "StorageInputOutput16";
+        case SpvCapabilityDeviceGroup: return "DeviceGroup";
+        case SpvCapabilityMultiView: return "MultiView";
+        case SpvCapabilityVariablePointersStorageBuffer: return "VariablePointersStorageBuffer";
+        case SpvCapabilityVariablePointers: return "VariablePointers";
+        case SpvCapabilitySampleMaskOverrideCoverageNV: return "SampleMaskOverrideCoverageNV";
+        case SpvCapabilityGeometryShaderPassthroughNV: return "GeometryShaderPassthroughNV";
+        case SpvCapabilityShaderViewportIndexLayerNV: return "ShaderViewportIndexLayerNV";
+        case SpvCapabilityShaderViewportMaskNV: return "ShaderViewportMaskNV";
+        case SpvCapabilityShaderStereoViewNV: return "ShaderStereoViewNV";
+        case SpvCapabilityPerViewAttributesNV: return "PerViewAttributesNV";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* SpvOpToString(SpvOp e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case SpvOpNop: return "OpNop";
+        case SpvOpUndef: return "OpUndef";
+        case SpvOpSourceContinued: return "OpSourceContinued";
+        case SpvOpSource: return "OpSource";
+        case SpvOpSourceExtension: return "OpSourceExtension";
+        case SpvOpName: return "OpName";
+        case SpvOpMemberName: return "OpMemberName";
+        case SpvOpString: return "OpString";
+        case SpvOpLine: return "OpLine";
+        case SpvOpExtension: return "OpExtension";
+        case SpvOpExtInstImport: return "OpExtInstImport";
+        case SpvOpExtInst: return "OpExtInst";
+        case SpvOpMemoryModel: return "OpMemoryModel";
+        case SpvOpEntryPoint: return "OpEntryPoint";
+        case SpvOpExecutionMode: return "OpExecutionMode";
+        case SpvOpCapability: return "OpCapability";
+        case SpvOpTypeVoid: return "OpTypeVoid";
+        case SpvOpTypeBool: return "OpTypeBool";
+        case SpvOpTypeInt: return "OpTypeInt";
+        case SpvOpTypeFloat: return "OpTypeFloat";
+        case SpvOpTypeVector: return "OpTypeVector";
+        case SpvOpTypeMatrix: return "OpTypeMatrix";
+        case SpvOpTypeImage: return "OpTypeImage";
+        case SpvOpTypeSampler: return "OpTypeSampler";
+        case SpvOpTypeSampledImage: return "OpTypeSampledImage";
+        case SpvOpTypeArray: return "OpTypeArray";
+        case SpvOpTypeRuntimeArray: return "OpTypeRuntimeArray";
+        case SpvOpTypeStruct: return "OpTypeStruct";
+        case SpvOpTypeOpaque: return "OpTypeOpaque";
+        case SpvOpTypePointer: return "OpTypePointer";
+        case SpvOpTypeFunction: return "OpTypeFunction";
+        case SpvOpTypeEvent: return "OpTypeEvent";
+        case SpvOpTypeDeviceEvent: return "OpTypeDeviceEvent";
+        case SpvOpTypeReserveId: return "OpTypeReserveId";
+        case SpvOpTypeQueue: return "OpTypeQueue";
+        case SpvOpTypePipe: return "OpTypePipe";
+        case SpvOpTypeForwardPointer: return "OpTypeForwardPointer";
+        case SpvOpConstantTrue: return "OpConstantTrue";
+        case SpvOpConstantFalse: return "OpConstantFalse";
+        case SpvOpConstant: return "OpConstant";
+        case SpvOpConstantComposite: return "OpConstantComposite";
+        case SpvOpConstantSampler: return "OpConstantSampler";
+        case SpvOpConstantNull: return "OpConstantNull";
+        case SpvOpSpecConstantTrue: return "OpSpecConstantTrue";
+        case SpvOpSpecConstantFalse: return "OpSpecConstantFalse";
+        case SpvOpSpecConstant: return "OpSpecConstant";
+        case SpvOpSpecConstantComposite: return "OpSpecConstantComposite";
+        case SpvOpSpecConstantOp: return "OpSpecConstantOp";
+        case SpvOpFunction: return "OpFunction";
+        case SpvOpFunctionParameter: return "OpFunctionParameter";
+        case SpvOpFunctionEnd: return "OpFunctionEnd";
+        case SpvOpFunctionCall: return "OpFunctionCall";
+        case SpvOpVariable: return "OpVariable";
+        case SpvOpImageTexelPointer: return "OpImageTexelPointer";
+        case SpvOpLoad: return "OpLoad";
+        case SpvOpStore: return "OpStore";
+        case SpvOpCopyMemory: return "OpCopyMemory";
+        case SpvOpCopyMemorySized: return "OpCopyMemorySized";
+        case SpvOpAccessChain: return "OpAccessChain";
+        case SpvOpInBoundsAccessChain: return "OpInBoundsAccessChain";
+        case SpvOpPtrAccessChain: return "OpPtrAccessChain";
+        case SpvOpArrayLength: return "OpArrayLength";
+        case SpvOpGenericPtrMemSemantics: return "OpGenericPtrMemSemantics";
+        case SpvOpInBoundsPtrAccessChain: return "OpInBoundsPtrAccessChain";
+        case SpvOpDecorate: return "OpDecorate";
+        case SpvOpMemberDecorate: return "OpMemberDecorate";
+        case SpvOpDecorationGroup: return "OpDecorationGroup";
+        case SpvOpGroupDecorate: return "OpGroupDecorate";
+        case SpvOpGroupMemberDecorate: return "OpGroupMemberDecorate";
+        case SpvOpVectorExtractDynamic: return "OpVectorExtractDynamic";
+        case SpvOpVectorInsertDynamic: return "OpVectorInsertDynamic";
+        case SpvOpVectorShuffle: return "OpVectorShuffle";
+        case SpvOpCompositeConstruct: return "OpCompositeConstruct";
+        case SpvOpCompositeExtract: return "OpCompositeExtract";
+        case SpvOpCompositeInsert: return "OpCompositeInsert";
+        case SpvOpCopyObject: return "OpCopyObject";
+        case SpvOpTranspose: return "OpTranspose";
+        case SpvOpSampledImage: return "OpSampledImage";
+        case SpvOpImageSampleImplicitLod: return "OpImageSampleImplicitLod";
+        case SpvOpImageSampleExplicitLod: return "OpImageSampleExplicitLod";
+        case SpvOpImageSampleDrefImplicitLod: return "OpImageSampleDrefImplicitLod";
+        case SpvOpImageSampleDrefExplicitLod: return "OpImageSampleDrefExplicitLod";
+        case SpvOpImageSampleProjImplicitLod: return "OpImageSampleProjImplicitLod";
+        case SpvOpImageSampleProjExplicitLod: return "OpImageSampleProjExplicitLod";
+        case SpvOpImageSampleProjDrefImplicitLod: return "OpImageSampleProjDrefImplicitLod";
+        case SpvOpImageSampleProjDrefExplicitLod: return "OpImageSampleProjDrefExplicitLod";
+        case SpvOpImageFetch: return "OpImageFetch";
+        case SpvOpImageGather: return "OpImageGather";
+        case SpvOpImageDrefGather: return "OpImageDrefGather";
+        case SpvOpImageRead: return "OpImageRead";
+        case SpvOpImageWrite: return "OpImageWrite";
+        case SpvOpImage: return "OpImage";
+        case SpvOpImageQueryFormat: return "OpImageQueryFormat";
+        case SpvOpImageQueryOrder: return "OpImageQueryOrder";
+        case SpvOpImageQuerySizeLod: return "OpImageQuerySizeLod";
+        case SpvOpImageQuerySize: return "OpImageQuerySize";
+        case SpvOpImageQueryLod: return "OpImageQueryLod";
+        case SpvOpImageQueryLevels: return "OpImageQueryLevels";
+        case SpvOpImageQuerySamples: return "OpImageQuerySamples";
+        case SpvOpConvertFToU: return "OpConvertFToU";
+        case SpvOpConvertFToS: return "OpConvertFToS";
+        case SpvOpConvertSToF: return "OpConvertSToF";
+        case SpvOpConvertUToF: return "OpConvertUToF";
+        case SpvOpUConvert: return "OpUConvert";
+        case SpvOpSConvert: return "OpSConvert";
+        case SpvOpFConvert: return "OpFConvert";
+        case SpvOpQuantizeToF16: return "OpQuantizeToF16";
+        case SpvOpConvertPtrToU: return "OpConvertPtrToU";
+        case SpvOpSatConvertSToU: return "OpSatConvertSToU";
+        case SpvOpSatConvertUToS: return "OpSatConvertUToS";
+        case SpvOpConvertUToPtr: return "OpConvertUToPtr";
+        case SpvOpPtrCastToGeneric: return "OpPtrCastToGeneric";
+        case SpvOpGenericCastToPtr: return "OpGenericCastToPtr";
+        case SpvOpGenericCastToPtrExplicit: return "OpGenericCastToPtrExplicit";
+        case SpvOpBitcast: return "OpBitcast";
+        case SpvOpSNegate: return "OpSNegate";
+        case SpvOpFNegate: return "OpFNegate";
+        case SpvOpIAdd: return "OpIAdd";
+        case SpvOpFAdd: return "OpFAdd";
+        case SpvOpISub: return "OpISub";
+        case SpvOpFSub: return "OpFSub";
+        case SpvOpIMul: return "OpIMul";
+        case SpvOpFMul: return "OpFMul";
+        case SpvOpUDiv: return "OpUDiv";
+        case SpvOpSDiv: return "OpSDiv";
+        case SpvOpFDiv: return "OpFDiv";
+        case SpvOpUMod: return "OpUMod";
+        case SpvOpSRem: return "OpSRem";
+        case SpvOpSMod: return "OpSMod";
+        case SpvOpFRem: return "OpFRem";
+        case SpvOpFMod: return "OpFMod";
+        case SpvOpVectorTimesScalar: return "OpVectorTimesScalar";
+        case SpvOpMatrixTimesScalar: return "OpMatrixTimesScalar";
+        case SpvOpVectorTimesMatrix: return "OpVectorTimesMatrix";
+        case SpvOpMatrixTimesVector: return "OpMatrixTimesVector";
+        case SpvOpMatrixTimesMatrix: return "OpMatrixTimesMatrix";
+        case SpvOpOuterProduct: return "OpOuterProduct";
+        case SpvOpDot: return "OpDot";
+        case SpvOpIAddCarry: return "OpIAddCarry";
+        case SpvOpISubBorrow: return "OpISubBorrow";
+        case SpvOpUMulExtended: return "OpUMulExtended";
+        case SpvOpSMulExtended: return "OpSMulExtended";
+        case SpvOpAny: return "OpAny";
+        case SpvOpAll: return "OpAll";
+        case SpvOpIsNan: return "OpIsNan";
+        case SpvOpIsInf: return "OpIsInf";
+        case SpvOpIsFinite: return "OpIsFinite";
+        case SpvOpIsNormal: return "OpIsNormal";
+        case SpvOpSignBitSet: return "OpSignBitSet";
+        case SpvOpLessOrGreater: return "OpLessOrGreater";
+        case SpvOpOrdered: return "OpOrdered";
+        case SpvOpUnordered: return "OpUnordered";
+        case SpvOpLogicalEqual: return "OpLogicalEqual";
+        case SpvOpLogicalNotEqual: return "OpLogicalNotEqual";
+        case SpvOpLogicalOr: return "OpLogicalOr";
+        case SpvOpLogicalAnd: return "OpLogicalAnd";
+        case SpvOpLogicalNot: return "OpLogicalNot";
+        case SpvOpSelect: return "OpSelect";
+        case SpvOpIEqual: return "OpIEqual";
+        case SpvOpINotEqual: return "OpINotEqual";
+        case SpvOpUGreaterThan: return "OpUGreaterThan";
+        case SpvOpSGreaterThan: return "OpSGreaterThan";
+        case SpvOpUGreaterThanEqual: return "OpUGreaterThanEqual";
+        case SpvOpSGreaterThanEqual: return "OpSGreaterThanEqual";
+        case SpvOpULessThan: return "OpULessThan";
+        case SpvOpSLessThan: return "OpSLessThan";
+        case SpvOpULessThanEqual: return "OpULessThanEqual";
+        case SpvOpSLessThanEqual: return "OpSLessThanEqual";
+        case SpvOpFOrdEqual: return "OpFOrdEqual";
+        case SpvOpFUnordEqual: return "OpFUnordEqual";
+        case SpvOpFOrdNotEqual: return "OpFOrdNotEqual";
+        case SpvOpFUnordNotEqual: return "OpFUnordNotEqual";
+        case SpvOpFOrdLessThan: return "OpFOrdLessThan";
+        case SpvOpFUnordLessThan: return "OpFUnordLessThan";
+        case SpvOpFOrdGreaterThan: return "OpFOrdGreaterThan";
+        case SpvOpFUnordGreaterThan: return "OpFUnordGreaterThan";
+        case SpvOpFOrdLessThanEqual: return "OpFOrdLessThanEqual";
+        case SpvOpFUnordLessThanEqual: return "OpFUnordLessThanEqual";
+        case SpvOpFOrdGreaterThanEqual: return "OpFOrdGreaterThanEqual";
+        case SpvOpFUnordGreaterThanEqual: return "OpFUnordGreaterThanEqual";
+        case SpvOpShiftRightLogical: return "OpShiftRightLogical";
+        case SpvOpShiftRightArithmetic: return "OpShiftRightArithmetic";
+        case SpvOpShiftLeftLogical: return "OpShiftLeftLogical";
+        case SpvOpBitwiseOr: return "OpBitwiseOr";
+        case SpvOpBitwiseXor: return "OpBitwiseXor";
+        case SpvOpBitwiseAnd: return "OpBitwiseAnd";
+        case SpvOpNot: return "OpNot";
+        case SpvOpBitFieldInsert: return "OpBitFieldInsert";
+        case SpvOpBitFieldSExtract: return "OpBitFieldSExtract";
+        case SpvOpBitFieldUExtract: return "OpBitFieldUExtract";
+        case SpvOpBitReverse: return "OpBitReverse";
+        case SpvOpBitCount: return "OpBitCount";
+        case SpvOpDPdx: return "OpDPdx";
+        case SpvOpDPdy: return "OpDPdy";
+        case SpvOpFwidth: return "OpFwidth";
+        case SpvOpDPdxFine: return "OpDPdxFine";
+        case SpvOpDPdyFine: return "OpDPdyFine";
+        case SpvOpFwidthFine: return "OpFwidthFine";
+        case SpvOpDPdxCoarse: return "OpDPdxCoarse";
+        case SpvOpDPdyCoarse: return "OpDPdyCoarse";
+        case SpvOpFwidthCoarse: return "OpFwidthCoarse";
+        case SpvOpEmitVertex: return "OpEmitVertex";
+        case SpvOpEndPrimitive: return "OpEndPrimitive";
+        case SpvOpEmitStreamVertex: return "OpEmitStreamVertex";
+        case SpvOpEndStreamPrimitive: return "OpEndStreamPrimitive";
+        case SpvOpControlBarrier: return "OpControlBarrier";
+        case SpvOpMemoryBarrier: return "OpMemoryBarrier";
+        case SpvOpAtomicLoad: return "OpAtomicLoad";
+        case SpvOpAtomicStore: return "OpAtomicStore";
+        case SpvOpAtomicExchange: return "OpAtomicExchange";
+        case SpvOpAtomicCompareExchange: return "OpAtomicCompareExchange";
+        case SpvOpAtomicCompareExchangeWeak: return "OpAtomicCompareExchangeWeak";
+        case SpvOpAtomicIIncrement: return "OpAtomicIIncrement";
+        case SpvOpAtomicIDecrement: return "OpAtomicIDecrement";
+        case SpvOpAtomicIAdd: return "OpAtomicIAdd";
+        case SpvOpAtomicISub: return "OpAtomicISub";
+        case SpvOpAtomicSMin: return "OpAtomicSMin";
+        case SpvOpAtomicUMin: return "OpAtomicUMin";
+        case SpvOpAtomicSMax: return "OpAtomicSMax";
+        case SpvOpAtomicUMax: return "OpAtomicUMax";
+        case SpvOpAtomicAnd: return "OpAtomicAnd";
+        case SpvOpAtomicOr: return "OpAtomicOr";
+        case SpvOpAtomicXor: return "OpAtomicXor";
+        case SpvOpPhi: return "OpPhi";
+        case SpvOpLoopMerge: return "OpLoopMerge";
+        case SpvOpSelectionMerge: return "OpSelectionMerge";
+        case SpvOpLabel: return "OpLabel";
+        case SpvOpBranch: return "OpBranch";
+        case SpvOpBranchConditional: return "OpBranchConditional";
+        case SpvOpSwitch: return "OpSwitch";
+        case SpvOpKill: return "OpKill";
+        case SpvOpReturn: return "OpReturn";
+        case SpvOpReturnValue: return "OpReturnValue";
+        case SpvOpUnreachable: return "OpUnreachable";
+        case SpvOpLifetimeStart: return "OpLifetimeStart";
+        case SpvOpLifetimeStop: return "OpLifetimeStop";
+        case SpvOpGroupAsyncCopy: return "OpGroupAsyncCopy";
+        case SpvOpGroupWaitEvents: return "OpGroupWaitEvents";
+        case SpvOpGroupAll: return "OpGroupAll";
+        case SpvOpGroupAny: return "OpGroupAny";
+        case SpvOpGroupBroadcast: return "OpGroupBroadcast";
+        case SpvOpGroupIAdd: return "OpGroupIAdd";
+        case SpvOpGroupFAdd: return "OpGroupFAdd";
+        case SpvOpGroupFMin: return "OpGroupFMin";
+        case SpvOpGroupUMin: return "OpGroupUMin";
+        case SpvOpGroupSMin: return "OpGroupSMin";
+        case SpvOpGroupFMax: return "OpGroupFMax";
+        case SpvOpGroupUMax: return "OpGroupUMax";
+        case SpvOpGroupSMax: return "OpGroupSMax";
+        case SpvOpReadPipe: return "OpReadPipe";
+        case SpvOpWritePipe: return "OpWritePipe";
+        case SpvOpReservedReadPipe: return "OpReservedReadPipe";
+        case SpvOpReservedWritePipe: return "OpReservedWritePipe";
+        case SpvOpReserveReadPipePackets: return "OpReserveReadPipePackets";
+        case SpvOpReserveWritePipePackets: return "OpReserveWritePipePackets";
+        case SpvOpCommitReadPipe: return "OpCommitReadPipe";
+        case SpvOpCommitWritePipe: return "OpCommitWritePipe";
+        case SpvOpIsValidReserveId: return "OpIsValidReserveId";
+        case SpvOpGetNumPipePackets: return "OpGetNumPipePackets";
+        case SpvOpGetMaxPipePackets: return "OpGetMaxPipePackets";
+        case SpvOpGroupReserveReadPipePackets: return "OpGroupReserveReadPipePackets";
+        case SpvOpGroupReserveWritePipePackets: return "OpGroupReserveWritePipePackets";
+        case SpvOpGroupCommitReadPipe: return "OpGroupCommitReadPipe";
+        case SpvOpGroupCommitWritePipe: return "OpGroupCommitWritePipe";
+        case SpvOpEnqueueMarker: return "OpEnqueueMarker";
+        case SpvOpEnqueueKernel: return "OpEnqueueKernel";
+        case SpvOpGetKernelNDrangeSubGroupCount: return "OpGetKernelNDrangeSubGroupCount";
+        case SpvOpGetKernelNDrangeMaxSubGroupSize: return "OpGetKernelNDrangeMaxSubGroupSize";
+        case SpvOpGetKernelWorkGroupSize: return "OpGetKernelWorkGroupSize";
+        case SpvOpGetKernelPreferredWorkGroupSizeMultiple: return "OpGetKernelPreferredWorkGroupSizeMultiple";
+        case SpvOpRetainEvent: return "OpRetainEvent";
+        case SpvOpReleaseEvent: return "OpReleaseEvent";
+        case SpvOpCreateUserEvent: return "OpCreateUserEvent";
+        case SpvOpIsValidEvent: return "OpIsValidEvent";
+        case SpvOpSetUserEventStatus: return "OpSetUserEventStatus";
+        case SpvOpCaptureEventProfilingInfo: return "OpCaptureEventProfilingInfo";
+        case SpvOpGetDefaultQueue: return "OpGetDefaultQueue";
+        case SpvOpBuildNDRange: return "OpBuildNDRange";
+        case SpvOpImageSparseSampleImplicitLod: return "OpImageSparseSampleImplicitLod";
+        case SpvOpImageSparseSampleExplicitLod: return "OpImageSparseSampleExplicitLod";
+        case SpvOpImageSparseSampleDrefImplicitLod: return "OpImageSparseSampleDrefImplicitLod";
+        case SpvOpImageSparseSampleDrefExplicitLod: return "OpImageSparseSampleDrefExplicitLod";
+        case SpvOpImageSparseSampleProjImplicitLod: return "OpImageSparseSampleProjImplicitLod";
+        case SpvOpImageSparseSampleProjExplicitLod: return "OpImageSparseSampleProjExplicitLod";
+        case SpvOpImageSparseSampleProjDrefImplicitLod: return "OpImageSparseSampleProjDrefImplicitLod";
+        case SpvOpImageSparseSampleProjDrefExplicitLod: return "OpImageSparseSampleProjDrefExplicitLod";
+        case SpvOpImageSparseFetch: return "OpImageSparseFetch";
+        case SpvOpImageSparseGather: return "OpImageSparseGather";
+        case SpvOpImageSparseDrefGather: return "OpImageSparseDrefGather";
+        case SpvOpImageSparseTexelsResident: return "OpImageSparseTexelsResident";
+        case SpvOpNoLine: return "OpNoLine";
+        case SpvOpAtomicFlagTestAndSet: return "OpAtomicFlagTestAndSet";
+        case SpvOpAtomicFlagClear: return "OpAtomicFlagClear";
+        case SpvOpImageSparseRead: return "OpImageSparseRead";
+        case SpvOpSizeOf: return "OpSizeOf";
+        case SpvOpTypePipeStorage: return "OpTypePipeStorage";
+        case SpvOpConstantPipeStorage: return "OpConstantPipeStorage";
+        case SpvOpCreatePipeFromPipeStorage: return "OpCreatePipeFromPipeStorage";
+        case SpvOpGetKernelLocalSizeForSubgroupCount: return "OpGetKernelLocalSizeForSubgroupCount";
+        case SpvOpGetKernelMaxNumSubgroups: return "OpGetKernelMaxNumSubgroups";
+        case SpvOpTypeNamedBarrier: return "OpTypeNamedBarrier";
+        case SpvOpNamedBarrierInitialize: return "OpNamedBarrierInitialize";
+        case SpvOpMemoryNamedBarrier: return "OpMemoryNamedBarrier";
+        case SpvOpModuleProcessed: return "OpModuleProcessed";
+        case SpvOpExecutionModeId: return "OpExecutionModeId";
+        case SpvOpDecorateId: return "OpDecorateId";
+        case SpvOpSubgroupBallotKHR: return "OpSubgroupBallotKHR";
+        case SpvOpSubgroupFirstInvocationKHR: return "OpSubgroupFirstInvocationKHR";
+        case SpvOpSubgroupAllKHR: return "OpSubgroupAllKHR";
+        case SpvOpSubgroupAnyKHR: return "OpSubgroupAnyKHR";
+        case SpvOpSubgroupAllEqualKHR: return "OpSubgroupAllEqualKHR";
+        case SpvOpSubgroupReadInvocationKHR: return "OpSubgroupReadInvocationKHR";
+        default: return "";
+    }
+}
+#endif
+
+#ifdef __cplusplus
+} // end of extern "C"
+#endif
+
+#endif  // #ifndef spirv_strings_H
+

--- a/include/spirv/1.2/spirv_strings.hpp
+++ b/include/spirv/1.2/spirv_strings.hpp
@@ -1,0 +1,1280 @@
+/*
+** Copyright (c) 2014-2017 The Khronos Group Inc.
+** 
+** Permission is hereby granted, free of charge, to any person obtaining a copy
+** of this software and/or associated documentation files (the "Materials"),
+** to deal in the Materials without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Materials, and to permit persons to whom the
+** Materials are furnished to do so, subject to the following conditions:
+** 
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Materials.
+** 
+** MODIFICATIONS TO THIS FILE MAY MEAN IT NO LONGER ACCURATELY REFLECTS KHRONOS
+** STANDARDS. THE UNMODIFIED, NORMATIVE VERSIONS OF KHRONOS SPECIFICATIONS AND
+** HEADER INFORMATION ARE LOCATED AT https://www.khronos.org/registry/ 
+** 
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+** OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+** THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM,OUT OF OR IN CONNECTION WITH THE MATERIALS OR THE USE OR OTHER DEALINGS
+** IN THE MATERIALS.
+*/
+
+#ifndef spirv_strings_HPP
+#define spirv_strings_HPP
+
+#include "spirv.hpp"
+
+#ifndef SPIRV_DEF
+#   ifdef SPIRV_STRINGS_IMPLEMENT
+#       define SPIRV_DEF
+#   else
+#       define SPIRV_DEF extern
+#   endif
+#endif
+
+namespace spv {
+
+SPIRV_DEF const char* SourceLanguageToString(SourceLanguage e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case SourceLanguageUnknown: return "Unknown";
+        case SourceLanguageESSL: return "ESSL";
+        case SourceLanguageGLSL: return "GLSL";
+        case SourceLanguageOpenCL_C: return "OpenCL_C";
+        case SourceLanguageOpenCL_CPP: return "OpenCL_CPP";
+        case SourceLanguageHLSL: return "HLSL";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* ExecutionModelToString(ExecutionModel e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case ExecutionModelVertex: return "Vertex";
+        case ExecutionModelTessellationControl: return "TessellationControl";
+        case ExecutionModelTessellationEvaluation: return "TessellationEvaluation";
+        case ExecutionModelGeometry: return "Geometry";
+        case ExecutionModelFragment: return "Fragment";
+        case ExecutionModelGLCompute: return "GLCompute";
+        case ExecutionModelKernel: return "Kernel";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* AddressingModelToString(AddressingModel e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case AddressingModelLogical: return "Logical";
+        case AddressingModelPhysical32: return "Physical32";
+        case AddressingModelPhysical64: return "Physical64";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* MemoryModelToString(MemoryModel e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case MemoryModelSimple: return "Simple";
+        case MemoryModelGLSL450: return "GLSL450";
+        case MemoryModelOpenCL: return "OpenCL";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* ExecutionModeToString(ExecutionMode e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case ExecutionModeInvocations: return "Invocations";
+        case ExecutionModeSpacingEqual: return "SpacingEqual";
+        case ExecutionModeSpacingFractionalEven: return "SpacingFractionalEven";
+        case ExecutionModeSpacingFractionalOdd: return "SpacingFractionalOdd";
+        case ExecutionModeVertexOrderCw: return "VertexOrderCw";
+        case ExecutionModeVertexOrderCcw: return "VertexOrderCcw";
+        case ExecutionModePixelCenterInteger: return "PixelCenterInteger";
+        case ExecutionModeOriginUpperLeft: return "OriginUpperLeft";
+        case ExecutionModeOriginLowerLeft: return "OriginLowerLeft";
+        case ExecutionModeEarlyFragmentTests: return "EarlyFragmentTests";
+        case ExecutionModePointMode: return "PointMode";
+        case ExecutionModeXfb: return "Xfb";
+        case ExecutionModeDepthReplacing: return "DepthReplacing";
+        case ExecutionModeDepthGreater: return "DepthGreater";
+        case ExecutionModeDepthLess: return "DepthLess";
+        case ExecutionModeDepthUnchanged: return "DepthUnchanged";
+        case ExecutionModeLocalSize: return "LocalSize";
+        case ExecutionModeLocalSizeHint: return "LocalSizeHint";
+        case ExecutionModeInputPoints: return "InputPoints";
+        case ExecutionModeInputLines: return "InputLines";
+        case ExecutionModeInputLinesAdjacency: return "InputLinesAdjacency";
+        case ExecutionModeTriangles: return "Triangles";
+        case ExecutionModeInputTrianglesAdjacency: return "InputTrianglesAdjacency";
+        case ExecutionModeQuads: return "Quads";
+        case ExecutionModeIsolines: return "Isolines";
+        case ExecutionModeOutputVertices: return "OutputVertices";
+        case ExecutionModeOutputPoints: return "OutputPoints";
+        case ExecutionModeOutputLineStrip: return "OutputLineStrip";
+        case ExecutionModeOutputTriangleStrip: return "OutputTriangleStrip";
+        case ExecutionModeVecTypeHint: return "VecTypeHint";
+        case ExecutionModeContractionOff: return "ContractionOff";
+        case ExecutionModeInitializer: return "Initializer";
+        case ExecutionModeFinalizer: return "Finalizer";
+        case ExecutionModeSubgroupSize: return "SubgroupSize";
+        case ExecutionModeSubgroupsPerWorkgroup: return "SubgroupsPerWorkgroup";
+        case ExecutionModeSubgroupsPerWorkgroupId: return "SubgroupsPerWorkgroupId";
+        case ExecutionModeLocalSizeId: return "LocalSizeId";
+        case ExecutionModeLocalSizeHintId: return "LocalSizeHintId";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* StorageClassToString(StorageClass e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case StorageClassUniformConstant: return "UniformConstant";
+        case StorageClassInput: return "Input";
+        case StorageClassUniform: return "Uniform";
+        case StorageClassOutput: return "Output";
+        case StorageClassWorkgroup: return "Workgroup";
+        case StorageClassCrossWorkgroup: return "CrossWorkgroup";
+        case StorageClassPrivate: return "Private";
+        case StorageClassFunction: return "Function";
+        case StorageClassGeneric: return "Generic";
+        case StorageClassPushConstant: return "PushConstant";
+        case StorageClassAtomicCounter: return "AtomicCounter";
+        case StorageClassImage: return "Image";
+        case StorageClassStorageBuffer: return "StorageBuffer";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* DimToString(Dim e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case Dim1D: return "1D";
+        case Dim2D: return "2D";
+        case Dim3D: return "3D";
+        case DimCube: return "Cube";
+        case DimRect: return "Rect";
+        case DimBuffer: return "Buffer";
+        case DimSubpassData: return "SubpassData";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* SamplerAddressingModeToString(SamplerAddressingMode e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case SamplerAddressingModeNone: return "None";
+        case SamplerAddressingModeClampToEdge: return "ClampToEdge";
+        case SamplerAddressingModeClamp: return "Clamp";
+        case SamplerAddressingModeRepeat: return "Repeat";
+        case SamplerAddressingModeRepeatMirrored: return "RepeatMirrored";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* SamplerFilterModeToString(SamplerFilterMode e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case SamplerFilterModeNearest: return "Nearest";
+        case SamplerFilterModeLinear: return "Linear";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* ImageFormatToString(ImageFormat e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case ImageFormatUnknown: return "Unknown";
+        case ImageFormatRgba32f: return "Rgba32f";
+        case ImageFormatRgba16f: return "Rgba16f";
+        case ImageFormatR32f: return "R32f";
+        case ImageFormatRgba8: return "Rgba8";
+        case ImageFormatRgba8Snorm: return "Rgba8Snorm";
+        case ImageFormatRg32f: return "Rg32f";
+        case ImageFormatRg16f: return "Rg16f";
+        case ImageFormatR11fG11fB10f: return "R11fG11fB10f";
+        case ImageFormatR16f: return "R16f";
+        case ImageFormatRgba16: return "Rgba16";
+        case ImageFormatRgb10A2: return "Rgb10A2";
+        case ImageFormatRg16: return "Rg16";
+        case ImageFormatRg8: return "Rg8";
+        case ImageFormatR16: return "R16";
+        case ImageFormatR8: return "R8";
+        case ImageFormatRgba16Snorm: return "Rgba16Snorm";
+        case ImageFormatRg16Snorm: return "Rg16Snorm";
+        case ImageFormatRg8Snorm: return "Rg8Snorm";
+        case ImageFormatR16Snorm: return "R16Snorm";
+        case ImageFormatR8Snorm: return "R8Snorm";
+        case ImageFormatRgba32i: return "Rgba32i";
+        case ImageFormatRgba16i: return "Rgba16i";
+        case ImageFormatRgba8i: return "Rgba8i";
+        case ImageFormatR32i: return "R32i";
+        case ImageFormatRg32i: return "Rg32i";
+        case ImageFormatRg16i: return "Rg16i";
+        case ImageFormatRg8i: return "Rg8i";
+        case ImageFormatR16i: return "R16i";
+        case ImageFormatR8i: return "R8i";
+        case ImageFormatRgba32ui: return "Rgba32ui";
+        case ImageFormatRgba16ui: return "Rgba16ui";
+        case ImageFormatRgba8ui: return "Rgba8ui";
+        case ImageFormatR32ui: return "R32ui";
+        case ImageFormatRgb10a2ui: return "Rgb10a2ui";
+        case ImageFormatRg32ui: return "Rg32ui";
+        case ImageFormatRg16ui: return "Rg16ui";
+        case ImageFormatRg8ui: return "Rg8ui";
+        case ImageFormatR16ui: return "R16ui";
+        case ImageFormatR8ui: return "R8ui";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* ImageChannelOrderToString(ImageChannelOrder e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case ImageChannelOrderR: return "R";
+        case ImageChannelOrderA: return "A";
+        case ImageChannelOrderRG: return "RG";
+        case ImageChannelOrderRA: return "RA";
+        case ImageChannelOrderRGB: return "RGB";
+        case ImageChannelOrderRGBA: return "RGBA";
+        case ImageChannelOrderBGRA: return "BGRA";
+        case ImageChannelOrderARGB: return "ARGB";
+        case ImageChannelOrderIntensity: return "Intensity";
+        case ImageChannelOrderLuminance: return "Luminance";
+        case ImageChannelOrderRx: return "Rx";
+        case ImageChannelOrderRGx: return "RGx";
+        case ImageChannelOrderRGBx: return "RGBx";
+        case ImageChannelOrderDepth: return "Depth";
+        case ImageChannelOrderDepthStencil: return "DepthStencil";
+        case ImageChannelOrdersRGB: return "sRGB";
+        case ImageChannelOrdersRGBx: return "sRGBx";
+        case ImageChannelOrdersRGBA: return "sRGBA";
+        case ImageChannelOrdersBGRA: return "sBGRA";
+        case ImageChannelOrderABGR: return "ABGR";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* ImageChannelDataTypeToString(ImageChannelDataType e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case ImageChannelDataTypeSnormInt8: return "SnormInt8";
+        case ImageChannelDataTypeSnormInt16: return "SnormInt16";
+        case ImageChannelDataTypeUnormInt8: return "UnormInt8";
+        case ImageChannelDataTypeUnormInt16: return "UnormInt16";
+        case ImageChannelDataTypeUnormShort565: return "UnormShort565";
+        case ImageChannelDataTypeUnormShort555: return "UnormShort555";
+        case ImageChannelDataTypeUnormInt101010: return "UnormInt101010";
+        case ImageChannelDataTypeSignedInt8: return "SignedInt8";
+        case ImageChannelDataTypeSignedInt16: return "SignedInt16";
+        case ImageChannelDataTypeSignedInt32: return "SignedInt32";
+        case ImageChannelDataTypeUnsignedInt8: return "UnsignedInt8";
+        case ImageChannelDataTypeUnsignedInt16: return "UnsignedInt16";
+        case ImageChannelDataTypeUnsignedInt32: return "UnsignedInt32";
+        case ImageChannelDataTypeHalfFloat: return "HalfFloat";
+        case ImageChannelDataTypeFloat: return "Float";
+        case ImageChannelDataTypeUnormInt24: return "UnormInt24";
+        case ImageChannelDataTypeUnormInt101010_2: return "UnormInt101010_2";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* ImageOperandsShiftToString(ImageOperandsShift e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case ImageOperandsBiasShift: return "Bias";
+        case ImageOperandsLodShift: return "Lod";
+        case ImageOperandsGradShift: return "Grad";
+        case ImageOperandsConstOffsetShift: return "ConstOffset";
+        case ImageOperandsOffsetShift: return "Offset";
+        case ImageOperandsConstOffsetsShift: return "ConstOffsets";
+        case ImageOperandsSampleShift: return "Sample";
+        case ImageOperandsMinLodShift: return "MinLod";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* ImageOperandsMaskToString(ImageOperandsMask e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case ImageOperandsMaskNone: return "None";
+        case ImageOperandsBiasMask: return "Bias";
+        case ImageOperandsLodMask: return "Lod";
+        case ImageOperandsGradMask: return "Grad";
+        case ImageOperandsConstOffsetMask: return "ConstOffset";
+        case ImageOperandsOffsetMask: return "Offset";
+        case ImageOperandsConstOffsetsMask: return "ConstOffsets";
+        case ImageOperandsSampleMask: return "Sample";
+        case ImageOperandsMinLodMask: return "MinLod";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* FPFastMathModeShiftToString(FPFastMathModeShift e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case FPFastMathModeNotNaNShift: return "NotNaN";
+        case FPFastMathModeNotInfShift: return "NotInf";
+        case FPFastMathModeNSZShift: return "NSZ";
+        case FPFastMathModeAllowRecipShift: return "AllowRecip";
+        case FPFastMathModeFastShift: return "Fast";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* FPFastMathModeMaskToString(FPFastMathModeMask e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case FPFastMathModeMaskNone: return "None";
+        case FPFastMathModeNotNaNMask: return "NotNaN";
+        case FPFastMathModeNotInfMask: return "NotInf";
+        case FPFastMathModeNSZMask: return "NSZ";
+        case FPFastMathModeAllowRecipMask: return "AllowRecip";
+        case FPFastMathModeFastMask: return "Fast";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* FPRoundingModeToString(FPRoundingMode e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case FPRoundingModeRTE: return "RTE";
+        case FPRoundingModeRTZ: return "RTZ";
+        case FPRoundingModeRTP: return "RTP";
+        case FPRoundingModeRTN: return "RTN";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* LinkageTypeToString(LinkageType e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case LinkageTypeExport: return "Export";
+        case LinkageTypeImport: return "Import";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* AccessQualifierToString(AccessQualifier e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case AccessQualifierReadOnly: return "ReadOnly";
+        case AccessQualifierWriteOnly: return "WriteOnly";
+        case AccessQualifierReadWrite: return "ReadWrite";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* FunctionParameterAttributeToString(FunctionParameterAttribute e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case FunctionParameterAttributeZext: return "Zext";
+        case FunctionParameterAttributeSext: return "Sext";
+        case FunctionParameterAttributeByVal: return "ByVal";
+        case FunctionParameterAttributeSret: return "Sret";
+        case FunctionParameterAttributeNoAlias: return "NoAlias";
+        case FunctionParameterAttributeNoCapture: return "NoCapture";
+        case FunctionParameterAttributeNoWrite: return "NoWrite";
+        case FunctionParameterAttributeNoReadWrite: return "NoReadWrite";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* DecorationToString(Decoration e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case DecorationRelaxedPrecision: return "RelaxedPrecision";
+        case DecorationSpecId: return "SpecId";
+        case DecorationBlock: return "Block";
+        case DecorationBufferBlock: return "BufferBlock";
+        case DecorationRowMajor: return "RowMajor";
+        case DecorationColMajor: return "ColMajor";
+        case DecorationArrayStride: return "ArrayStride";
+        case DecorationMatrixStride: return "MatrixStride";
+        case DecorationGLSLShared: return "GLSLShared";
+        case DecorationGLSLPacked: return "GLSLPacked";
+        case DecorationCPacked: return "CPacked";
+        case DecorationBuiltIn: return "BuiltIn";
+        case DecorationNoPerspective: return "NoPerspective";
+        case DecorationFlat: return "Flat";
+        case DecorationPatch: return "Patch";
+        case DecorationCentroid: return "Centroid";
+        case DecorationSample: return "Sample";
+        case DecorationInvariant: return "Invariant";
+        case DecorationRestrict: return "Restrict";
+        case DecorationAliased: return "Aliased";
+        case DecorationVolatile: return "Volatile";
+        case DecorationConstant: return "Constant";
+        case DecorationCoherent: return "Coherent";
+        case DecorationNonWritable: return "NonWritable";
+        case DecorationNonReadable: return "NonReadable";
+        case DecorationUniform: return "Uniform";
+        case DecorationSaturatedConversion: return "SaturatedConversion";
+        case DecorationStream: return "Stream";
+        case DecorationLocation: return "Location";
+        case DecorationComponent: return "Component";
+        case DecorationIndex: return "Index";
+        case DecorationBinding: return "Binding";
+        case DecorationDescriptorSet: return "DescriptorSet";
+        case DecorationOffset: return "Offset";
+        case DecorationXfbBuffer: return "XfbBuffer";
+        case DecorationXfbStride: return "XfbStride";
+        case DecorationFuncParamAttr: return "FuncParamAttr";
+        case DecorationFPRoundingMode: return "FPRoundingMode";
+        case DecorationFPFastMathMode: return "FPFastMathMode";
+        case DecorationLinkageAttributes: return "LinkageAttributes";
+        case DecorationNoContraction: return "NoContraction";
+        case DecorationInputAttachmentIndex: return "InputAttachmentIndex";
+        case DecorationAlignment: return "Alignment";
+        case DecorationMaxByteOffset: return "MaxByteOffset";
+        case DecorationAlignmentId: return "AlignmentId";
+        case DecorationMaxByteOffsetId: return "MaxByteOffsetId";
+        case DecorationOverrideCoverageNV: return "OverrideCoverageNV";
+        case DecorationPassthroughNV: return "PassthroughNV";
+        case DecorationViewportRelativeNV: return "ViewportRelativeNV";
+        case DecorationSecondaryViewportRelativeNV: return "SecondaryViewportRelativeNV";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* BuiltInToString(BuiltIn e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case BuiltInPosition: return "Position";
+        case BuiltInPointSize: return "PointSize";
+        case BuiltInClipDistance: return "ClipDistance";
+        case BuiltInCullDistance: return "CullDistance";
+        case BuiltInVertexId: return "VertexId";
+        case BuiltInInstanceId: return "InstanceId";
+        case BuiltInPrimitiveId: return "PrimitiveId";
+        case BuiltInInvocationId: return "InvocationId";
+        case BuiltInLayer: return "Layer";
+        case BuiltInViewportIndex: return "ViewportIndex";
+        case BuiltInTessLevelOuter: return "TessLevelOuter";
+        case BuiltInTessLevelInner: return "TessLevelInner";
+        case BuiltInTessCoord: return "TessCoord";
+        case BuiltInPatchVertices: return "PatchVertices";
+        case BuiltInFragCoord: return "FragCoord";
+        case BuiltInPointCoord: return "PointCoord";
+        case BuiltInFrontFacing: return "FrontFacing";
+        case BuiltInSampleId: return "SampleId";
+        case BuiltInSamplePosition: return "SamplePosition";
+        case BuiltInSampleMask: return "SampleMask";
+        case BuiltInFragDepth: return "FragDepth";
+        case BuiltInHelperInvocation: return "HelperInvocation";
+        case BuiltInNumWorkgroups: return "NumWorkgroups";
+        case BuiltInWorkgroupSize: return "WorkgroupSize";
+        case BuiltInWorkgroupId: return "WorkgroupId";
+        case BuiltInLocalInvocationId: return "LocalInvocationId";
+        case BuiltInGlobalInvocationId: return "GlobalInvocationId";
+        case BuiltInLocalInvocationIndex: return "LocalInvocationIndex";
+        case BuiltInWorkDim: return "WorkDim";
+        case BuiltInGlobalSize: return "GlobalSize";
+        case BuiltInEnqueuedWorkgroupSize: return "EnqueuedWorkgroupSize";
+        case BuiltInGlobalOffset: return "GlobalOffset";
+        case BuiltInGlobalLinearId: return "GlobalLinearId";
+        case BuiltInSubgroupSize: return "SubgroupSize";
+        case BuiltInSubgroupMaxSize: return "SubgroupMaxSize";
+        case BuiltInNumSubgroups: return "NumSubgroups";
+        case BuiltInNumEnqueuedSubgroups: return "NumEnqueuedSubgroups";
+        case BuiltInSubgroupId: return "SubgroupId";
+        case BuiltInSubgroupLocalInvocationId: return "SubgroupLocalInvocationId";
+        case BuiltInVertexIndex: return "VertexIndex";
+        case BuiltInInstanceIndex: return "InstanceIndex";
+        case BuiltInSubgroupEqMaskKHR: return "SubgroupEqMaskKHR";
+        case BuiltInSubgroupGeMaskKHR: return "SubgroupGeMaskKHR";
+        case BuiltInSubgroupGtMaskKHR: return "SubgroupGtMaskKHR";
+        case BuiltInSubgroupLeMaskKHR: return "SubgroupLeMaskKHR";
+        case BuiltInSubgroupLtMaskKHR: return "SubgroupLtMaskKHR";
+        case BuiltInBaseVertex: return "BaseVertex";
+        case BuiltInBaseInstance: return "BaseInstance";
+        case BuiltInDrawIndex: return "DrawIndex";
+        case BuiltInDeviceIndex: return "DeviceIndex";
+        case BuiltInViewIndex: return "ViewIndex";
+        case BuiltInViewportMaskNV: return "ViewportMaskNV";
+        case BuiltInSecondaryPositionNV: return "SecondaryPositionNV";
+        case BuiltInSecondaryViewportMaskNV: return "SecondaryViewportMaskNV";
+        case BuiltInPositionPerViewNV: return "PositionPerViewNV";
+        case BuiltInViewportMaskPerViewNV: return "ViewportMaskPerViewNV";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* SelectionControlShiftToString(SelectionControlShift e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case SelectionControlFlattenShift: return "Flatten";
+        case SelectionControlDontFlattenShift: return "DontFlatten";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* SelectionControlMaskToString(SelectionControlMask e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case SelectionControlMaskNone: return "None";
+        case SelectionControlFlattenMask: return "Flatten";
+        case SelectionControlDontFlattenMask: return "DontFlatten";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* LoopControlShiftToString(LoopControlShift e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case LoopControlUnrollShift: return "Unroll";
+        case LoopControlDontUnrollShift: return "DontUnroll";
+        case LoopControlDependencyInfiniteShift: return "DependencyInfinite";
+        case LoopControlDependencyLengthShift: return "DependencyLength";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* LoopControlMaskToString(LoopControlMask e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case LoopControlMaskNone: return "None";
+        case LoopControlUnrollMask: return "Unroll";
+        case LoopControlDontUnrollMask: return "DontUnroll";
+        case LoopControlDependencyInfiniteMask: return "DependencyInfinite";
+        case LoopControlDependencyLengthMask: return "DependencyLength";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* FunctionControlShiftToString(FunctionControlShift e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case FunctionControlInlineShift: return "Inline";
+        case FunctionControlDontInlineShift: return "DontInline";
+        case FunctionControlPureShift: return "Pure";
+        case FunctionControlConstShift: return "Const";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* FunctionControlMaskToString(FunctionControlMask e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case FunctionControlMaskNone: return "None";
+        case FunctionControlInlineMask: return "Inline";
+        case FunctionControlDontInlineMask: return "DontInline";
+        case FunctionControlPureMask: return "Pure";
+        case FunctionControlConstMask: return "Const";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* MemorySemanticsShiftToString(MemorySemanticsShift e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case MemorySemanticsAcquireShift: return "Acquire";
+        case MemorySemanticsReleaseShift: return "Release";
+        case MemorySemanticsAcquireReleaseShift: return "AcquireRelease";
+        case MemorySemanticsSequentiallyConsistentShift: return "SequentiallyConsistent";
+        case MemorySemanticsUniformMemoryShift: return "UniformMemory";
+        case MemorySemanticsSubgroupMemoryShift: return "SubgroupMemory";
+        case MemorySemanticsWorkgroupMemoryShift: return "WorkgroupMemory";
+        case MemorySemanticsCrossWorkgroupMemoryShift: return "CrossWorkgroupMemory";
+        case MemorySemanticsAtomicCounterMemoryShift: return "AtomicCounterMemory";
+        case MemorySemanticsImageMemoryShift: return "ImageMemory";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* MemorySemanticsMaskToString(MemorySemanticsMask e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case MemorySemanticsMaskNone: return "None";
+        case MemorySemanticsAcquireMask: return "Acquire";
+        case MemorySemanticsReleaseMask: return "Release";
+        case MemorySemanticsAcquireReleaseMask: return "AcquireRelease";
+        case MemorySemanticsSequentiallyConsistentMask: return "SequentiallyConsistent";
+        case MemorySemanticsUniformMemoryMask: return "UniformMemory";
+        case MemorySemanticsSubgroupMemoryMask: return "SubgroupMemory";
+        case MemorySemanticsWorkgroupMemoryMask: return "WorkgroupMemory";
+        case MemorySemanticsCrossWorkgroupMemoryMask: return "CrossWorkgroupMemory";
+        case MemorySemanticsAtomicCounterMemoryMask: return "AtomicCounterMemory";
+        case MemorySemanticsImageMemoryMask: return "ImageMemory";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* MemoryAccessShiftToString(MemoryAccessShift e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case MemoryAccessVolatileShift: return "Volatile";
+        case MemoryAccessAlignedShift: return "Aligned";
+        case MemoryAccessNontemporalShift: return "Nontemporal";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* MemoryAccessMaskToString(MemoryAccessMask e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case MemoryAccessMaskNone: return "None";
+        case MemoryAccessVolatileMask: return "Volatile";
+        case MemoryAccessAlignedMask: return "Aligned";
+        case MemoryAccessNontemporalMask: return "Nontemporal";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* ScopeToString(Scope e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case ScopeCrossDevice: return "CrossDevice";
+        case ScopeDevice: return "Device";
+        case ScopeWorkgroup: return "Workgroup";
+        case ScopeSubgroup: return "Subgroup";
+        case ScopeInvocation: return "Invocation";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* GroupOperationToString(GroupOperation e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case GroupOperationReduce: return "Reduce";
+        case GroupOperationInclusiveScan: return "InclusiveScan";
+        case GroupOperationExclusiveScan: return "ExclusiveScan";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* KernelEnqueueFlagsToString(KernelEnqueueFlags e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case KernelEnqueueFlagsNoWait: return "NoWait";
+        case KernelEnqueueFlagsWaitKernel: return "WaitKernel";
+        case KernelEnqueueFlagsWaitWorkGroup: return "WaitWorkGroup";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* KernelProfilingInfoShiftToString(KernelProfilingInfoShift e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case KernelProfilingInfoCmdExecTimeShift: return "CmdExecTime";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* KernelProfilingInfoMaskToString(KernelProfilingInfoMask e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case KernelProfilingInfoMaskNone: return "None";
+        case KernelProfilingInfoCmdExecTimeMask: return "CmdExecTime";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* CapabilityToString(Capability e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case CapabilityMatrix: return "Matrix";
+        case CapabilityShader: return "Shader";
+        case CapabilityGeometry: return "Geometry";
+        case CapabilityTessellation: return "Tessellation";
+        case CapabilityAddresses: return "Addresses";
+        case CapabilityLinkage: return "Linkage";
+        case CapabilityKernel: return "Kernel";
+        case CapabilityVector16: return "Vector16";
+        case CapabilityFloat16Buffer: return "Float16Buffer";
+        case CapabilityFloat16: return "Float16";
+        case CapabilityFloat64: return "Float64";
+        case CapabilityInt64: return "Int64";
+        case CapabilityInt64Atomics: return "Int64Atomics";
+        case CapabilityImageBasic: return "ImageBasic";
+        case CapabilityImageReadWrite: return "ImageReadWrite";
+        case CapabilityImageMipmap: return "ImageMipmap";
+        case CapabilityPipes: return "Pipes";
+        case CapabilityGroups: return "Groups";
+        case CapabilityDeviceEnqueue: return "DeviceEnqueue";
+        case CapabilityLiteralSampler: return "LiteralSampler";
+        case CapabilityAtomicStorage: return "AtomicStorage";
+        case CapabilityInt16: return "Int16";
+        case CapabilityTessellationPointSize: return "TessellationPointSize";
+        case CapabilityGeometryPointSize: return "GeometryPointSize";
+        case CapabilityImageGatherExtended: return "ImageGatherExtended";
+        case CapabilityStorageImageMultisample: return "StorageImageMultisample";
+        case CapabilityUniformBufferArrayDynamicIndexing: return "UniformBufferArrayDynamicIndexing";
+        case CapabilitySampledImageArrayDynamicIndexing: return "SampledImageArrayDynamicIndexing";
+        case CapabilityStorageBufferArrayDynamicIndexing: return "StorageBufferArrayDynamicIndexing";
+        case CapabilityStorageImageArrayDynamicIndexing: return "StorageImageArrayDynamicIndexing";
+        case CapabilityClipDistance: return "ClipDistance";
+        case CapabilityCullDistance: return "CullDistance";
+        case CapabilityImageCubeArray: return "ImageCubeArray";
+        case CapabilitySampleRateShading: return "SampleRateShading";
+        case CapabilityImageRect: return "ImageRect";
+        case CapabilitySampledRect: return "SampledRect";
+        case CapabilityGenericPointer: return "GenericPointer";
+        case CapabilityInt8: return "Int8";
+        case CapabilityInputAttachment: return "InputAttachment";
+        case CapabilitySparseResidency: return "SparseResidency";
+        case CapabilityMinLod: return "MinLod";
+        case CapabilitySampled1D: return "Sampled1D";
+        case CapabilityImage1D: return "Image1D";
+        case CapabilitySampledCubeArray: return "SampledCubeArray";
+        case CapabilitySampledBuffer: return "SampledBuffer";
+        case CapabilityImageBuffer: return "ImageBuffer";
+        case CapabilityImageMSArray: return "ImageMSArray";
+        case CapabilityStorageImageExtendedFormats: return "StorageImageExtendedFormats";
+        case CapabilityImageQuery: return "ImageQuery";
+        case CapabilityDerivativeControl: return "DerivativeControl";
+        case CapabilityInterpolationFunction: return "InterpolationFunction";
+        case CapabilityTransformFeedback: return "TransformFeedback";
+        case CapabilityGeometryStreams: return "GeometryStreams";
+        case CapabilityStorageImageReadWithoutFormat: return "StorageImageReadWithoutFormat";
+        case CapabilityStorageImageWriteWithoutFormat: return "StorageImageWriteWithoutFormat";
+        case CapabilityMultiViewport: return "MultiViewport";
+        case CapabilitySubgroupDispatch: return "SubgroupDispatch";
+        case CapabilityNamedBarrier: return "NamedBarrier";
+        case CapabilityPipeStorage: return "PipeStorage";
+        case CapabilitySubgroupBallotKHR: return "SubgroupBallotKHR";
+        case CapabilityDrawParameters: return "DrawParameters";
+        case CapabilitySubgroupVoteKHR: return "SubgroupVoteKHR";
+        case CapabilityStorageBuffer16BitAccess: return "StorageBuffer16BitAccess";
+        //case CapabilityStorageUniformBufferBlock16: return "StorageUniformBufferBlock16";
+        case CapabilityStorageUniform16: return "StorageUniform16";
+        //case CapabilityUniformAndStorageBuffer16BitAccess: return "UniformAndStorageBuffer16BitAccess";
+        case CapabilityStoragePushConstant16: return "StoragePushConstant16";
+        case CapabilityStorageInputOutput16: return "StorageInputOutput16";
+        case CapabilityDeviceGroup: return "DeviceGroup";
+        case CapabilityMultiView: return "MultiView";
+        case CapabilityVariablePointersStorageBuffer: return "VariablePointersStorageBuffer";
+        case CapabilityVariablePointers: return "VariablePointers";
+        case CapabilitySampleMaskOverrideCoverageNV: return "SampleMaskOverrideCoverageNV";
+        case CapabilityGeometryShaderPassthroughNV: return "GeometryShaderPassthroughNV";
+        case CapabilityShaderViewportIndexLayerNV: return "ShaderViewportIndexLayerNV";
+        case CapabilityShaderViewportMaskNV: return "ShaderViewportMaskNV";
+        case CapabilityShaderStereoViewNV: return "ShaderStereoViewNV";
+        case CapabilityPerViewAttributesNV: return "PerViewAttributesNV";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* OpToString(Op e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case OpNop: return "OpNop";
+        case OpUndef: return "OpUndef";
+        case OpSourceContinued: return "OpSourceContinued";
+        case OpSource: return "OpSource";
+        case OpSourceExtension: return "OpSourceExtension";
+        case OpName: return "OpName";
+        case OpMemberName: return "OpMemberName";
+        case OpString: return "OpString";
+        case OpLine: return "OpLine";
+        case OpExtension: return "OpExtension";
+        case OpExtInstImport: return "OpExtInstImport";
+        case OpExtInst: return "OpExtInst";
+        case OpMemoryModel: return "OpMemoryModel";
+        case OpEntryPoint: return "OpEntryPoint";
+        case OpExecutionMode: return "OpExecutionMode";
+        case OpCapability: return "OpCapability";
+        case OpTypeVoid: return "OpTypeVoid";
+        case OpTypeBool: return "OpTypeBool";
+        case OpTypeInt: return "OpTypeInt";
+        case OpTypeFloat: return "OpTypeFloat";
+        case OpTypeVector: return "OpTypeVector";
+        case OpTypeMatrix: return "OpTypeMatrix";
+        case OpTypeImage: return "OpTypeImage";
+        case OpTypeSampler: return "OpTypeSampler";
+        case OpTypeSampledImage: return "OpTypeSampledImage";
+        case OpTypeArray: return "OpTypeArray";
+        case OpTypeRuntimeArray: return "OpTypeRuntimeArray";
+        case OpTypeStruct: return "OpTypeStruct";
+        case OpTypeOpaque: return "OpTypeOpaque";
+        case OpTypePointer: return "OpTypePointer";
+        case OpTypeFunction: return "OpTypeFunction";
+        case OpTypeEvent: return "OpTypeEvent";
+        case OpTypeDeviceEvent: return "OpTypeDeviceEvent";
+        case OpTypeReserveId: return "OpTypeReserveId";
+        case OpTypeQueue: return "OpTypeQueue";
+        case OpTypePipe: return "OpTypePipe";
+        case OpTypeForwardPointer: return "OpTypeForwardPointer";
+        case OpConstantTrue: return "OpConstantTrue";
+        case OpConstantFalse: return "OpConstantFalse";
+        case OpConstant: return "OpConstant";
+        case OpConstantComposite: return "OpConstantComposite";
+        case OpConstantSampler: return "OpConstantSampler";
+        case OpConstantNull: return "OpConstantNull";
+        case OpSpecConstantTrue: return "OpSpecConstantTrue";
+        case OpSpecConstantFalse: return "OpSpecConstantFalse";
+        case OpSpecConstant: return "OpSpecConstant";
+        case OpSpecConstantComposite: return "OpSpecConstantComposite";
+        case OpSpecConstantOp: return "OpSpecConstantOp";
+        case OpFunction: return "OpFunction";
+        case OpFunctionParameter: return "OpFunctionParameter";
+        case OpFunctionEnd: return "OpFunctionEnd";
+        case OpFunctionCall: return "OpFunctionCall";
+        case OpVariable: return "OpVariable";
+        case OpImageTexelPointer: return "OpImageTexelPointer";
+        case OpLoad: return "OpLoad";
+        case OpStore: return "OpStore";
+        case OpCopyMemory: return "OpCopyMemory";
+        case OpCopyMemorySized: return "OpCopyMemorySized";
+        case OpAccessChain: return "OpAccessChain";
+        case OpInBoundsAccessChain: return "OpInBoundsAccessChain";
+        case OpPtrAccessChain: return "OpPtrAccessChain";
+        case OpArrayLength: return "OpArrayLength";
+        case OpGenericPtrMemSemantics: return "OpGenericPtrMemSemantics";
+        case OpInBoundsPtrAccessChain: return "OpInBoundsPtrAccessChain";
+        case OpDecorate: return "OpDecorate";
+        case OpMemberDecorate: return "OpMemberDecorate";
+        case OpDecorationGroup: return "OpDecorationGroup";
+        case OpGroupDecorate: return "OpGroupDecorate";
+        case OpGroupMemberDecorate: return "OpGroupMemberDecorate";
+        case OpVectorExtractDynamic: return "OpVectorExtractDynamic";
+        case OpVectorInsertDynamic: return "OpVectorInsertDynamic";
+        case OpVectorShuffle: return "OpVectorShuffle";
+        case OpCompositeConstruct: return "OpCompositeConstruct";
+        case OpCompositeExtract: return "OpCompositeExtract";
+        case OpCompositeInsert: return "OpCompositeInsert";
+        case OpCopyObject: return "OpCopyObject";
+        case OpTranspose: return "OpTranspose";
+        case OpSampledImage: return "OpSampledImage";
+        case OpImageSampleImplicitLod: return "OpImageSampleImplicitLod";
+        case OpImageSampleExplicitLod: return "OpImageSampleExplicitLod";
+        case OpImageSampleDrefImplicitLod: return "OpImageSampleDrefImplicitLod";
+        case OpImageSampleDrefExplicitLod: return "OpImageSampleDrefExplicitLod";
+        case OpImageSampleProjImplicitLod: return "OpImageSampleProjImplicitLod";
+        case OpImageSampleProjExplicitLod: return "OpImageSampleProjExplicitLod";
+        case OpImageSampleProjDrefImplicitLod: return "OpImageSampleProjDrefImplicitLod";
+        case OpImageSampleProjDrefExplicitLod: return "OpImageSampleProjDrefExplicitLod";
+        case OpImageFetch: return "OpImageFetch";
+        case OpImageGather: return "OpImageGather";
+        case OpImageDrefGather: return "OpImageDrefGather";
+        case OpImageRead: return "OpImageRead";
+        case OpImageWrite: return "OpImageWrite";
+        case OpImage: return "OpImage";
+        case OpImageQueryFormat: return "OpImageQueryFormat";
+        case OpImageQueryOrder: return "OpImageQueryOrder";
+        case OpImageQuerySizeLod: return "OpImageQuerySizeLod";
+        case OpImageQuerySize: return "OpImageQuerySize";
+        case OpImageQueryLod: return "OpImageQueryLod";
+        case OpImageQueryLevels: return "OpImageQueryLevels";
+        case OpImageQuerySamples: return "OpImageQuerySamples";
+        case OpConvertFToU: return "OpConvertFToU";
+        case OpConvertFToS: return "OpConvertFToS";
+        case OpConvertSToF: return "OpConvertSToF";
+        case OpConvertUToF: return "OpConvertUToF";
+        case OpUConvert: return "OpUConvert";
+        case OpSConvert: return "OpSConvert";
+        case OpFConvert: return "OpFConvert";
+        case OpQuantizeToF16: return "OpQuantizeToF16";
+        case OpConvertPtrToU: return "OpConvertPtrToU";
+        case OpSatConvertSToU: return "OpSatConvertSToU";
+        case OpSatConvertUToS: return "OpSatConvertUToS";
+        case OpConvertUToPtr: return "OpConvertUToPtr";
+        case OpPtrCastToGeneric: return "OpPtrCastToGeneric";
+        case OpGenericCastToPtr: return "OpGenericCastToPtr";
+        case OpGenericCastToPtrExplicit: return "OpGenericCastToPtrExplicit";
+        case OpBitcast: return "OpBitcast";
+        case OpSNegate: return "OpSNegate";
+        case OpFNegate: return "OpFNegate";
+        case OpIAdd: return "OpIAdd";
+        case OpFAdd: return "OpFAdd";
+        case OpISub: return "OpISub";
+        case OpFSub: return "OpFSub";
+        case OpIMul: return "OpIMul";
+        case OpFMul: return "OpFMul";
+        case OpUDiv: return "OpUDiv";
+        case OpSDiv: return "OpSDiv";
+        case OpFDiv: return "OpFDiv";
+        case OpUMod: return "OpUMod";
+        case OpSRem: return "OpSRem";
+        case OpSMod: return "OpSMod";
+        case OpFRem: return "OpFRem";
+        case OpFMod: return "OpFMod";
+        case OpVectorTimesScalar: return "OpVectorTimesScalar";
+        case OpMatrixTimesScalar: return "OpMatrixTimesScalar";
+        case OpVectorTimesMatrix: return "OpVectorTimesMatrix";
+        case OpMatrixTimesVector: return "OpMatrixTimesVector";
+        case OpMatrixTimesMatrix: return "OpMatrixTimesMatrix";
+        case OpOuterProduct: return "OpOuterProduct";
+        case OpDot: return "OpDot";
+        case OpIAddCarry: return "OpIAddCarry";
+        case OpISubBorrow: return "OpISubBorrow";
+        case OpUMulExtended: return "OpUMulExtended";
+        case OpSMulExtended: return "OpSMulExtended";
+        case OpAny: return "OpAny";
+        case OpAll: return "OpAll";
+        case OpIsNan: return "OpIsNan";
+        case OpIsInf: return "OpIsInf";
+        case OpIsFinite: return "OpIsFinite";
+        case OpIsNormal: return "OpIsNormal";
+        case OpSignBitSet: return "OpSignBitSet";
+        case OpLessOrGreater: return "OpLessOrGreater";
+        case OpOrdered: return "OpOrdered";
+        case OpUnordered: return "OpUnordered";
+        case OpLogicalEqual: return "OpLogicalEqual";
+        case OpLogicalNotEqual: return "OpLogicalNotEqual";
+        case OpLogicalOr: return "OpLogicalOr";
+        case OpLogicalAnd: return "OpLogicalAnd";
+        case OpLogicalNot: return "OpLogicalNot";
+        case OpSelect: return "OpSelect";
+        case OpIEqual: return "OpIEqual";
+        case OpINotEqual: return "OpINotEqual";
+        case OpUGreaterThan: return "OpUGreaterThan";
+        case OpSGreaterThan: return "OpSGreaterThan";
+        case OpUGreaterThanEqual: return "OpUGreaterThanEqual";
+        case OpSGreaterThanEqual: return "OpSGreaterThanEqual";
+        case OpULessThan: return "OpULessThan";
+        case OpSLessThan: return "OpSLessThan";
+        case OpULessThanEqual: return "OpULessThanEqual";
+        case OpSLessThanEqual: return "OpSLessThanEqual";
+        case OpFOrdEqual: return "OpFOrdEqual";
+        case OpFUnordEqual: return "OpFUnordEqual";
+        case OpFOrdNotEqual: return "OpFOrdNotEqual";
+        case OpFUnordNotEqual: return "OpFUnordNotEqual";
+        case OpFOrdLessThan: return "OpFOrdLessThan";
+        case OpFUnordLessThan: return "OpFUnordLessThan";
+        case OpFOrdGreaterThan: return "OpFOrdGreaterThan";
+        case OpFUnordGreaterThan: return "OpFUnordGreaterThan";
+        case OpFOrdLessThanEqual: return "OpFOrdLessThanEqual";
+        case OpFUnordLessThanEqual: return "OpFUnordLessThanEqual";
+        case OpFOrdGreaterThanEqual: return "OpFOrdGreaterThanEqual";
+        case OpFUnordGreaterThanEqual: return "OpFUnordGreaterThanEqual";
+        case OpShiftRightLogical: return "OpShiftRightLogical";
+        case OpShiftRightArithmetic: return "OpShiftRightArithmetic";
+        case OpShiftLeftLogical: return "OpShiftLeftLogical";
+        case OpBitwiseOr: return "OpBitwiseOr";
+        case OpBitwiseXor: return "OpBitwiseXor";
+        case OpBitwiseAnd: return "OpBitwiseAnd";
+        case OpNot: return "OpNot";
+        case OpBitFieldInsert: return "OpBitFieldInsert";
+        case OpBitFieldSExtract: return "OpBitFieldSExtract";
+        case OpBitFieldUExtract: return "OpBitFieldUExtract";
+        case OpBitReverse: return "OpBitReverse";
+        case OpBitCount: return "OpBitCount";
+        case OpDPdx: return "OpDPdx";
+        case OpDPdy: return "OpDPdy";
+        case OpFwidth: return "OpFwidth";
+        case OpDPdxFine: return "OpDPdxFine";
+        case OpDPdyFine: return "OpDPdyFine";
+        case OpFwidthFine: return "OpFwidthFine";
+        case OpDPdxCoarse: return "OpDPdxCoarse";
+        case OpDPdyCoarse: return "OpDPdyCoarse";
+        case OpFwidthCoarse: return "OpFwidthCoarse";
+        case OpEmitVertex: return "OpEmitVertex";
+        case OpEndPrimitive: return "OpEndPrimitive";
+        case OpEmitStreamVertex: return "OpEmitStreamVertex";
+        case OpEndStreamPrimitive: return "OpEndStreamPrimitive";
+        case OpControlBarrier: return "OpControlBarrier";
+        case OpMemoryBarrier: return "OpMemoryBarrier";
+        case OpAtomicLoad: return "OpAtomicLoad";
+        case OpAtomicStore: return "OpAtomicStore";
+        case OpAtomicExchange: return "OpAtomicExchange";
+        case OpAtomicCompareExchange: return "OpAtomicCompareExchange";
+        case OpAtomicCompareExchangeWeak: return "OpAtomicCompareExchangeWeak";
+        case OpAtomicIIncrement: return "OpAtomicIIncrement";
+        case OpAtomicIDecrement: return "OpAtomicIDecrement";
+        case OpAtomicIAdd: return "OpAtomicIAdd";
+        case OpAtomicISub: return "OpAtomicISub";
+        case OpAtomicSMin: return "OpAtomicSMin";
+        case OpAtomicUMin: return "OpAtomicUMin";
+        case OpAtomicSMax: return "OpAtomicSMax";
+        case OpAtomicUMax: return "OpAtomicUMax";
+        case OpAtomicAnd: return "OpAtomicAnd";
+        case OpAtomicOr: return "OpAtomicOr";
+        case OpAtomicXor: return "OpAtomicXor";
+        case OpPhi: return "OpPhi";
+        case OpLoopMerge: return "OpLoopMerge";
+        case OpSelectionMerge: return "OpSelectionMerge";
+        case OpLabel: return "OpLabel";
+        case OpBranch: return "OpBranch";
+        case OpBranchConditional: return "OpBranchConditional";
+        case OpSwitch: return "OpSwitch";
+        case OpKill: return "OpKill";
+        case OpReturn: return "OpReturn";
+        case OpReturnValue: return "OpReturnValue";
+        case OpUnreachable: return "OpUnreachable";
+        case OpLifetimeStart: return "OpLifetimeStart";
+        case OpLifetimeStop: return "OpLifetimeStop";
+        case OpGroupAsyncCopy: return "OpGroupAsyncCopy";
+        case OpGroupWaitEvents: return "OpGroupWaitEvents";
+        case OpGroupAll: return "OpGroupAll";
+        case OpGroupAny: return "OpGroupAny";
+        case OpGroupBroadcast: return "OpGroupBroadcast";
+        case OpGroupIAdd: return "OpGroupIAdd";
+        case OpGroupFAdd: return "OpGroupFAdd";
+        case OpGroupFMin: return "OpGroupFMin";
+        case OpGroupUMin: return "OpGroupUMin";
+        case OpGroupSMin: return "OpGroupSMin";
+        case OpGroupFMax: return "OpGroupFMax";
+        case OpGroupUMax: return "OpGroupUMax";
+        case OpGroupSMax: return "OpGroupSMax";
+        case OpReadPipe: return "OpReadPipe";
+        case OpWritePipe: return "OpWritePipe";
+        case OpReservedReadPipe: return "OpReservedReadPipe";
+        case OpReservedWritePipe: return "OpReservedWritePipe";
+        case OpReserveReadPipePackets: return "OpReserveReadPipePackets";
+        case OpReserveWritePipePackets: return "OpReserveWritePipePackets";
+        case OpCommitReadPipe: return "OpCommitReadPipe";
+        case OpCommitWritePipe: return "OpCommitWritePipe";
+        case OpIsValidReserveId: return "OpIsValidReserveId";
+        case OpGetNumPipePackets: return "OpGetNumPipePackets";
+        case OpGetMaxPipePackets: return "OpGetMaxPipePackets";
+        case OpGroupReserveReadPipePackets: return "OpGroupReserveReadPipePackets";
+        case OpGroupReserveWritePipePackets: return "OpGroupReserveWritePipePackets";
+        case OpGroupCommitReadPipe: return "OpGroupCommitReadPipe";
+        case OpGroupCommitWritePipe: return "OpGroupCommitWritePipe";
+        case OpEnqueueMarker: return "OpEnqueueMarker";
+        case OpEnqueueKernel: return "OpEnqueueKernel";
+        case OpGetKernelNDrangeSubGroupCount: return "OpGetKernelNDrangeSubGroupCount";
+        case OpGetKernelNDrangeMaxSubGroupSize: return "OpGetKernelNDrangeMaxSubGroupSize";
+        case OpGetKernelWorkGroupSize: return "OpGetKernelWorkGroupSize";
+        case OpGetKernelPreferredWorkGroupSizeMultiple: return "OpGetKernelPreferredWorkGroupSizeMultiple";
+        case OpRetainEvent: return "OpRetainEvent";
+        case OpReleaseEvent: return "OpReleaseEvent";
+        case OpCreateUserEvent: return "OpCreateUserEvent";
+        case OpIsValidEvent: return "OpIsValidEvent";
+        case OpSetUserEventStatus: return "OpSetUserEventStatus";
+        case OpCaptureEventProfilingInfo: return "OpCaptureEventProfilingInfo";
+        case OpGetDefaultQueue: return "OpGetDefaultQueue";
+        case OpBuildNDRange: return "OpBuildNDRange";
+        case OpImageSparseSampleImplicitLod: return "OpImageSparseSampleImplicitLod";
+        case OpImageSparseSampleExplicitLod: return "OpImageSparseSampleExplicitLod";
+        case OpImageSparseSampleDrefImplicitLod: return "OpImageSparseSampleDrefImplicitLod";
+        case OpImageSparseSampleDrefExplicitLod: return "OpImageSparseSampleDrefExplicitLod";
+        case OpImageSparseSampleProjImplicitLod: return "OpImageSparseSampleProjImplicitLod";
+        case OpImageSparseSampleProjExplicitLod: return "OpImageSparseSampleProjExplicitLod";
+        case OpImageSparseSampleProjDrefImplicitLod: return "OpImageSparseSampleProjDrefImplicitLod";
+        case OpImageSparseSampleProjDrefExplicitLod: return "OpImageSparseSampleProjDrefExplicitLod";
+        case OpImageSparseFetch: return "OpImageSparseFetch";
+        case OpImageSparseGather: return "OpImageSparseGather";
+        case OpImageSparseDrefGather: return "OpImageSparseDrefGather";
+        case OpImageSparseTexelsResident: return "OpImageSparseTexelsResident";
+        case OpNoLine: return "OpNoLine";
+        case OpAtomicFlagTestAndSet: return "OpAtomicFlagTestAndSet";
+        case OpAtomicFlagClear: return "OpAtomicFlagClear";
+        case OpImageSparseRead: return "OpImageSparseRead";
+        case OpSizeOf: return "OpSizeOf";
+        case OpTypePipeStorage: return "OpTypePipeStorage";
+        case OpConstantPipeStorage: return "OpConstantPipeStorage";
+        case OpCreatePipeFromPipeStorage: return "OpCreatePipeFromPipeStorage";
+        case OpGetKernelLocalSizeForSubgroupCount: return "OpGetKernelLocalSizeForSubgroupCount";
+        case OpGetKernelMaxNumSubgroups: return "OpGetKernelMaxNumSubgroups";
+        case OpTypeNamedBarrier: return "OpTypeNamedBarrier";
+        case OpNamedBarrierInitialize: return "OpNamedBarrierInitialize";
+        case OpMemoryNamedBarrier: return "OpMemoryNamedBarrier";
+        case OpModuleProcessed: return "OpModuleProcessed";
+        case OpExecutionModeId: return "OpExecutionModeId";
+        case OpDecorateId: return "OpDecorateId";
+        case OpSubgroupBallotKHR: return "OpSubgroupBallotKHR";
+        case OpSubgroupFirstInvocationKHR: return "OpSubgroupFirstInvocationKHR";
+        case OpSubgroupAllKHR: return "OpSubgroupAllKHR";
+        case OpSubgroupAnyKHR: return "OpSubgroupAnyKHR";
+        case OpSubgroupAllEqualKHR: return "OpSubgroupAllEqualKHR";
+        case OpSubgroupReadInvocationKHR: return "OpSubgroupReadInvocationKHR";
+        default: return "";
+    }
+}
+#endif
+
+}  // end namespace spv
+
+#endif  // #ifndef spirv_strings_HPP
+

--- a/include/spirv/1.2/spirv_strings.hpp11
+++ b/include/spirv/1.2/spirv_strings.hpp11
@@ -1,0 +1,1280 @@
+/*
+** Copyright (c) 2014-2017 The Khronos Group Inc.
+** 
+** Permission is hereby granted, free of charge, to any person obtaining a copy
+** of this software and/or associated documentation files (the "Materials"),
+** to deal in the Materials without restriction, including without limitation
+** the rights to use, copy, modify, merge, publish, distribute, sublicense,
+** and/or sell copies of the Materials, and to permit persons to whom the
+** Materials are furnished to do so, subject to the following conditions:
+** 
+** The above copyright notice and this permission notice shall be included in
+** all copies or substantial portions of the Materials.
+** 
+** MODIFICATIONS TO THIS FILE MAY MEAN IT NO LONGER ACCURATELY REFLECTS KHRONOS
+** STANDARDS. THE UNMODIFIED, NORMATIVE VERSIONS OF KHRONOS SPECIFICATIONS AND
+** HEADER INFORMATION ARE LOCATED AT https://www.khronos.org/registry/ 
+** 
+** THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+** OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+** THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+** FROM,OUT OF OR IN CONNECTION WITH THE MATERIALS OR THE USE OR OTHER DEALINGS
+** IN THE MATERIALS.
+*/
+
+#ifndef spirv_strings_HPP
+#define spirv_strings_HPP
+
+#include "spirv.hpp11"
+
+#ifndef SPIRV_DEF
+#   ifdef SPIRV_STRINGS_IMPLEMENT
+#       define SPIRV_DEF
+#   else
+#       define SPIRV_DEF extern
+#   endif
+#endif
+
+namespace spv {
+
+SPIRV_DEF const char* SourceLanguageToString(SourceLanguage e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case SourceLanguage::Unknown: return "Unknown";
+        case SourceLanguage::ESSL: return "ESSL";
+        case SourceLanguage::GLSL: return "GLSL";
+        case SourceLanguage::OpenCL_C: return "OpenCL_C";
+        case SourceLanguage::OpenCL_CPP: return "OpenCL_CPP";
+        case SourceLanguage::HLSL: return "HLSL";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* ExecutionModelToString(ExecutionModel e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case ExecutionModel::Vertex: return "Vertex";
+        case ExecutionModel::TessellationControl: return "TessellationControl";
+        case ExecutionModel::TessellationEvaluation: return "TessellationEvaluation";
+        case ExecutionModel::Geometry: return "Geometry";
+        case ExecutionModel::Fragment: return "Fragment";
+        case ExecutionModel::GLCompute: return "GLCompute";
+        case ExecutionModel::Kernel: return "Kernel";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* AddressingModelToString(AddressingModel e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case AddressingModel::Logical: return "Logical";
+        case AddressingModel::Physical32: return "Physical32";
+        case AddressingModel::Physical64: return "Physical64";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* MemoryModelToString(MemoryModel e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case MemoryModel::Simple: return "Simple";
+        case MemoryModel::GLSL450: return "GLSL450";
+        case MemoryModel::OpenCL: return "OpenCL";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* ExecutionModeToString(ExecutionMode e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case ExecutionMode::Invocations: return "Invocations";
+        case ExecutionMode::SpacingEqual: return "SpacingEqual";
+        case ExecutionMode::SpacingFractionalEven: return "SpacingFractionalEven";
+        case ExecutionMode::SpacingFractionalOdd: return "SpacingFractionalOdd";
+        case ExecutionMode::VertexOrderCw: return "VertexOrderCw";
+        case ExecutionMode::VertexOrderCcw: return "VertexOrderCcw";
+        case ExecutionMode::PixelCenterInteger: return "PixelCenterInteger";
+        case ExecutionMode::OriginUpperLeft: return "OriginUpperLeft";
+        case ExecutionMode::OriginLowerLeft: return "OriginLowerLeft";
+        case ExecutionMode::EarlyFragmentTests: return "EarlyFragmentTests";
+        case ExecutionMode::PointMode: return "PointMode";
+        case ExecutionMode::Xfb: return "Xfb";
+        case ExecutionMode::DepthReplacing: return "DepthReplacing";
+        case ExecutionMode::DepthGreater: return "DepthGreater";
+        case ExecutionMode::DepthLess: return "DepthLess";
+        case ExecutionMode::DepthUnchanged: return "DepthUnchanged";
+        case ExecutionMode::LocalSize: return "LocalSize";
+        case ExecutionMode::LocalSizeHint: return "LocalSizeHint";
+        case ExecutionMode::InputPoints: return "InputPoints";
+        case ExecutionMode::InputLines: return "InputLines";
+        case ExecutionMode::InputLinesAdjacency: return "InputLinesAdjacency";
+        case ExecutionMode::Triangles: return "Triangles";
+        case ExecutionMode::InputTrianglesAdjacency: return "InputTrianglesAdjacency";
+        case ExecutionMode::Quads: return "Quads";
+        case ExecutionMode::Isolines: return "Isolines";
+        case ExecutionMode::OutputVertices: return "OutputVertices";
+        case ExecutionMode::OutputPoints: return "OutputPoints";
+        case ExecutionMode::OutputLineStrip: return "OutputLineStrip";
+        case ExecutionMode::OutputTriangleStrip: return "OutputTriangleStrip";
+        case ExecutionMode::VecTypeHint: return "VecTypeHint";
+        case ExecutionMode::ContractionOff: return "ContractionOff";
+        case ExecutionMode::Initializer: return "Initializer";
+        case ExecutionMode::Finalizer: return "Finalizer";
+        case ExecutionMode::SubgroupSize: return "SubgroupSize";
+        case ExecutionMode::SubgroupsPerWorkgroup: return "SubgroupsPerWorkgroup";
+        case ExecutionMode::SubgroupsPerWorkgroupId: return "SubgroupsPerWorkgroupId";
+        case ExecutionMode::LocalSizeId: return "LocalSizeId";
+        case ExecutionMode::LocalSizeHintId: return "LocalSizeHintId";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* StorageClassToString(StorageClass e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case StorageClass::UniformConstant: return "UniformConstant";
+        case StorageClass::Input: return "Input";
+        case StorageClass::Uniform: return "Uniform";
+        case StorageClass::Output: return "Output";
+        case StorageClass::Workgroup: return "Workgroup";
+        case StorageClass::CrossWorkgroup: return "CrossWorkgroup";
+        case StorageClass::Private: return "Private";
+        case StorageClass::Function: return "Function";
+        case StorageClass::Generic: return "Generic";
+        case StorageClass::PushConstant: return "PushConstant";
+        case StorageClass::AtomicCounter: return "AtomicCounter";
+        case StorageClass::Image: return "Image";
+        case StorageClass::StorageBuffer: return "StorageBuffer";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* DimToString(Dim e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case Dim::Dim1D: return "1D";
+        case Dim::Dim2D: return "2D";
+        case Dim::Dim3D: return "3D";
+        case Dim::Cube: return "Cube";
+        case Dim::Rect: return "Rect";
+        case Dim::Buffer: return "Buffer";
+        case Dim::SubpassData: return "SubpassData";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* SamplerAddressingModeToString(SamplerAddressingMode e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case SamplerAddressingMode::None: return "None";
+        case SamplerAddressingMode::ClampToEdge: return "ClampToEdge";
+        case SamplerAddressingMode::Clamp: return "Clamp";
+        case SamplerAddressingMode::Repeat: return "Repeat";
+        case SamplerAddressingMode::RepeatMirrored: return "RepeatMirrored";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* SamplerFilterModeToString(SamplerFilterMode e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case SamplerFilterMode::Nearest: return "Nearest";
+        case SamplerFilterMode::Linear: return "Linear";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* ImageFormatToString(ImageFormat e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case ImageFormat::Unknown: return "Unknown";
+        case ImageFormat::Rgba32f: return "Rgba32f";
+        case ImageFormat::Rgba16f: return "Rgba16f";
+        case ImageFormat::R32f: return "R32f";
+        case ImageFormat::Rgba8: return "Rgba8";
+        case ImageFormat::Rgba8Snorm: return "Rgba8Snorm";
+        case ImageFormat::Rg32f: return "Rg32f";
+        case ImageFormat::Rg16f: return "Rg16f";
+        case ImageFormat::R11fG11fB10f: return "R11fG11fB10f";
+        case ImageFormat::R16f: return "R16f";
+        case ImageFormat::Rgba16: return "Rgba16";
+        case ImageFormat::Rgb10A2: return "Rgb10A2";
+        case ImageFormat::Rg16: return "Rg16";
+        case ImageFormat::Rg8: return "Rg8";
+        case ImageFormat::R16: return "R16";
+        case ImageFormat::R8: return "R8";
+        case ImageFormat::Rgba16Snorm: return "Rgba16Snorm";
+        case ImageFormat::Rg16Snorm: return "Rg16Snorm";
+        case ImageFormat::Rg8Snorm: return "Rg8Snorm";
+        case ImageFormat::R16Snorm: return "R16Snorm";
+        case ImageFormat::R8Snorm: return "R8Snorm";
+        case ImageFormat::Rgba32i: return "Rgba32i";
+        case ImageFormat::Rgba16i: return "Rgba16i";
+        case ImageFormat::Rgba8i: return "Rgba8i";
+        case ImageFormat::R32i: return "R32i";
+        case ImageFormat::Rg32i: return "Rg32i";
+        case ImageFormat::Rg16i: return "Rg16i";
+        case ImageFormat::Rg8i: return "Rg8i";
+        case ImageFormat::R16i: return "R16i";
+        case ImageFormat::R8i: return "R8i";
+        case ImageFormat::Rgba32ui: return "Rgba32ui";
+        case ImageFormat::Rgba16ui: return "Rgba16ui";
+        case ImageFormat::Rgba8ui: return "Rgba8ui";
+        case ImageFormat::R32ui: return "R32ui";
+        case ImageFormat::Rgb10a2ui: return "Rgb10a2ui";
+        case ImageFormat::Rg32ui: return "Rg32ui";
+        case ImageFormat::Rg16ui: return "Rg16ui";
+        case ImageFormat::Rg8ui: return "Rg8ui";
+        case ImageFormat::R16ui: return "R16ui";
+        case ImageFormat::R8ui: return "R8ui";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* ImageChannelOrderToString(ImageChannelOrder e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case ImageChannelOrder::R: return "R";
+        case ImageChannelOrder::A: return "A";
+        case ImageChannelOrder::RG: return "RG";
+        case ImageChannelOrder::RA: return "RA";
+        case ImageChannelOrder::RGB: return "RGB";
+        case ImageChannelOrder::RGBA: return "RGBA";
+        case ImageChannelOrder::BGRA: return "BGRA";
+        case ImageChannelOrder::ARGB: return "ARGB";
+        case ImageChannelOrder::Intensity: return "Intensity";
+        case ImageChannelOrder::Luminance: return "Luminance";
+        case ImageChannelOrder::Rx: return "Rx";
+        case ImageChannelOrder::RGx: return "RGx";
+        case ImageChannelOrder::RGBx: return "RGBx";
+        case ImageChannelOrder::Depth: return "Depth";
+        case ImageChannelOrder::DepthStencil: return "DepthStencil";
+        case ImageChannelOrder::sRGB: return "sRGB";
+        case ImageChannelOrder::sRGBx: return "sRGBx";
+        case ImageChannelOrder::sRGBA: return "sRGBA";
+        case ImageChannelOrder::sBGRA: return "sBGRA";
+        case ImageChannelOrder::ABGR: return "ABGR";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* ImageChannelDataTypeToString(ImageChannelDataType e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case ImageChannelDataType::SnormInt8: return "SnormInt8";
+        case ImageChannelDataType::SnormInt16: return "SnormInt16";
+        case ImageChannelDataType::UnormInt8: return "UnormInt8";
+        case ImageChannelDataType::UnormInt16: return "UnormInt16";
+        case ImageChannelDataType::UnormShort565: return "UnormShort565";
+        case ImageChannelDataType::UnormShort555: return "UnormShort555";
+        case ImageChannelDataType::UnormInt101010: return "UnormInt101010";
+        case ImageChannelDataType::SignedInt8: return "SignedInt8";
+        case ImageChannelDataType::SignedInt16: return "SignedInt16";
+        case ImageChannelDataType::SignedInt32: return "SignedInt32";
+        case ImageChannelDataType::UnsignedInt8: return "UnsignedInt8";
+        case ImageChannelDataType::UnsignedInt16: return "UnsignedInt16";
+        case ImageChannelDataType::UnsignedInt32: return "UnsignedInt32";
+        case ImageChannelDataType::HalfFloat: return "HalfFloat";
+        case ImageChannelDataType::Float: return "Float";
+        case ImageChannelDataType::UnormInt24: return "UnormInt24";
+        case ImageChannelDataType::UnormInt101010_2: return "UnormInt101010_2";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* ImageOperandsShiftToString(ImageOperandsShift e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case ImageOperandsShift::Bias: return "Bias";
+        case ImageOperandsShift::Lod: return "Lod";
+        case ImageOperandsShift::Grad: return "Grad";
+        case ImageOperandsShift::ConstOffset: return "ConstOffset";
+        case ImageOperandsShift::Offset: return "Offset";
+        case ImageOperandsShift::ConstOffsets: return "ConstOffsets";
+        case ImageOperandsShift::Sample: return "Sample";
+        case ImageOperandsShift::MinLod: return "MinLod";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* ImageOperandsMaskToString(ImageOperandsMask e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case ImageOperandsMask::MaskNone: return "None";
+        case ImageOperandsMask::Bias: return "Bias";
+        case ImageOperandsMask::Lod: return "Lod";
+        case ImageOperandsMask::Grad: return "Grad";
+        case ImageOperandsMask::ConstOffset: return "ConstOffset";
+        case ImageOperandsMask::Offset: return "Offset";
+        case ImageOperandsMask::ConstOffsets: return "ConstOffsets";
+        case ImageOperandsMask::Sample: return "Sample";
+        case ImageOperandsMask::MinLod: return "MinLod";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* FPFastMathModeShiftToString(FPFastMathModeShift e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case FPFastMathModeShift::NotNaN: return "NotNaN";
+        case FPFastMathModeShift::NotInf: return "NotInf";
+        case FPFastMathModeShift::NSZ: return "NSZ";
+        case FPFastMathModeShift::AllowRecip: return "AllowRecip";
+        case FPFastMathModeShift::Fast: return "Fast";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* FPFastMathModeMaskToString(FPFastMathModeMask e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case FPFastMathModeMask::MaskNone: return "None";
+        case FPFastMathModeMask::NotNaN: return "NotNaN";
+        case FPFastMathModeMask::NotInf: return "NotInf";
+        case FPFastMathModeMask::NSZ: return "NSZ";
+        case FPFastMathModeMask::AllowRecip: return "AllowRecip";
+        case FPFastMathModeMask::Fast: return "Fast";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* FPRoundingModeToString(FPRoundingMode e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case FPRoundingMode::RTE: return "RTE";
+        case FPRoundingMode::RTZ: return "RTZ";
+        case FPRoundingMode::RTP: return "RTP";
+        case FPRoundingMode::RTN: return "RTN";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* LinkageTypeToString(LinkageType e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case LinkageType::Export: return "Export";
+        case LinkageType::Import: return "Import";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* AccessQualifierToString(AccessQualifier e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case AccessQualifier::ReadOnly: return "ReadOnly";
+        case AccessQualifier::WriteOnly: return "WriteOnly";
+        case AccessQualifier::ReadWrite: return "ReadWrite";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* FunctionParameterAttributeToString(FunctionParameterAttribute e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case FunctionParameterAttribute::Zext: return "Zext";
+        case FunctionParameterAttribute::Sext: return "Sext";
+        case FunctionParameterAttribute::ByVal: return "ByVal";
+        case FunctionParameterAttribute::Sret: return "Sret";
+        case FunctionParameterAttribute::NoAlias: return "NoAlias";
+        case FunctionParameterAttribute::NoCapture: return "NoCapture";
+        case FunctionParameterAttribute::NoWrite: return "NoWrite";
+        case FunctionParameterAttribute::NoReadWrite: return "NoReadWrite";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* DecorationToString(Decoration e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case Decoration::RelaxedPrecision: return "RelaxedPrecision";
+        case Decoration::SpecId: return "SpecId";
+        case Decoration::Block: return "Block";
+        case Decoration::BufferBlock: return "BufferBlock";
+        case Decoration::RowMajor: return "RowMajor";
+        case Decoration::ColMajor: return "ColMajor";
+        case Decoration::ArrayStride: return "ArrayStride";
+        case Decoration::MatrixStride: return "MatrixStride";
+        case Decoration::GLSLShared: return "GLSLShared";
+        case Decoration::GLSLPacked: return "GLSLPacked";
+        case Decoration::CPacked: return "CPacked";
+        case Decoration::BuiltIn: return "BuiltIn";
+        case Decoration::NoPerspective: return "NoPerspective";
+        case Decoration::Flat: return "Flat";
+        case Decoration::Patch: return "Patch";
+        case Decoration::Centroid: return "Centroid";
+        case Decoration::Sample: return "Sample";
+        case Decoration::Invariant: return "Invariant";
+        case Decoration::Restrict: return "Restrict";
+        case Decoration::Aliased: return "Aliased";
+        case Decoration::Volatile: return "Volatile";
+        case Decoration::Constant: return "Constant";
+        case Decoration::Coherent: return "Coherent";
+        case Decoration::NonWritable: return "NonWritable";
+        case Decoration::NonReadable: return "NonReadable";
+        case Decoration::Uniform: return "Uniform";
+        case Decoration::SaturatedConversion: return "SaturatedConversion";
+        case Decoration::Stream: return "Stream";
+        case Decoration::Location: return "Location";
+        case Decoration::Component: return "Component";
+        case Decoration::Index: return "Index";
+        case Decoration::Binding: return "Binding";
+        case Decoration::DescriptorSet: return "DescriptorSet";
+        case Decoration::Offset: return "Offset";
+        case Decoration::XfbBuffer: return "XfbBuffer";
+        case Decoration::XfbStride: return "XfbStride";
+        case Decoration::FuncParamAttr: return "FuncParamAttr";
+        case Decoration::FPRoundingMode: return "FPRoundingMode";
+        case Decoration::FPFastMathMode: return "FPFastMathMode";
+        case Decoration::LinkageAttributes: return "LinkageAttributes";
+        case Decoration::NoContraction: return "NoContraction";
+        case Decoration::InputAttachmentIndex: return "InputAttachmentIndex";
+        case Decoration::Alignment: return "Alignment";
+        case Decoration::MaxByteOffset: return "MaxByteOffset";
+        case Decoration::AlignmentId: return "AlignmentId";
+        case Decoration::MaxByteOffsetId: return "MaxByteOffsetId";
+        case Decoration::OverrideCoverageNV: return "OverrideCoverageNV";
+        case Decoration::PassthroughNV: return "PassthroughNV";
+        case Decoration::ViewportRelativeNV: return "ViewportRelativeNV";
+        case Decoration::SecondaryViewportRelativeNV: return "SecondaryViewportRelativeNV";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* BuiltInToString(BuiltIn e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case BuiltIn::Position: return "Position";
+        case BuiltIn::PointSize: return "PointSize";
+        case BuiltIn::ClipDistance: return "ClipDistance";
+        case BuiltIn::CullDistance: return "CullDistance";
+        case BuiltIn::VertexId: return "VertexId";
+        case BuiltIn::InstanceId: return "InstanceId";
+        case BuiltIn::PrimitiveId: return "PrimitiveId";
+        case BuiltIn::InvocationId: return "InvocationId";
+        case BuiltIn::Layer: return "Layer";
+        case BuiltIn::ViewportIndex: return "ViewportIndex";
+        case BuiltIn::TessLevelOuter: return "TessLevelOuter";
+        case BuiltIn::TessLevelInner: return "TessLevelInner";
+        case BuiltIn::TessCoord: return "TessCoord";
+        case BuiltIn::PatchVertices: return "PatchVertices";
+        case BuiltIn::FragCoord: return "FragCoord";
+        case BuiltIn::PointCoord: return "PointCoord";
+        case BuiltIn::FrontFacing: return "FrontFacing";
+        case BuiltIn::SampleId: return "SampleId";
+        case BuiltIn::SamplePosition: return "SamplePosition";
+        case BuiltIn::SampleMask: return "SampleMask";
+        case BuiltIn::FragDepth: return "FragDepth";
+        case BuiltIn::HelperInvocation: return "HelperInvocation";
+        case BuiltIn::NumWorkgroups: return "NumWorkgroups";
+        case BuiltIn::WorkgroupSize: return "WorkgroupSize";
+        case BuiltIn::WorkgroupId: return "WorkgroupId";
+        case BuiltIn::LocalInvocationId: return "LocalInvocationId";
+        case BuiltIn::GlobalInvocationId: return "GlobalInvocationId";
+        case BuiltIn::LocalInvocationIndex: return "LocalInvocationIndex";
+        case BuiltIn::WorkDim: return "WorkDim";
+        case BuiltIn::GlobalSize: return "GlobalSize";
+        case BuiltIn::EnqueuedWorkgroupSize: return "EnqueuedWorkgroupSize";
+        case BuiltIn::GlobalOffset: return "GlobalOffset";
+        case BuiltIn::GlobalLinearId: return "GlobalLinearId";
+        case BuiltIn::SubgroupSize: return "SubgroupSize";
+        case BuiltIn::SubgroupMaxSize: return "SubgroupMaxSize";
+        case BuiltIn::NumSubgroups: return "NumSubgroups";
+        case BuiltIn::NumEnqueuedSubgroups: return "NumEnqueuedSubgroups";
+        case BuiltIn::SubgroupId: return "SubgroupId";
+        case BuiltIn::SubgroupLocalInvocationId: return "SubgroupLocalInvocationId";
+        case BuiltIn::VertexIndex: return "VertexIndex";
+        case BuiltIn::InstanceIndex: return "InstanceIndex";
+        case BuiltIn::SubgroupEqMaskKHR: return "SubgroupEqMaskKHR";
+        case BuiltIn::SubgroupGeMaskKHR: return "SubgroupGeMaskKHR";
+        case BuiltIn::SubgroupGtMaskKHR: return "SubgroupGtMaskKHR";
+        case BuiltIn::SubgroupLeMaskKHR: return "SubgroupLeMaskKHR";
+        case BuiltIn::SubgroupLtMaskKHR: return "SubgroupLtMaskKHR";
+        case BuiltIn::BaseVertex: return "BaseVertex";
+        case BuiltIn::BaseInstance: return "BaseInstance";
+        case BuiltIn::DrawIndex: return "DrawIndex";
+        case BuiltIn::DeviceIndex: return "DeviceIndex";
+        case BuiltIn::ViewIndex: return "ViewIndex";
+        case BuiltIn::ViewportMaskNV: return "ViewportMaskNV";
+        case BuiltIn::SecondaryPositionNV: return "SecondaryPositionNV";
+        case BuiltIn::SecondaryViewportMaskNV: return "SecondaryViewportMaskNV";
+        case BuiltIn::PositionPerViewNV: return "PositionPerViewNV";
+        case BuiltIn::ViewportMaskPerViewNV: return "ViewportMaskPerViewNV";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* SelectionControlShiftToString(SelectionControlShift e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case SelectionControlShift::Flatten: return "Flatten";
+        case SelectionControlShift::DontFlatten: return "DontFlatten";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* SelectionControlMaskToString(SelectionControlMask e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case SelectionControlMask::MaskNone: return "None";
+        case SelectionControlMask::Flatten: return "Flatten";
+        case SelectionControlMask::DontFlatten: return "DontFlatten";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* LoopControlShiftToString(LoopControlShift e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case LoopControlShift::Unroll: return "Unroll";
+        case LoopControlShift::DontUnroll: return "DontUnroll";
+        case LoopControlShift::DependencyInfinite: return "DependencyInfinite";
+        case LoopControlShift::DependencyLength: return "DependencyLength";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* LoopControlMaskToString(LoopControlMask e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case LoopControlMask::MaskNone: return "None";
+        case LoopControlMask::Unroll: return "Unroll";
+        case LoopControlMask::DontUnroll: return "DontUnroll";
+        case LoopControlMask::DependencyInfinite: return "DependencyInfinite";
+        case LoopControlMask::DependencyLength: return "DependencyLength";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* FunctionControlShiftToString(FunctionControlShift e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case FunctionControlShift::Inline: return "Inline";
+        case FunctionControlShift::DontInline: return "DontInline";
+        case FunctionControlShift::Pure: return "Pure";
+        case FunctionControlShift::Const: return "Const";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* FunctionControlMaskToString(FunctionControlMask e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case FunctionControlMask::MaskNone: return "None";
+        case FunctionControlMask::Inline: return "Inline";
+        case FunctionControlMask::DontInline: return "DontInline";
+        case FunctionControlMask::Pure: return "Pure";
+        case FunctionControlMask::Const: return "Const";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* MemorySemanticsShiftToString(MemorySemanticsShift e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case MemorySemanticsShift::Acquire: return "Acquire";
+        case MemorySemanticsShift::Release: return "Release";
+        case MemorySemanticsShift::AcquireRelease: return "AcquireRelease";
+        case MemorySemanticsShift::SequentiallyConsistent: return "SequentiallyConsistent";
+        case MemorySemanticsShift::UniformMemory: return "UniformMemory";
+        case MemorySemanticsShift::SubgroupMemory: return "SubgroupMemory";
+        case MemorySemanticsShift::WorkgroupMemory: return "WorkgroupMemory";
+        case MemorySemanticsShift::CrossWorkgroupMemory: return "CrossWorkgroupMemory";
+        case MemorySemanticsShift::AtomicCounterMemory: return "AtomicCounterMemory";
+        case MemorySemanticsShift::ImageMemory: return "ImageMemory";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* MemorySemanticsMaskToString(MemorySemanticsMask e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case MemorySemanticsMask::MaskNone: return "None";
+        case MemorySemanticsMask::Acquire: return "Acquire";
+        case MemorySemanticsMask::Release: return "Release";
+        case MemorySemanticsMask::AcquireRelease: return "AcquireRelease";
+        case MemorySemanticsMask::SequentiallyConsistent: return "SequentiallyConsistent";
+        case MemorySemanticsMask::UniformMemory: return "UniformMemory";
+        case MemorySemanticsMask::SubgroupMemory: return "SubgroupMemory";
+        case MemorySemanticsMask::WorkgroupMemory: return "WorkgroupMemory";
+        case MemorySemanticsMask::CrossWorkgroupMemory: return "CrossWorkgroupMemory";
+        case MemorySemanticsMask::AtomicCounterMemory: return "AtomicCounterMemory";
+        case MemorySemanticsMask::ImageMemory: return "ImageMemory";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* MemoryAccessShiftToString(MemoryAccessShift e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case MemoryAccessShift::Volatile: return "Volatile";
+        case MemoryAccessShift::Aligned: return "Aligned";
+        case MemoryAccessShift::Nontemporal: return "Nontemporal";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* MemoryAccessMaskToString(MemoryAccessMask e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case MemoryAccessMask::MaskNone: return "None";
+        case MemoryAccessMask::Volatile: return "Volatile";
+        case MemoryAccessMask::Aligned: return "Aligned";
+        case MemoryAccessMask::Nontemporal: return "Nontemporal";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* ScopeToString(Scope e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case Scope::CrossDevice: return "CrossDevice";
+        case Scope::Device: return "Device";
+        case Scope::Workgroup: return "Workgroup";
+        case Scope::Subgroup: return "Subgroup";
+        case Scope::Invocation: return "Invocation";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* GroupOperationToString(GroupOperation e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case GroupOperation::Reduce: return "Reduce";
+        case GroupOperation::InclusiveScan: return "InclusiveScan";
+        case GroupOperation::ExclusiveScan: return "ExclusiveScan";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* KernelEnqueueFlagsToString(KernelEnqueueFlags e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case KernelEnqueueFlags::NoWait: return "NoWait";
+        case KernelEnqueueFlags::WaitKernel: return "WaitKernel";
+        case KernelEnqueueFlags::WaitWorkGroup: return "WaitWorkGroup";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* KernelProfilingInfoShiftToString(KernelProfilingInfoShift e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case KernelProfilingInfoShift::CmdExecTime: return "CmdExecTime";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* KernelProfilingInfoMaskToString(KernelProfilingInfoMask e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case KernelProfilingInfoMask::MaskNone: return "None";
+        case KernelProfilingInfoMask::CmdExecTime: return "CmdExecTime";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* CapabilityToString(Capability e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case Capability::Matrix: return "Matrix";
+        case Capability::Shader: return "Shader";
+        case Capability::Geometry: return "Geometry";
+        case Capability::Tessellation: return "Tessellation";
+        case Capability::Addresses: return "Addresses";
+        case Capability::Linkage: return "Linkage";
+        case Capability::Kernel: return "Kernel";
+        case Capability::Vector16: return "Vector16";
+        case Capability::Float16Buffer: return "Float16Buffer";
+        case Capability::Float16: return "Float16";
+        case Capability::Float64: return "Float64";
+        case Capability::Int64: return "Int64";
+        case Capability::Int64Atomics: return "Int64Atomics";
+        case Capability::ImageBasic: return "ImageBasic";
+        case Capability::ImageReadWrite: return "ImageReadWrite";
+        case Capability::ImageMipmap: return "ImageMipmap";
+        case Capability::Pipes: return "Pipes";
+        case Capability::Groups: return "Groups";
+        case Capability::DeviceEnqueue: return "DeviceEnqueue";
+        case Capability::LiteralSampler: return "LiteralSampler";
+        case Capability::AtomicStorage: return "AtomicStorage";
+        case Capability::Int16: return "Int16";
+        case Capability::TessellationPointSize: return "TessellationPointSize";
+        case Capability::GeometryPointSize: return "GeometryPointSize";
+        case Capability::ImageGatherExtended: return "ImageGatherExtended";
+        case Capability::StorageImageMultisample: return "StorageImageMultisample";
+        case Capability::UniformBufferArrayDynamicIndexing: return "UniformBufferArrayDynamicIndexing";
+        case Capability::SampledImageArrayDynamicIndexing: return "SampledImageArrayDynamicIndexing";
+        case Capability::StorageBufferArrayDynamicIndexing: return "StorageBufferArrayDynamicIndexing";
+        case Capability::StorageImageArrayDynamicIndexing: return "StorageImageArrayDynamicIndexing";
+        case Capability::ClipDistance: return "ClipDistance";
+        case Capability::CullDistance: return "CullDistance";
+        case Capability::ImageCubeArray: return "ImageCubeArray";
+        case Capability::SampleRateShading: return "SampleRateShading";
+        case Capability::ImageRect: return "ImageRect";
+        case Capability::SampledRect: return "SampledRect";
+        case Capability::GenericPointer: return "GenericPointer";
+        case Capability::Int8: return "Int8";
+        case Capability::InputAttachment: return "InputAttachment";
+        case Capability::SparseResidency: return "SparseResidency";
+        case Capability::MinLod: return "MinLod";
+        case Capability::Sampled1D: return "Sampled1D";
+        case Capability::Image1D: return "Image1D";
+        case Capability::SampledCubeArray: return "SampledCubeArray";
+        case Capability::SampledBuffer: return "SampledBuffer";
+        case Capability::ImageBuffer: return "ImageBuffer";
+        case Capability::ImageMSArray: return "ImageMSArray";
+        case Capability::StorageImageExtendedFormats: return "StorageImageExtendedFormats";
+        case Capability::ImageQuery: return "ImageQuery";
+        case Capability::DerivativeControl: return "DerivativeControl";
+        case Capability::InterpolationFunction: return "InterpolationFunction";
+        case Capability::TransformFeedback: return "TransformFeedback";
+        case Capability::GeometryStreams: return "GeometryStreams";
+        case Capability::StorageImageReadWithoutFormat: return "StorageImageReadWithoutFormat";
+        case Capability::StorageImageWriteWithoutFormat: return "StorageImageWriteWithoutFormat";
+        case Capability::MultiViewport: return "MultiViewport";
+        case Capability::SubgroupDispatch: return "SubgroupDispatch";
+        case Capability::NamedBarrier: return "NamedBarrier";
+        case Capability::PipeStorage: return "PipeStorage";
+        case Capability::SubgroupBallotKHR: return "SubgroupBallotKHR";
+        case Capability::DrawParameters: return "DrawParameters";
+        case Capability::SubgroupVoteKHR: return "SubgroupVoteKHR";
+        case Capability::StorageBuffer16BitAccess: return "StorageBuffer16BitAccess";
+        //case Capability::StorageUniformBufferBlock16: return "StorageUniformBufferBlock16";
+        case Capability::StorageUniform16: return "StorageUniform16";
+        //case Capability::UniformAndStorageBuffer16BitAccess: return "UniformAndStorageBuffer16BitAccess";
+        case Capability::StoragePushConstant16: return "StoragePushConstant16";
+        case Capability::StorageInputOutput16: return "StorageInputOutput16";
+        case Capability::DeviceGroup: return "DeviceGroup";
+        case Capability::MultiView: return "MultiView";
+        case Capability::VariablePointersStorageBuffer: return "VariablePointersStorageBuffer";
+        case Capability::VariablePointers: return "VariablePointers";
+        case Capability::SampleMaskOverrideCoverageNV: return "SampleMaskOverrideCoverageNV";
+        case Capability::GeometryShaderPassthroughNV: return "GeometryShaderPassthroughNV";
+        case Capability::ShaderViewportIndexLayerNV: return "ShaderViewportIndexLayerNV";
+        case Capability::ShaderViewportMaskNV: return "ShaderViewportMaskNV";
+        case Capability::ShaderStereoViewNV: return "ShaderStereoViewNV";
+        case Capability::PerViewAttributesNV: return "PerViewAttributesNV";
+        default: return "";
+    }
+}
+#endif
+
+SPIRV_DEF const char* OpToString(Op e)
+#ifndef SPIRV_STRINGS_IMPLEMENT
+;
+#else
+{
+    switch(e)
+    {
+        case Op::OpNop: return "OpNop";
+        case Op::OpUndef: return "OpUndef";
+        case Op::OpSourceContinued: return "OpSourceContinued";
+        case Op::OpSource: return "OpSource";
+        case Op::OpSourceExtension: return "OpSourceExtension";
+        case Op::OpName: return "OpName";
+        case Op::OpMemberName: return "OpMemberName";
+        case Op::OpString: return "OpString";
+        case Op::OpLine: return "OpLine";
+        case Op::OpExtension: return "OpExtension";
+        case Op::OpExtInstImport: return "OpExtInstImport";
+        case Op::OpExtInst: return "OpExtInst";
+        case Op::OpMemoryModel: return "OpMemoryModel";
+        case Op::OpEntryPoint: return "OpEntryPoint";
+        case Op::OpExecutionMode: return "OpExecutionMode";
+        case Op::OpCapability: return "OpCapability";
+        case Op::OpTypeVoid: return "OpTypeVoid";
+        case Op::OpTypeBool: return "OpTypeBool";
+        case Op::OpTypeInt: return "OpTypeInt";
+        case Op::OpTypeFloat: return "OpTypeFloat";
+        case Op::OpTypeVector: return "OpTypeVector";
+        case Op::OpTypeMatrix: return "OpTypeMatrix";
+        case Op::OpTypeImage: return "OpTypeImage";
+        case Op::OpTypeSampler: return "OpTypeSampler";
+        case Op::OpTypeSampledImage: return "OpTypeSampledImage";
+        case Op::OpTypeArray: return "OpTypeArray";
+        case Op::OpTypeRuntimeArray: return "OpTypeRuntimeArray";
+        case Op::OpTypeStruct: return "OpTypeStruct";
+        case Op::OpTypeOpaque: return "OpTypeOpaque";
+        case Op::OpTypePointer: return "OpTypePointer";
+        case Op::OpTypeFunction: return "OpTypeFunction";
+        case Op::OpTypeEvent: return "OpTypeEvent";
+        case Op::OpTypeDeviceEvent: return "OpTypeDeviceEvent";
+        case Op::OpTypeReserveId: return "OpTypeReserveId";
+        case Op::OpTypeQueue: return "OpTypeQueue";
+        case Op::OpTypePipe: return "OpTypePipe";
+        case Op::OpTypeForwardPointer: return "OpTypeForwardPointer";
+        case Op::OpConstantTrue: return "OpConstantTrue";
+        case Op::OpConstantFalse: return "OpConstantFalse";
+        case Op::OpConstant: return "OpConstant";
+        case Op::OpConstantComposite: return "OpConstantComposite";
+        case Op::OpConstantSampler: return "OpConstantSampler";
+        case Op::OpConstantNull: return "OpConstantNull";
+        case Op::OpSpecConstantTrue: return "OpSpecConstantTrue";
+        case Op::OpSpecConstantFalse: return "OpSpecConstantFalse";
+        case Op::OpSpecConstant: return "OpSpecConstant";
+        case Op::OpSpecConstantComposite: return "OpSpecConstantComposite";
+        case Op::OpSpecConstantOp: return "OpSpecConstantOp";
+        case Op::OpFunction: return "OpFunction";
+        case Op::OpFunctionParameter: return "OpFunctionParameter";
+        case Op::OpFunctionEnd: return "OpFunctionEnd";
+        case Op::OpFunctionCall: return "OpFunctionCall";
+        case Op::OpVariable: return "OpVariable";
+        case Op::OpImageTexelPointer: return "OpImageTexelPointer";
+        case Op::OpLoad: return "OpLoad";
+        case Op::OpStore: return "OpStore";
+        case Op::OpCopyMemory: return "OpCopyMemory";
+        case Op::OpCopyMemorySized: return "OpCopyMemorySized";
+        case Op::OpAccessChain: return "OpAccessChain";
+        case Op::OpInBoundsAccessChain: return "OpInBoundsAccessChain";
+        case Op::OpPtrAccessChain: return "OpPtrAccessChain";
+        case Op::OpArrayLength: return "OpArrayLength";
+        case Op::OpGenericPtrMemSemantics: return "OpGenericPtrMemSemantics";
+        case Op::OpInBoundsPtrAccessChain: return "OpInBoundsPtrAccessChain";
+        case Op::OpDecorate: return "OpDecorate";
+        case Op::OpMemberDecorate: return "OpMemberDecorate";
+        case Op::OpDecorationGroup: return "OpDecorationGroup";
+        case Op::OpGroupDecorate: return "OpGroupDecorate";
+        case Op::OpGroupMemberDecorate: return "OpGroupMemberDecorate";
+        case Op::OpVectorExtractDynamic: return "OpVectorExtractDynamic";
+        case Op::OpVectorInsertDynamic: return "OpVectorInsertDynamic";
+        case Op::OpVectorShuffle: return "OpVectorShuffle";
+        case Op::OpCompositeConstruct: return "OpCompositeConstruct";
+        case Op::OpCompositeExtract: return "OpCompositeExtract";
+        case Op::OpCompositeInsert: return "OpCompositeInsert";
+        case Op::OpCopyObject: return "OpCopyObject";
+        case Op::OpTranspose: return "OpTranspose";
+        case Op::OpSampledImage: return "OpSampledImage";
+        case Op::OpImageSampleImplicitLod: return "OpImageSampleImplicitLod";
+        case Op::OpImageSampleExplicitLod: return "OpImageSampleExplicitLod";
+        case Op::OpImageSampleDrefImplicitLod: return "OpImageSampleDrefImplicitLod";
+        case Op::OpImageSampleDrefExplicitLod: return "OpImageSampleDrefExplicitLod";
+        case Op::OpImageSampleProjImplicitLod: return "OpImageSampleProjImplicitLod";
+        case Op::OpImageSampleProjExplicitLod: return "OpImageSampleProjExplicitLod";
+        case Op::OpImageSampleProjDrefImplicitLod: return "OpImageSampleProjDrefImplicitLod";
+        case Op::OpImageSampleProjDrefExplicitLod: return "OpImageSampleProjDrefExplicitLod";
+        case Op::OpImageFetch: return "OpImageFetch";
+        case Op::OpImageGather: return "OpImageGather";
+        case Op::OpImageDrefGather: return "OpImageDrefGather";
+        case Op::OpImageRead: return "OpImageRead";
+        case Op::OpImageWrite: return "OpImageWrite";
+        case Op::OpImage: return "OpImage";
+        case Op::OpImageQueryFormat: return "OpImageQueryFormat";
+        case Op::OpImageQueryOrder: return "OpImageQueryOrder";
+        case Op::OpImageQuerySizeLod: return "OpImageQuerySizeLod";
+        case Op::OpImageQuerySize: return "OpImageQuerySize";
+        case Op::OpImageQueryLod: return "OpImageQueryLod";
+        case Op::OpImageQueryLevels: return "OpImageQueryLevels";
+        case Op::OpImageQuerySamples: return "OpImageQuerySamples";
+        case Op::OpConvertFToU: return "OpConvertFToU";
+        case Op::OpConvertFToS: return "OpConvertFToS";
+        case Op::OpConvertSToF: return "OpConvertSToF";
+        case Op::OpConvertUToF: return "OpConvertUToF";
+        case Op::OpUConvert: return "OpUConvert";
+        case Op::OpSConvert: return "OpSConvert";
+        case Op::OpFConvert: return "OpFConvert";
+        case Op::OpQuantizeToF16: return "OpQuantizeToF16";
+        case Op::OpConvertPtrToU: return "OpConvertPtrToU";
+        case Op::OpSatConvertSToU: return "OpSatConvertSToU";
+        case Op::OpSatConvertUToS: return "OpSatConvertUToS";
+        case Op::OpConvertUToPtr: return "OpConvertUToPtr";
+        case Op::OpPtrCastToGeneric: return "OpPtrCastToGeneric";
+        case Op::OpGenericCastToPtr: return "OpGenericCastToPtr";
+        case Op::OpGenericCastToPtrExplicit: return "OpGenericCastToPtrExplicit";
+        case Op::OpBitcast: return "OpBitcast";
+        case Op::OpSNegate: return "OpSNegate";
+        case Op::OpFNegate: return "OpFNegate";
+        case Op::OpIAdd: return "OpIAdd";
+        case Op::OpFAdd: return "OpFAdd";
+        case Op::OpISub: return "OpISub";
+        case Op::OpFSub: return "OpFSub";
+        case Op::OpIMul: return "OpIMul";
+        case Op::OpFMul: return "OpFMul";
+        case Op::OpUDiv: return "OpUDiv";
+        case Op::OpSDiv: return "OpSDiv";
+        case Op::OpFDiv: return "OpFDiv";
+        case Op::OpUMod: return "OpUMod";
+        case Op::OpSRem: return "OpSRem";
+        case Op::OpSMod: return "OpSMod";
+        case Op::OpFRem: return "OpFRem";
+        case Op::OpFMod: return "OpFMod";
+        case Op::OpVectorTimesScalar: return "OpVectorTimesScalar";
+        case Op::OpMatrixTimesScalar: return "OpMatrixTimesScalar";
+        case Op::OpVectorTimesMatrix: return "OpVectorTimesMatrix";
+        case Op::OpMatrixTimesVector: return "OpMatrixTimesVector";
+        case Op::OpMatrixTimesMatrix: return "OpMatrixTimesMatrix";
+        case Op::OpOuterProduct: return "OpOuterProduct";
+        case Op::OpDot: return "OpDot";
+        case Op::OpIAddCarry: return "OpIAddCarry";
+        case Op::OpISubBorrow: return "OpISubBorrow";
+        case Op::OpUMulExtended: return "OpUMulExtended";
+        case Op::OpSMulExtended: return "OpSMulExtended";
+        case Op::OpAny: return "OpAny";
+        case Op::OpAll: return "OpAll";
+        case Op::OpIsNan: return "OpIsNan";
+        case Op::OpIsInf: return "OpIsInf";
+        case Op::OpIsFinite: return "OpIsFinite";
+        case Op::OpIsNormal: return "OpIsNormal";
+        case Op::OpSignBitSet: return "OpSignBitSet";
+        case Op::OpLessOrGreater: return "OpLessOrGreater";
+        case Op::OpOrdered: return "OpOrdered";
+        case Op::OpUnordered: return "OpUnordered";
+        case Op::OpLogicalEqual: return "OpLogicalEqual";
+        case Op::OpLogicalNotEqual: return "OpLogicalNotEqual";
+        case Op::OpLogicalOr: return "OpLogicalOr";
+        case Op::OpLogicalAnd: return "OpLogicalAnd";
+        case Op::OpLogicalNot: return "OpLogicalNot";
+        case Op::OpSelect: return "OpSelect";
+        case Op::OpIEqual: return "OpIEqual";
+        case Op::OpINotEqual: return "OpINotEqual";
+        case Op::OpUGreaterThan: return "OpUGreaterThan";
+        case Op::OpSGreaterThan: return "OpSGreaterThan";
+        case Op::OpUGreaterThanEqual: return "OpUGreaterThanEqual";
+        case Op::OpSGreaterThanEqual: return "OpSGreaterThanEqual";
+        case Op::OpULessThan: return "OpULessThan";
+        case Op::OpSLessThan: return "OpSLessThan";
+        case Op::OpULessThanEqual: return "OpULessThanEqual";
+        case Op::OpSLessThanEqual: return "OpSLessThanEqual";
+        case Op::OpFOrdEqual: return "OpFOrdEqual";
+        case Op::OpFUnordEqual: return "OpFUnordEqual";
+        case Op::OpFOrdNotEqual: return "OpFOrdNotEqual";
+        case Op::OpFUnordNotEqual: return "OpFUnordNotEqual";
+        case Op::OpFOrdLessThan: return "OpFOrdLessThan";
+        case Op::OpFUnordLessThan: return "OpFUnordLessThan";
+        case Op::OpFOrdGreaterThan: return "OpFOrdGreaterThan";
+        case Op::OpFUnordGreaterThan: return "OpFUnordGreaterThan";
+        case Op::OpFOrdLessThanEqual: return "OpFOrdLessThanEqual";
+        case Op::OpFUnordLessThanEqual: return "OpFUnordLessThanEqual";
+        case Op::OpFOrdGreaterThanEqual: return "OpFOrdGreaterThanEqual";
+        case Op::OpFUnordGreaterThanEqual: return "OpFUnordGreaterThanEqual";
+        case Op::OpShiftRightLogical: return "OpShiftRightLogical";
+        case Op::OpShiftRightArithmetic: return "OpShiftRightArithmetic";
+        case Op::OpShiftLeftLogical: return "OpShiftLeftLogical";
+        case Op::OpBitwiseOr: return "OpBitwiseOr";
+        case Op::OpBitwiseXor: return "OpBitwiseXor";
+        case Op::OpBitwiseAnd: return "OpBitwiseAnd";
+        case Op::OpNot: return "OpNot";
+        case Op::OpBitFieldInsert: return "OpBitFieldInsert";
+        case Op::OpBitFieldSExtract: return "OpBitFieldSExtract";
+        case Op::OpBitFieldUExtract: return "OpBitFieldUExtract";
+        case Op::OpBitReverse: return "OpBitReverse";
+        case Op::OpBitCount: return "OpBitCount";
+        case Op::OpDPdx: return "OpDPdx";
+        case Op::OpDPdy: return "OpDPdy";
+        case Op::OpFwidth: return "OpFwidth";
+        case Op::OpDPdxFine: return "OpDPdxFine";
+        case Op::OpDPdyFine: return "OpDPdyFine";
+        case Op::OpFwidthFine: return "OpFwidthFine";
+        case Op::OpDPdxCoarse: return "OpDPdxCoarse";
+        case Op::OpDPdyCoarse: return "OpDPdyCoarse";
+        case Op::OpFwidthCoarse: return "OpFwidthCoarse";
+        case Op::OpEmitVertex: return "OpEmitVertex";
+        case Op::OpEndPrimitive: return "OpEndPrimitive";
+        case Op::OpEmitStreamVertex: return "OpEmitStreamVertex";
+        case Op::OpEndStreamPrimitive: return "OpEndStreamPrimitive";
+        case Op::OpControlBarrier: return "OpControlBarrier";
+        case Op::OpMemoryBarrier: return "OpMemoryBarrier";
+        case Op::OpAtomicLoad: return "OpAtomicLoad";
+        case Op::OpAtomicStore: return "OpAtomicStore";
+        case Op::OpAtomicExchange: return "OpAtomicExchange";
+        case Op::OpAtomicCompareExchange: return "OpAtomicCompareExchange";
+        case Op::OpAtomicCompareExchangeWeak: return "OpAtomicCompareExchangeWeak";
+        case Op::OpAtomicIIncrement: return "OpAtomicIIncrement";
+        case Op::OpAtomicIDecrement: return "OpAtomicIDecrement";
+        case Op::OpAtomicIAdd: return "OpAtomicIAdd";
+        case Op::OpAtomicISub: return "OpAtomicISub";
+        case Op::OpAtomicSMin: return "OpAtomicSMin";
+        case Op::OpAtomicUMin: return "OpAtomicUMin";
+        case Op::OpAtomicSMax: return "OpAtomicSMax";
+        case Op::OpAtomicUMax: return "OpAtomicUMax";
+        case Op::OpAtomicAnd: return "OpAtomicAnd";
+        case Op::OpAtomicOr: return "OpAtomicOr";
+        case Op::OpAtomicXor: return "OpAtomicXor";
+        case Op::OpPhi: return "OpPhi";
+        case Op::OpLoopMerge: return "OpLoopMerge";
+        case Op::OpSelectionMerge: return "OpSelectionMerge";
+        case Op::OpLabel: return "OpLabel";
+        case Op::OpBranch: return "OpBranch";
+        case Op::OpBranchConditional: return "OpBranchConditional";
+        case Op::OpSwitch: return "OpSwitch";
+        case Op::OpKill: return "OpKill";
+        case Op::OpReturn: return "OpReturn";
+        case Op::OpReturnValue: return "OpReturnValue";
+        case Op::OpUnreachable: return "OpUnreachable";
+        case Op::OpLifetimeStart: return "OpLifetimeStart";
+        case Op::OpLifetimeStop: return "OpLifetimeStop";
+        case Op::OpGroupAsyncCopy: return "OpGroupAsyncCopy";
+        case Op::OpGroupWaitEvents: return "OpGroupWaitEvents";
+        case Op::OpGroupAll: return "OpGroupAll";
+        case Op::OpGroupAny: return "OpGroupAny";
+        case Op::OpGroupBroadcast: return "OpGroupBroadcast";
+        case Op::OpGroupIAdd: return "OpGroupIAdd";
+        case Op::OpGroupFAdd: return "OpGroupFAdd";
+        case Op::OpGroupFMin: return "OpGroupFMin";
+        case Op::OpGroupUMin: return "OpGroupUMin";
+        case Op::OpGroupSMin: return "OpGroupSMin";
+        case Op::OpGroupFMax: return "OpGroupFMax";
+        case Op::OpGroupUMax: return "OpGroupUMax";
+        case Op::OpGroupSMax: return "OpGroupSMax";
+        case Op::OpReadPipe: return "OpReadPipe";
+        case Op::OpWritePipe: return "OpWritePipe";
+        case Op::OpReservedReadPipe: return "OpReservedReadPipe";
+        case Op::OpReservedWritePipe: return "OpReservedWritePipe";
+        case Op::OpReserveReadPipePackets: return "OpReserveReadPipePackets";
+        case Op::OpReserveWritePipePackets: return "OpReserveWritePipePackets";
+        case Op::OpCommitReadPipe: return "OpCommitReadPipe";
+        case Op::OpCommitWritePipe: return "OpCommitWritePipe";
+        case Op::OpIsValidReserveId: return "OpIsValidReserveId";
+        case Op::OpGetNumPipePackets: return "OpGetNumPipePackets";
+        case Op::OpGetMaxPipePackets: return "OpGetMaxPipePackets";
+        case Op::OpGroupReserveReadPipePackets: return "OpGroupReserveReadPipePackets";
+        case Op::OpGroupReserveWritePipePackets: return "OpGroupReserveWritePipePackets";
+        case Op::OpGroupCommitReadPipe: return "OpGroupCommitReadPipe";
+        case Op::OpGroupCommitWritePipe: return "OpGroupCommitWritePipe";
+        case Op::OpEnqueueMarker: return "OpEnqueueMarker";
+        case Op::OpEnqueueKernel: return "OpEnqueueKernel";
+        case Op::OpGetKernelNDrangeSubGroupCount: return "OpGetKernelNDrangeSubGroupCount";
+        case Op::OpGetKernelNDrangeMaxSubGroupSize: return "OpGetKernelNDrangeMaxSubGroupSize";
+        case Op::OpGetKernelWorkGroupSize: return "OpGetKernelWorkGroupSize";
+        case Op::OpGetKernelPreferredWorkGroupSizeMultiple: return "OpGetKernelPreferredWorkGroupSizeMultiple";
+        case Op::OpRetainEvent: return "OpRetainEvent";
+        case Op::OpReleaseEvent: return "OpReleaseEvent";
+        case Op::OpCreateUserEvent: return "OpCreateUserEvent";
+        case Op::OpIsValidEvent: return "OpIsValidEvent";
+        case Op::OpSetUserEventStatus: return "OpSetUserEventStatus";
+        case Op::OpCaptureEventProfilingInfo: return "OpCaptureEventProfilingInfo";
+        case Op::OpGetDefaultQueue: return "OpGetDefaultQueue";
+        case Op::OpBuildNDRange: return "OpBuildNDRange";
+        case Op::OpImageSparseSampleImplicitLod: return "OpImageSparseSampleImplicitLod";
+        case Op::OpImageSparseSampleExplicitLod: return "OpImageSparseSampleExplicitLod";
+        case Op::OpImageSparseSampleDrefImplicitLod: return "OpImageSparseSampleDrefImplicitLod";
+        case Op::OpImageSparseSampleDrefExplicitLod: return "OpImageSparseSampleDrefExplicitLod";
+        case Op::OpImageSparseSampleProjImplicitLod: return "OpImageSparseSampleProjImplicitLod";
+        case Op::OpImageSparseSampleProjExplicitLod: return "OpImageSparseSampleProjExplicitLod";
+        case Op::OpImageSparseSampleProjDrefImplicitLod: return "OpImageSparseSampleProjDrefImplicitLod";
+        case Op::OpImageSparseSampleProjDrefExplicitLod: return "OpImageSparseSampleProjDrefExplicitLod";
+        case Op::OpImageSparseFetch: return "OpImageSparseFetch";
+        case Op::OpImageSparseGather: return "OpImageSparseGather";
+        case Op::OpImageSparseDrefGather: return "OpImageSparseDrefGather";
+        case Op::OpImageSparseTexelsResident: return "OpImageSparseTexelsResident";
+        case Op::OpNoLine: return "OpNoLine";
+        case Op::OpAtomicFlagTestAndSet: return "OpAtomicFlagTestAndSet";
+        case Op::OpAtomicFlagClear: return "OpAtomicFlagClear";
+        case Op::OpImageSparseRead: return "OpImageSparseRead";
+        case Op::OpSizeOf: return "OpSizeOf";
+        case Op::OpTypePipeStorage: return "OpTypePipeStorage";
+        case Op::OpConstantPipeStorage: return "OpConstantPipeStorage";
+        case Op::OpCreatePipeFromPipeStorage: return "OpCreatePipeFromPipeStorage";
+        case Op::OpGetKernelLocalSizeForSubgroupCount: return "OpGetKernelLocalSizeForSubgroupCount";
+        case Op::OpGetKernelMaxNumSubgroups: return "OpGetKernelMaxNumSubgroups";
+        case Op::OpTypeNamedBarrier: return "OpTypeNamedBarrier";
+        case Op::OpNamedBarrierInitialize: return "OpNamedBarrierInitialize";
+        case Op::OpMemoryNamedBarrier: return "OpMemoryNamedBarrier";
+        case Op::OpModuleProcessed: return "OpModuleProcessed";
+        case Op::OpExecutionModeId: return "OpExecutionModeId";
+        case Op::OpDecorateId: return "OpDecorateId";
+        case Op::OpSubgroupBallotKHR: return "OpSubgroupBallotKHR";
+        case Op::OpSubgroupFirstInvocationKHR: return "OpSubgroupFirstInvocationKHR";
+        case Op::OpSubgroupAllKHR: return "OpSubgroupAllKHR";
+        case Op::OpSubgroupAnyKHR: return "OpSubgroupAnyKHR";
+        case Op::OpSubgroupAllEqualKHR: return "OpSubgroupAllEqualKHR";
+        case Op::OpSubgroupReadInvocationKHR: return "OpSubgroupReadInvocationKHR";
+        default: return "";
+    }
+}
+#endif
+
+}  // end namespace spv
+
+#endif  // #ifndef spirv_strings_HPP
+


### PR DESCRIPTION
I created three new header files with `...ToString` functions for all SPIRV/1.2 enums:
`spirv_strings.h`, `spirv_strings.hpp`, and `spirv_strings.hpp11`.

They can be used like this in C++11:
```cpp
// Defines the function implementations
// (similar to https://github.com/nothings/stb/blob/master/stb_image.h)
#define SPIRV_STRINGS_IMPLEMENT
#include <spirv/1.2/spirv_strings.hpp11>

/* ... */

const char* s1 = spv::OpToString(spv::Op::OpName); // returns "OpName"
const char* s2 =  spv::SourceLanguageToString(spv::SourceLanguage::GLSL); // returns "GLSL"
```

Or like this in C:
```c
#define SPIRV_STRINGS_IMPLEMENT
#include <spirv/1.2/spirv_strings.h>

/* ... */

const char* s1 = SpvOpToString(SpvOpName); // returns "OpName"
const char* s2 =  SpvSourceLanguageToString(SpvSourceLanguageGLSL); // returns "GLSL"
```

I needed this for a custom disassembler and SPIRV debugging functionality.