### PR TITLE
Fix Google extension grammar error and backport 

### DIFF
--- a/include/spirv/1.0/spirv.core.grammar.json
+++ b/include/spirv/1.0/spirv.core.grammar.json
@@ -3013,6 +3013,15 @@
       "capabilities" : [ "SparseResidency" ]
     },
     {
+      "opname" : "OpDecorateId",
+      "opcode" : 332,
+      "operands" : [
+        { "kind" : "IdRef", "name" : "'Target'" },
+        { "kind" : "Decoration" }
+      ],
+      "extensions" : [ "SPV_GOOGLE_hlsl_functionality1" ]
+    },
+    {
       "opname" : "OpSubgroupBallotKHR",
       "opcode" : 4421,
       "operands" : [
@@ -3277,6 +3286,25 @@
         { "kind" : "IdRef", "name" : "'Data'" }
       ],
       "capabilities" : [ "SubgroupImageBlockIOINTEL" ]
+    },
+    {
+      "opname" : "OpDecorateStringGOOGLE",
+      "opcode" : 5632,
+      "operands" : [
+        { "kind" : "IdRef",         "name" : "'Target'" },
+        { "kind" : "Decoration" }
+      ],
+      "extensions" : [ "SPV_GOOGLE_decorate_string" ]
+    },
+    {
+      "opname" : "OpMemberDecorateStringGOOGLE",
+      "opcode" : 5633,
+      "operands" : [
+        { "kind" : "IdRef",          "name" : "'Struct Type'" },
+        { "kind" : "LiteralInteger", "name" : "'Member'" },
+        { "kind" : "Decoration" }
+      ],
+      "extensions" : [ "SPV_GOOGLE_decorate_string" ]
     }
   ],
   "operand_kinds" : [
@@ -4836,6 +4864,22 @@
           "parameters" : [
             { "kind" : "LiteralInteger", "name" : "'Offset'" }
           ]
+        },
+        {
+          "enumerant" : "HlslCounterBufferGOOGLE",
+          "value" : 5634,
+          "parameters" : [
+            { "kind" : "IdRef", "name" : "'Counter Buffer'" }
+          ],
+          "extensions" : [ "SPV_GOOGLE_hlsl_functionality1" ]
+        },
+        {
+          "enumerant" : "HlslSemanticGOOGLE",
+          "value" : 5635,
+          "parameters" : [
+            { "kind" : "LiteralString", "name" : "'Semantic'" }
+          ],
+          "extensions" : [ "SPV_GOOGLE_hlsl_functionality1" ]
         }
       ]
     },

--- a/include/spirv/1.0/spirv.h
+++ b/include/spirv/1.0/spirv.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2014-2017 The Khronos Group Inc.
+** Copyright (c) 2014-2018 The Khronos Group Inc.
 ** 
 ** Permission is hereby granted, free of charge, to any person obtaining a copy
 ** of this software and/or associated documentation files (the "Materials"),
@@ -387,6 +387,8 @@ typedef enum SpvDecoration_ {
     SpvDecorationPassthroughNV = 5250,
     SpvDecorationViewportRelativeNV = 5252,
     SpvDecorationSecondaryViewportRelativeNV = 5256,
+    SpvDecorationHlslCounterBufferGOOGLE = 5634,
+    SpvDecorationHlslSemanticGOOGLE = 5635,
     SpvDecorationMax = 0x7fffffff,
 } SpvDecoration;
 
@@ -957,6 +959,7 @@ typedef enum SpvOp_ {
     SpvOpAtomicFlagTestAndSet = 318,
     SpvOpAtomicFlagClear = 319,
     SpvOpImageSparseRead = 320,
+    SpvOpDecorateId = 332,
     SpvOpSubgroupBallotKHR = 4421,
     SpvOpSubgroupFirstInvocationKHR = 4422,
     SpvOpSubgroupAllKHR = 4428,
@@ -981,6 +984,8 @@ typedef enum SpvOp_ {
     SpvOpSubgroupBlockWriteINTEL = 5576,
     SpvOpSubgroupImageBlockReadINTEL = 5577,
     SpvOpSubgroupImageBlockWriteINTEL = 5578,
+    SpvOpDecorateStringGOOGLE = 5632,
+    SpvOpMemberDecorateStringGOOGLE = 5633,
     SpvOpMax = 0x7fffffff,
 } SpvOp;
 

--- a/include/spirv/1.0/spirv.hpp
+++ b/include/spirv/1.0/spirv.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2017 The Khronos Group Inc.
+// Copyright (c) 2014-2018 The Khronos Group Inc.
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and/or associated documentation files (the "Materials"),
@@ -383,6 +383,8 @@ enum Decoration {
     DecorationPassthroughNV = 5250,
     DecorationViewportRelativeNV = 5252,
     DecorationSecondaryViewportRelativeNV = 5256,
+    DecorationHlslCounterBufferGOOGLE = 5634,
+    DecorationHlslSemanticGOOGLE = 5635,
     DecorationMax = 0x7fffffff,
 };
 
@@ -953,6 +955,7 @@ enum Op {
     OpAtomicFlagTestAndSet = 318,
     OpAtomicFlagClear = 319,
     OpImageSparseRead = 320,
+    OpDecorateId = 332,
     OpSubgroupBallotKHR = 4421,
     OpSubgroupFirstInvocationKHR = 4422,
     OpSubgroupAllKHR = 4428,
@@ -977,6 +980,8 @@ enum Op {
     OpSubgroupBlockWriteINTEL = 5576,
     OpSubgroupImageBlockReadINTEL = 5577,
     OpSubgroupImageBlockWriteINTEL = 5578,
+    OpDecorateStringGOOGLE = 5632,
+    OpMemberDecorateStringGOOGLE = 5633,
     OpMax = 0x7fffffff,
 };
 

--- a/include/spirv/1.0/spirv.hpp11
+++ b/include/spirv/1.0/spirv.hpp11
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2017 The Khronos Group Inc.
+// Copyright (c) 2014-2018 The Khronos Group Inc.
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and/or associated documentation files (the "Materials"),
@@ -383,6 +383,8 @@ enum class Decoration : unsigned {
     PassthroughNV = 5250,
     ViewportRelativeNV = 5252,
     SecondaryViewportRelativeNV = 5256,
+    HlslCounterBufferGOOGLE = 5634,
+    HlslSemanticGOOGLE = 5635,
     Max = 0x7fffffff,
 };
 
@@ -953,6 +955,7 @@ enum class Op : unsigned {
     OpAtomicFlagTestAndSet = 318,
     OpAtomicFlagClear = 319,
     OpImageSparseRead = 320,
+    OpDecorateId = 332,
     OpSubgroupBallotKHR = 4421,
     OpSubgroupFirstInvocationKHR = 4422,
     OpSubgroupAllKHR = 4428,
@@ -977,6 +980,8 @@ enum class Op : unsigned {
     OpSubgroupBlockWriteINTEL = 5576,
     OpSubgroupImageBlockReadINTEL = 5577,
     OpSubgroupImageBlockWriteINTEL = 5578,
+    OpDecorateStringGOOGLE = 5632,
+    OpMemberDecorateStringGOOGLE = 5633,
     Max = 0x7fffffff,
 };
 

--- a/include/spirv/1.0/spirv.json
+++ b/include/spirv/1.0/spirv.json
@@ -6,7 +6,7 @@
             "Comment":
             [
                 [
-                    "Copyright (c) 2014-2017 The Khronos Group Inc.",
+                    "Copyright (c) 2014-2018 The Khronos Group Inc.",
                     "",
                     "Permission is hereby granted, free of charge, to any person obtaining a copy",
                     "of this software and/or associated documentation files (the \"Materials\"),",
@@ -422,7 +422,9 @@
                     "OverrideCoverageNV": 5248,
                     "PassthroughNV": 5250,
                     "ViewportRelativeNV": 5252,
-                    "SecondaryViewportRelativeNV": 5256
+                    "SecondaryViewportRelativeNV": 5256,
+                    "HlslCounterBufferGOOGLE": 5634,
+                    "HlslSemanticGOOGLE": 5635
                 }
             },
             {
@@ -983,6 +985,7 @@
                     "OpAtomicFlagTestAndSet": 318,
                     "OpAtomicFlagClear": 319,
                     "OpImageSparseRead": 320,
+                    "OpDecorateId": 332,
                     "OpSubgroupBallotKHR": 4421,
                     "OpSubgroupFirstInvocationKHR": 4422,
                     "OpSubgroupAllKHR": 4428,
@@ -1006,7 +1009,9 @@
                     "OpSubgroupBlockReadINTEL": 5575,
                     "OpSubgroupBlockWriteINTEL": 5576,
                     "OpSubgroupImageBlockReadINTEL": 5577,
-                    "OpSubgroupImageBlockWriteINTEL": 5578
+                    "OpSubgroupImageBlockWriteINTEL": 5578,
+                    "OpDecorateStringGOOGLE": 5632,
+                    "OpMemberDecorateStringGOOGLE": 5633
                 }
             }
         ]

--- a/include/spirv/1.0/spirv.lua
+++ b/include/spirv/1.0/spirv.lua
@@ -1,4 +1,4 @@
--- Copyright (c) 2014-2017 The Khronos Group Inc.
+-- Copyright (c) 2014-2018 The Khronos Group Inc.
 -- 
 -- Permission is hereby granted, free of charge, to any person obtaining a copy
 -- of this software and/or associated documentation files (the "Materials"),
@@ -356,6 +356,8 @@ spv = {
         PassthroughNV = 5250,
         ViewportRelativeNV = 5252,
         SecondaryViewportRelativeNV = 5256,
+        HlslCounterBufferGOOGLE = 5634,
+        HlslSemanticGOOGLE = 5635,
     },
 
     BuiltIn = {
@@ -914,6 +916,7 @@ spv = {
         OpAtomicFlagTestAndSet = 318,
         OpAtomicFlagClear = 319,
         OpImageSparseRead = 320,
+        OpDecorateId = 332,
         OpSubgroupBallotKHR = 4421,
         OpSubgroupFirstInvocationKHR = 4422,
         OpSubgroupAllKHR = 4428,
@@ -938,6 +941,8 @@ spv = {
         OpSubgroupBlockWriteINTEL = 5576,
         OpSubgroupImageBlockReadINTEL = 5577,
         OpSubgroupImageBlockWriteINTEL = 5578,
+        OpDecorateStringGOOGLE = 5632,
+        OpMemberDecorateStringGOOGLE = 5633,
     },
 
 }

--- a/include/spirv/1.0/spirv.py
+++ b/include/spirv/1.0/spirv.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2017 The Khronos Group Inc.
+# Copyright (c) 2014-2018 The Khronos Group Inc.
 # 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and/or associated documentation files (the "Materials"),
@@ -356,6 +356,8 @@ spv = {
         'PassthroughNV' : 5250,
         'ViewportRelativeNV' : 5252,
         'SecondaryViewportRelativeNV' : 5256,
+        'HlslCounterBufferGOOGLE' : 5634,
+        'HlslSemanticGOOGLE' : 5635,
     },
 
     'BuiltIn' : {
@@ -914,6 +916,7 @@ spv = {
         'OpAtomicFlagTestAndSet' : 318,
         'OpAtomicFlagClear' : 319,
         'OpImageSparseRead' : 320,
+        'OpDecorateId' : 332,
         'OpSubgroupBallotKHR' : 4421,
         'OpSubgroupFirstInvocationKHR' : 4422,
         'OpSubgroupAllKHR' : 4428,
@@ -938,6 +941,8 @@ spv = {
         'OpSubgroupBlockWriteINTEL' : 5576,
         'OpSubgroupImageBlockReadINTEL' : 5577,
         'OpSubgroupImageBlockWriteINTEL' : 5578,
+        'OpDecorateStringGOOGLE' : 5632,
+        'OpMemberDecorateStringGOOGLE' : 5633,
     },
 
 }

--- a/include/spirv/1.1/spirv.core.grammar.json
+++ b/include/spirv/1.1/spirv.core.grammar.json
@@ -3115,6 +3115,15 @@
       ]
     },
     {
+      "opname" : "OpDecorateId",
+      "opcode" : 332,
+      "operands" : [
+        { "kind" : "IdRef", "name" : "'Target'" },
+        { "kind" : "Decoration" }
+      ],
+      "extensions" : [ "SPV_GOOGLE_hlsl_functionality1" ]
+    },
+    {
       "opname" : "OpSubgroupBallotKHR",
       "opcode" : 4421,
       "operands" : [
@@ -3379,6 +3388,25 @@
         { "kind" : "IdRef", "name" : "'Data'" }
       ],
       "capabilities" : [ "SubgroupImageBlockIOINTEL" ]
+    },
+    {
+      "opname" : "OpDecorateStringGOOGLE",
+      "opcode" : 5632,
+      "operands" : [
+        { "kind" : "IdRef",         "name" : "'Target'" },
+        { "kind" : "Decoration" }
+      ],
+      "extensions" : [ "SPV_GOOGLE_decorate_string" ]
+    },
+    {
+      "opname" : "OpMemberDecorateStringGOOGLE",
+      "opcode" : 5633,
+      "operands" : [
+        { "kind" : "IdRef",          "name" : "'Struct Type'" },
+        { "kind" : "LiteralInteger", "name" : "'Member'" },
+        { "kind" : "Decoration" }
+      ],
+      "extensions" : [ "SPV_GOOGLE_decorate_string" ]
     }
   ],
   "operand_kinds" : [
@@ -4984,6 +5012,22 @@
           "parameters" : [
             { "kind" : "LiteralInteger", "name" : "'Offset'" }
           ]
+        },
+        {
+          "enumerant" : "HlslCounterBufferGOOGLE",
+          "value" : 5634,
+          "parameters" : [
+            { "kind" : "IdRef", "name" : "'Counter Buffer'" }
+          ],
+          "extensions" : [ "SPV_GOOGLE_hlsl_functionality1" ]
+        },
+        {
+          "enumerant" : "HlslSemanticGOOGLE",
+          "value" : 5635,
+          "parameters" : [
+            { "kind" : "LiteralString", "name" : "'Semantic'" }
+          ],
+          "extensions" : [ "SPV_GOOGLE_hlsl_functionality1" ]
         }
       ]
     },

--- a/include/spirv/1.1/spirv.h
+++ b/include/spirv/1.1/spirv.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2014-2017 The Khronos Group Inc.
+** Copyright (c) 2014-2018 The Khronos Group Inc.
 ** 
 ** Permission is hereby granted, free of charge, to any person obtaining a copy
 ** of this software and/or associated documentation files (the "Materials"),
@@ -392,6 +392,8 @@ typedef enum SpvDecoration_ {
     SpvDecorationPassthroughNV = 5250,
     SpvDecorationViewportRelativeNV = 5252,
     SpvDecorationSecondaryViewportRelativeNV = 5256,
+    SpvDecorationHlslCounterBufferGOOGLE = 5634,
+    SpvDecorationHlslSemanticGOOGLE = 5635,
     SpvDecorationMax = 0x7fffffff,
 } SpvDecoration;
 
@@ -979,6 +981,7 @@ typedef enum SpvOp_ {
     SpvOpNamedBarrierInitialize = 328,
     SpvOpMemoryNamedBarrier = 329,
     SpvOpModuleProcessed = 330,
+    SpvOpDecorateId = 332,
     SpvOpSubgroupBallotKHR = 4421,
     SpvOpSubgroupFirstInvocationKHR = 4422,
     SpvOpSubgroupAllKHR = 4428,
@@ -1003,6 +1006,8 @@ typedef enum SpvOp_ {
     SpvOpSubgroupBlockWriteINTEL = 5576,
     SpvOpSubgroupImageBlockReadINTEL = 5577,
     SpvOpSubgroupImageBlockWriteINTEL = 5578,
+    SpvOpDecorateStringGOOGLE = 5632,
+    SpvOpMemberDecorateStringGOOGLE = 5633,
     SpvOpMax = 0x7fffffff,
 } SpvOp;
 

--- a/include/spirv/1.1/spirv.hpp
+++ b/include/spirv/1.1/spirv.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2017 The Khronos Group Inc.
+// Copyright (c) 2014-2018 The Khronos Group Inc.
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and/or associated documentation files (the "Materials"),
@@ -388,6 +388,8 @@ enum Decoration {
     DecorationPassthroughNV = 5250,
     DecorationViewportRelativeNV = 5252,
     DecorationSecondaryViewportRelativeNV = 5256,
+    DecorationHlslCounterBufferGOOGLE = 5634,
+    DecorationHlslSemanticGOOGLE = 5635,
     DecorationMax = 0x7fffffff,
 };
 
@@ -975,6 +977,7 @@ enum Op {
     OpNamedBarrierInitialize = 328,
     OpMemoryNamedBarrier = 329,
     OpModuleProcessed = 330,
+    OpDecorateId = 332,
     OpSubgroupBallotKHR = 4421,
     OpSubgroupFirstInvocationKHR = 4422,
     OpSubgroupAllKHR = 4428,
@@ -999,6 +1002,8 @@ enum Op {
     OpSubgroupBlockWriteINTEL = 5576,
     OpSubgroupImageBlockReadINTEL = 5577,
     OpSubgroupImageBlockWriteINTEL = 5578,
+    OpDecorateStringGOOGLE = 5632,
+    OpMemberDecorateStringGOOGLE = 5633,
     OpMax = 0x7fffffff,
 };
 

--- a/include/spirv/1.1/spirv.hpp11
+++ b/include/spirv/1.1/spirv.hpp11
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2017 The Khronos Group Inc.
+// Copyright (c) 2014-2018 The Khronos Group Inc.
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and/or associated documentation files (the "Materials"),
@@ -388,6 +388,8 @@ enum class Decoration : unsigned {
     PassthroughNV = 5250,
     ViewportRelativeNV = 5252,
     SecondaryViewportRelativeNV = 5256,
+    HlslCounterBufferGOOGLE = 5634,
+    HlslSemanticGOOGLE = 5635,
     Max = 0x7fffffff,
 };
 
@@ -975,6 +977,7 @@ enum class Op : unsigned {
     OpNamedBarrierInitialize = 328,
     OpMemoryNamedBarrier = 329,
     OpModuleProcessed = 330,
+    OpDecorateId = 332,
     OpSubgroupBallotKHR = 4421,
     OpSubgroupFirstInvocationKHR = 4422,
     OpSubgroupAllKHR = 4428,
@@ -999,6 +1002,8 @@ enum class Op : unsigned {
     OpSubgroupBlockWriteINTEL = 5576,
     OpSubgroupImageBlockReadINTEL = 5577,
     OpSubgroupImageBlockWriteINTEL = 5578,
+    OpDecorateStringGOOGLE = 5632,
+    OpMemberDecorateStringGOOGLE = 5633,
     Max = 0x7fffffff,
 };
 

--- a/include/spirv/1.1/spirv.json
+++ b/include/spirv/1.1/spirv.json
@@ -6,7 +6,7 @@
             "Comment":
             [
                 [
-                    "Copyright (c) 2014-2017 The Khronos Group Inc.",
+                    "Copyright (c) 2014-2018 The Khronos Group Inc.",
                     "",
                     "Permission is hereby granted, free of charge, to any person obtaining a copy",
                     "of this software and/or associated documentation files (the \"Materials\"),",
@@ -427,7 +427,9 @@
                     "OverrideCoverageNV": 5248,
                     "PassthroughNV": 5250,
                     "ViewportRelativeNV": 5252,
-                    "SecondaryViewportRelativeNV": 5256
+                    "SecondaryViewportRelativeNV": 5256,
+                    "HlslCounterBufferGOOGLE": 5634,
+                    "HlslSemanticGOOGLE": 5635
                 }
             },
             {
@@ -1003,6 +1005,7 @@
                     "OpNamedBarrierInitialize": 328,
                     "OpMemoryNamedBarrier": 329,
                     "OpModuleProcessed": 330,
+                    "OpDecorateId": 332,
                     "OpSubgroupBallotKHR": 4421,
                     "OpSubgroupFirstInvocationKHR": 4422,
                     "OpSubgroupAllKHR": 4428,
@@ -1026,7 +1029,9 @@
                     "OpSubgroupBlockReadINTEL": 5575,
                     "OpSubgroupBlockWriteINTEL": 5576,
                     "OpSubgroupImageBlockReadINTEL": 5577,
-                    "OpSubgroupImageBlockWriteINTEL": 5578
+                    "OpSubgroupImageBlockWriteINTEL": 5578,
+                    "OpDecorateStringGOOGLE": 5632,
+                    "OpMemberDecorateStringGOOGLE": 5633
                 }
             }
         ]

--- a/include/spirv/1.1/spirv.lua
+++ b/include/spirv/1.1/spirv.lua
@@ -1,4 +1,4 @@
--- Copyright (c) 2014-2017 The Khronos Group Inc.
+-- Copyright (c) 2014-2018 The Khronos Group Inc.
 -- 
 -- Permission is hereby granted, free of charge, to any person obtaining a copy
 -- of this software and/or associated documentation files (the "Materials"),
@@ -361,6 +361,8 @@ spv = {
         PassthroughNV = 5250,
         ViewportRelativeNV = 5252,
         SecondaryViewportRelativeNV = 5256,
+        HlslCounterBufferGOOGLE = 5634,
+        HlslSemanticGOOGLE = 5635,
     },
 
     BuiltIn = {
@@ -936,6 +938,7 @@ spv = {
         OpNamedBarrierInitialize = 328,
         OpMemoryNamedBarrier = 329,
         OpModuleProcessed = 330,
+        OpDecorateId = 332,
         OpSubgroupBallotKHR = 4421,
         OpSubgroupFirstInvocationKHR = 4422,
         OpSubgroupAllKHR = 4428,
@@ -960,6 +963,8 @@ spv = {
         OpSubgroupBlockWriteINTEL = 5576,
         OpSubgroupImageBlockReadINTEL = 5577,
         OpSubgroupImageBlockWriteINTEL = 5578,
+        OpDecorateStringGOOGLE = 5632,
+        OpMemberDecorateStringGOOGLE = 5633,
     },
 
 }

--- a/include/spirv/1.1/spirv.py
+++ b/include/spirv/1.1/spirv.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2017 The Khronos Group Inc.
+# Copyright (c) 2014-2018 The Khronos Group Inc.
 # 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and/or associated documentation files (the "Materials"),
@@ -361,6 +361,8 @@ spv = {
         'PassthroughNV' : 5250,
         'ViewportRelativeNV' : 5252,
         'SecondaryViewportRelativeNV' : 5256,
+        'HlslCounterBufferGOOGLE' : 5634,
+        'HlslSemanticGOOGLE' : 5635,
     },
 
     'BuiltIn' : {
@@ -936,6 +938,7 @@ spv = {
         'OpNamedBarrierInitialize' : 328,
         'OpMemoryNamedBarrier' : 329,
         'OpModuleProcessed' : 330,
+        'OpDecorateId' : 332,
         'OpSubgroupBallotKHR' : 4421,
         'OpSubgroupFirstInvocationKHR' : 4422,
         'OpSubgroupAllKHR' : 4428,
@@ -960,6 +963,8 @@ spv = {
         'OpSubgroupBlockWriteINTEL' : 5576,
         'OpSubgroupImageBlockReadINTEL' : 5577,
         'OpSubgroupImageBlockWriteINTEL' : 5578,
+        'OpDecorateStringGOOGLE' : 5632,
+        'OpMemberDecorateStringGOOGLE' : 5633,
     },
 
 }

--- a/include/spirv/1.2/spirv.core.grammar.json
+++ b/include/spirv/1.2/spirv.core.grammar.json
@@ -3395,6 +3395,25 @@
         { "kind" : "IdRef", "name" : "'Data'" }
       ],
       "capabilities" : [ "SubgroupImageBlockIOINTEL" ]
+    },
+    {
+      "opname" : "OpDecorateStringGOOGLE",
+      "opcode" : 5632,
+      "operands" : [
+        { "kind" : "IdRef",         "name" : "'Target'" },
+        { "kind" : "Decoration" }
+      ],
+      "extensions" : [ "SPV_GOOGLE_decorate_string" ]
+    },
+    {
+      "opname" : "OpMemberDecorateStringGOOGLE",
+      "opcode" : 5633,
+      "operands" : [
+        { "kind" : "IdRef",          "name" : "'Struct Type'" },
+        { "kind" : "LiteralInteger", "name" : "'Member'" },
+        { "kind" : "Decoration" }
+      ],
+      "extensions" : [ "SPV_GOOGLE_decorate_string" ]
     }
   ],
   "operand_kinds" : [
@@ -5041,6 +5060,22 @@
           "parameters" : [
             { "kind" : "LiteralInteger", "name" : "'Offset'" }
           ]
+        },
+        {
+          "enumerant" : "HlslCounterBufferGOOGLE",
+          "value" : 5634,
+          "parameters" : [
+            { "kind" : "IdRef", "name" : "'Counter Buffer'" }
+          ],
+          "extensions" : [ "SPV_GOOGLE_hlsl_functionality1" ]
+        },
+        {
+          "enumerant" : "HlslSemanticGOOGLE",
+          "value" : 5635,
+          "parameters" : [
+            { "kind" : "LiteralString", "name" : "'Semantic'" }
+          ],
+          "extensions" : [ "SPV_GOOGLE_hlsl_functionality1" ]
         }
       ]
     },

--- a/include/spirv/1.2/spirv.h
+++ b/include/spirv/1.2/spirv.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2014-2017 The Khronos Group Inc.
+** Copyright (c) 2014-2018 The Khronos Group Inc.
 ** 
 ** Permission is hereby granted, free of charge, to any person obtaining a copy
 ** of this software and/or associated documentation files (the "Materials"),
@@ -397,6 +397,8 @@ typedef enum SpvDecoration_ {
     SpvDecorationPassthroughNV = 5250,
     SpvDecorationViewportRelativeNV = 5252,
     SpvDecorationSecondaryViewportRelativeNV = 5256,
+    SpvDecorationHlslCounterBufferGOOGLE = 5634,
+    SpvDecorationHlslSemanticGOOGLE = 5635,
     SpvDecorationMax = 0x7fffffff,
 } SpvDecoration;
 
@@ -1010,6 +1012,8 @@ typedef enum SpvOp_ {
     SpvOpSubgroupBlockWriteINTEL = 5576,
     SpvOpSubgroupImageBlockReadINTEL = 5577,
     SpvOpSubgroupImageBlockWriteINTEL = 5578,
+    SpvOpDecorateStringGOOGLE = 5632,
+    SpvOpMemberDecorateStringGOOGLE = 5633,
     SpvOpMax = 0x7fffffff,
 } SpvOp;
 

--- a/include/spirv/1.2/spirv.hpp
+++ b/include/spirv/1.2/spirv.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2017 The Khronos Group Inc.
+// Copyright (c) 2014-2018 The Khronos Group Inc.
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and/or associated documentation files (the "Materials"),
@@ -393,6 +393,8 @@ enum Decoration {
     DecorationPassthroughNV = 5250,
     DecorationViewportRelativeNV = 5252,
     DecorationSecondaryViewportRelativeNV = 5256,
+    DecorationHlslCounterBufferGOOGLE = 5634,
+    DecorationHlslSemanticGOOGLE = 5635,
     DecorationMax = 0x7fffffff,
 };
 
@@ -1006,6 +1008,8 @@ enum Op {
     OpSubgroupBlockWriteINTEL = 5576,
     OpSubgroupImageBlockReadINTEL = 5577,
     OpSubgroupImageBlockWriteINTEL = 5578,
+    OpDecorateStringGOOGLE = 5632,
+    OpMemberDecorateStringGOOGLE = 5633,
     OpMax = 0x7fffffff,
 };
 

--- a/include/spirv/1.2/spirv.hpp11
+++ b/include/spirv/1.2/spirv.hpp11
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2017 The Khronos Group Inc.
+// Copyright (c) 2014-2018 The Khronos Group Inc.
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and/or associated documentation files (the "Materials"),
@@ -393,6 +393,8 @@ enum class Decoration : unsigned {
     PassthroughNV = 5250,
     ViewportRelativeNV = 5252,
     SecondaryViewportRelativeNV = 5256,
+    HlslCounterBufferGOOGLE = 5634,
+    HlslSemanticGOOGLE = 5635,
     Max = 0x7fffffff,
 };
 
@@ -1006,6 +1008,8 @@ enum class Op : unsigned {
     OpSubgroupBlockWriteINTEL = 5576,
     OpSubgroupImageBlockReadINTEL = 5577,
     OpSubgroupImageBlockWriteINTEL = 5578,
+    OpDecorateStringGOOGLE = 5632,
+    OpMemberDecorateStringGOOGLE = 5633,
     Max = 0x7fffffff,
 };
 

--- a/include/spirv/1.2/spirv.json
+++ b/include/spirv/1.2/spirv.json
@@ -6,7 +6,7 @@
             "Comment":
             [
                 [
-                    "Copyright (c) 2014-2017 The Khronos Group Inc.",
+                    "Copyright (c) 2014-2018 The Khronos Group Inc.",
                     "",
                     "Permission is hereby granted, free of charge, to any person obtaining a copy",
                     "of this software and/or associated documentation files (the \"Materials\"),",
@@ -432,7 +432,9 @@
                     "OverrideCoverageNV": 5248,
                     "PassthroughNV": 5250,
                     "ViewportRelativeNV": 5252,
-                    "SecondaryViewportRelativeNV": 5256
+                    "SecondaryViewportRelativeNV": 5256,
+                    "HlslCounterBufferGOOGLE": 5634,
+                    "HlslSemanticGOOGLE": 5635
                 }
             },
             {
@@ -1033,7 +1035,9 @@
                     "OpSubgroupBlockReadINTEL": 5575,
                     "OpSubgroupBlockWriteINTEL": 5576,
                     "OpSubgroupImageBlockReadINTEL": 5577,
-                    "OpSubgroupImageBlockWriteINTEL": 5578
+                    "OpSubgroupImageBlockWriteINTEL": 5578,
+                    "OpDecorateStringGOOGLE": 5632,
+                    "OpMemberDecorateStringGOOGLE": 5633
                 }
             }
         ]

--- a/include/spirv/1.2/spirv.lua
+++ b/include/spirv/1.2/spirv.lua
@@ -1,4 +1,4 @@
--- Copyright (c) 2014-2017 The Khronos Group Inc.
+-- Copyright (c) 2014-2018 The Khronos Group Inc.
 -- 
 -- Permission is hereby granted, free of charge, to any person obtaining a copy
 -- of this software and/or associated documentation files (the "Materials"),
@@ -366,6 +366,8 @@ spv = {
         PassthroughNV = 5250,
         ViewportRelativeNV = 5252,
         SecondaryViewportRelativeNV = 5256,
+        HlslCounterBufferGOOGLE = 5634,
+        HlslSemanticGOOGLE = 5635,
     },
 
     BuiltIn = {
@@ -967,6 +969,8 @@ spv = {
         OpSubgroupBlockWriteINTEL = 5576,
         OpSubgroupImageBlockReadINTEL = 5577,
         OpSubgroupImageBlockWriteINTEL = 5578,
+        OpDecorateStringGOOGLE = 5632,
+        OpMemberDecorateStringGOOGLE = 5633,
     },
 
 }

--- a/include/spirv/1.2/spirv.py
+++ b/include/spirv/1.2/spirv.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2017 The Khronos Group Inc.
+# Copyright (c) 2014-2018 The Khronos Group Inc.
 # 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and/or associated documentation files (the "Materials"),
@@ -366,6 +366,8 @@ spv = {
         'PassthroughNV' : 5250,
         'ViewportRelativeNV' : 5252,
         'SecondaryViewportRelativeNV' : 5256,
+        'HlslCounterBufferGOOGLE' : 5634,
+        'HlslSemanticGOOGLE' : 5635,
     },
 
     'BuiltIn' : {
@@ -967,6 +969,8 @@ spv = {
         'OpSubgroupBlockWriteINTEL' : 5576,
         'OpSubgroupImageBlockReadINTEL' : 5577,
         'OpSubgroupImageBlockWriteINTEL' : 5578,
+        'OpDecorateStringGOOGLE' : 5632,
+        'OpMemberDecorateStringGOOGLE' : 5633,
     },
 
 }

--- a/include/spirv/unified1/spirv.core.grammar.json
+++ b/include/spirv/unified1/spirv.core.grammar.json
@@ -3436,9 +3436,7 @@
       "opcode" : 5632,
       "operands" : [
         { "kind" : "IdRef",         "name" : "'Target'" },
-        { "kind" : "Decoration" },
-        { "kind" : "LiteralString" },
-        { "kind" : "LiteralString", "quantifier" : "*" }
+        { "kind" : "Decoration" }
       ],
       "extensions" : [ "SPV_GOOGLE_decorate_string" ],
       "version" : "None"
@@ -3449,9 +3447,7 @@
       "operands" : [
         { "kind" : "IdRef",          "name" : "'Struct Type'" },
         { "kind" : "LiteralInteger", "name" : "'Member'" },
-        { "kind" : "Decoration" },
-        { "kind" : "LiteralString" },
-        { "kind" : "LiteralString",  "quantifier" : "*" }
+        { "kind" : "Decoration" }
       ],
       "extensions" : [ "SPV_GOOGLE_decorate_string" ],
       "version" : "None"

--- a/tools/buildHeaders/jsonToSpirv.cpp
+++ b/tools/buildHeaders/jsonToSpirv.cpp
@@ -119,7 +119,8 @@ ClassOptionality ToOperandClassAndOptionality(const std::string& operandKind, co
         else if (quantifier == "?")
             return {OperandLiteralString, true};
         else {
-            return {OperandVariableLiteralStrings, false};
+            assert(0 && "this case should not exist");
+            return {OperandNone, false};
         }
     } else if (operandKind == "PairLiteralIntegerIdRef") {
         // Used by OpSwitch in the grammar

--- a/tools/buildHeaders/jsonToSpirv.h
+++ b/tools/buildHeaders/jsonToSpirv.h
@@ -47,7 +47,6 @@ enum OperandClass {
     OperandOptionalLiteral,
     OperandOptionalLiteralString,
     OperandVariableLiterals,
-    OperandVariableLiteralStrings,
     OperandVariableIdLiteral,
     OperandVariableLiteralId,
     OperandLiteralNumber,


### PR DESCRIPTION
Fix grammar error for Google decorate_string & hlsl_functionality1.

We don't need to put "LiteralString" as a parameter to OpDecorateString itself;
they should be specified by the Decoration instead.

Note that for the backport, I also included OpDecorateId, but guarded it
with an "extension" field.

Let me know if this is not the preferred way to go. I'd happy to adjust.