### PR TITLE
reserve SPIR-V enum block for upcoming Intel extension

### DIFF
--- a/include/spirv/spir-v.xml
+++ b/include/spirv/spir-v.xml
@@ -99,14 +99,15 @@
     <ids type="opcode" start="4992" end="5247" vendor="AMD"/>
     <ids type="opcode" start="5248" end="5503" vendor="NVIDIA"/>
     <ids type="opcode" start="5504" end="5567" vendor="Imagination"/>
+    <ids type="opcode" start="5568" end="5631" vendor="Intel" comment="Contact ben.ashbaugh@intel.com"/>
     <!-- Opcodes & enumerants reservable for future use. To get a block, allocate
          multiples of 64 starting at the lowest available point in this
          block and add a corresponding <ids> tag immediately above. Make
          sure to fill in the vendor attribute, and preferably add a contact
          person/address in a comment attribute. -->
 
-    <!-- Example new block: <ids type="opcode" start="5504" end="5504+64n-1" vendor="Add vendor" comment="Contact TBD"/> -->
+    <!-- Example new block: <ids type="opcode" start="XXXX" end="XXXX+64n-1" vendor="Add vendor" comment="Contact TBD"/> -->
 
-    <ids type="opcode" start="5504" end="4294967295" comment="Opcode range reservable for future use by vendors"/>
+    <ids type="opcode" start="5632" end="4294967295" comment="Opcode range reservable for future use by vendors"/>
 
 </registry>


### PR DESCRIPTION
Please reserve a block of 64 SPIR-V enums for an upcoming Intel extension.  Thanks!