### PR TITLE
Allow SubgroupSize and SubgroupLocalInvocationId with SubgroupBallotKHR

### DIFF
--- a/include/spirv/1.0/spirv.core.grammar.json
+++ b/include/spirv/1.0/spirv.core.grammar.json
@@ -5005,7 +5005,7 @@
         {
           "enumerant" : "SubgroupSize",
           "value" : 36,
-          "capabilities" : [ "Kernel" ]
+          "capabilities" : [ "Kernel", "SubgroupBallotKHR" ]
         },
         {
           "enumerant" : "SubgroupMaxSize",
@@ -5030,7 +5030,7 @@
         {
           "enumerant" : "SubgroupLocalInvocationId",
           "value" : 41,
-          "capabilities" : [ "Kernel" ]
+          "capabilities" : [ "Kernel", "SubgroupBallotKHR" ]
         },
         {
           "enumerant" : "VertexIndex",

--- a/include/spirv/1.1/spirv.core.grammar.json
+++ b/include/spirv/1.1/spirv.core.grammar.json
@@ -5153,7 +5153,7 @@
         {
           "enumerant" : "SubgroupSize",
           "value" : 36,
-          "capabilities" : [ "Kernel" ]
+          "capabilities" : [ "Kernel", "SubgroupBallotKHR" ]
         },
         {
           "enumerant" : "SubgroupMaxSize",
@@ -5178,7 +5178,7 @@
         {
           "enumerant" : "SubgroupLocalInvocationId",
           "value" : 41,
-          "capabilities" : [ "Kernel" ]
+          "capabilities" : [ "Kernel", "SubgroupBallotKHR" ]
         },
         {
           "enumerant" : "VertexIndex",

--- a/include/spirv/1.2/spirv.core.grammar.json
+++ b/include/spirv/1.2/spirv.core.grammar.json
@@ -5210,7 +5210,7 @@
         {
           "enumerant" : "SubgroupSize",
           "value" : 36,
-          "capabilities" : [ "Kernel" ]
+          "capabilities" : [ "Kernel", "SubgroupBallotKHR" ]
         },
         {
           "enumerant" : "SubgroupMaxSize",
@@ -5235,7 +5235,7 @@
         {
           "enumerant" : "SubgroupLocalInvocationId",
           "value" : 41,
-          "capabilities" : [ "Kernel" ]
+          "capabilities" : [ "Kernel", "SubgroupBallotKHR" ]
         },
         {
           "enumerant" : "VertexIndex",

--- a/include/spirv/unified1/spirv.core.grammar.json
+++ b/include/spirv/unified1/spirv.core.grammar.json
@@ -5229,7 +5229,7 @@
         {
           "enumerant" : "SubgroupSize",
           "value" : 36,
-          "capabilities" : [ "Kernel" ]
+          "capabilities" : [ "Kernel", "SubgroupBallotKHR" ]
         },
         {
           "enumerant" : "SubgroupMaxSize",
@@ -5254,7 +5254,7 @@
         {
           "enumerant" : "SubgroupLocalInvocationId",
           "value" : 41,
-          "capabilities" : [ "Kernel" ]
+          "capabilities" : [ "Kernel", "SubgroupBallotKHR" ]
         },
         {
           "enumerant" : "VertexIndex",


### PR DESCRIPTION
As specified in https://www.khronos.org/registry/spir-v/extensions/KHR/SPV_KHR_shader_ballot.html:

```
 (Add the SubgroupBallotKHR capability to SubgroupSize.)
 (Add the SubgroupBallotKHR capability to SubgroupLocalInvocationId.)
```