### PR TITLE
cmake: support default install target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,10 +42,19 @@ project(SPIRV-Headers)
 # directory.  To install the headers:
 #   1. mkdir build ; cd build
 #   2. cmake ..
-#   3. cmake --build . install-headers
+#   3. cmake --build . --target install
 
-file(GLOB_RECURSE FILES include/spirv/*)
+file(GLOB_RECURSE HEADER_FILES
+    RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
+    include/spirv/*)
+foreach(HEADER_FILE ${HEADER_FILES})
+    get_filename_component(HEADER_INSTALL_DIR ${HEADER_FILE} PATH)
+    install(FILES ${HEADER_FILE} DESTINATION ${HEADER_INSTALL_DIR})
+endforeach()
+
+# legacy
 add_custom_target(install-headers
-  COMMAND cmake -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/include/spirv ${CMAKE_INSTALL_PREFIX}/include/spirv)
+    COMMAND cmake -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/include/spirv
+        ${CMAKE_INSTALL_PREFIX}/include/spirv)
 
 add_subdirectory(example)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@
 # The SPIR-V headers from the SPIR-V Registry
 # https://www.khronos.org/registry/spir-v/
 #
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.11)
 project(SPIRV-Headers)
 
 # There are two ways to use this project.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,6 @@ endforeach()
 # legacy
 add_custom_target(install-headers
     COMMAND cmake -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/include/spirv
-        ${CMAKE_INSTALL_PREFIX}/include/spirv)
+        $ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/include/spirv)
 
 add_subdirectory(example)

--- a/README.md
+++ b/README.md
@@ -42,10 +42,7 @@ tracker](https://github.com/KhronosGroup/SPIRV-Headers/issues).
 mkdir build
 cd build
 cmake ..
-# Linux
-cmake --build . --target install-headers
-# Windows
-cmake --build . --config Debug --target install-headers
+cmake --build . --target install
 ```
 
 Then, for example, you will have `/usr/local/include/spirv/1.0/spirv.h`


### PR DESCRIPTION
Allow the common install target to support the installation of header files (rather then having a custom target). Developers should be able to invoke the install target as follows:

    cmake --build . --target install

This change leaves the original custom target to install headers for legacy support.

# testing

Tested the changed with: CMake 2.8.0 (Linux; with example commented out; see b8d95fb37e1b1d4fd61af907be057ad469d262e5), 2.8.12 (Linux), 3.8.0 (Linux), 3.9.3 (Windows)

Each version results in the same outputs for either the `install` or `install-headers` targets; validation via:
```
cmakeVer=$($CMAKE --version | awk '{print $3; exit}')
buildDir=build-$cmakeVer
mkdir -p $buildDir &&
    pushd $buildDir >/dev/null &&
    $CMAKE .. -DCMAKE_INSTALL_PREFIX=out-new &&
    $CMAKE --build . --target install &&
    $CMAKE .. -DCMAKE_INSTALL_PREFIX=out-old &&
    $CMAKE --build . --target install-headers &&
    diff out-new/ out-old/ &&
    echo "same for $cmakeVer" &&
    popd >/dev/null
```