### PR TITLE
Register the VKD3D Shader Compiler

### DIFF
--- a/include/spirv/spir-v.xml
+++ b/include/spirv/spir-v.xml
@@ -67,7 +67,8 @@
         <id value="15"  vendor="Google" tool="rspirv" comment="Contact Lei Zhang, antiagainst@gmail.com"/>
         <id value="16"  vendor="X-LEGEND"   tool="Mesa-IR/SPIR-V Translator" comment="Contact Metora Wang, github:metora/MesaGLSLCompiler"/>
         <id value="17"  vendor="Khronos" tool="SPIR-V Tools Linker" comment="Contact David Neto, dneto@google.com"/>
-        <unused start="18" end="0xFFFF" comment="Tool ID range reservable for future use by vendors"/>
+        <id value="18"  vendor="Wine" tool="VKD3D Shader Compiler" comment="Contact wine-devel@winehq.org"/>
+        <unused start="19" end="0xFFFF" comment="Tool ID range reservable for future use by vendors"/>
     </ids>
 
     <!-- SECTION: SPIR-V Opcodes and Enumerants -->


### PR DESCRIPTION
We are developing a Direct3D shader bytecode to SPIR-V translator as a part of our D3D12 to Vulkan translation library - [VKD3D](https://source.winehq.org/git/vkd3d.git/).