### PR TITLE
Add missing 'extensions' for OpGroupNonUniformPartitionNV

### DIFF
--- a/include/spirv/unified1/spirv.core.grammar.json
+++ b/include/spirv/unified1/spirv.core.grammar.json
@@ -3937,6 +3937,7 @@
         { "kind" : "IdRef", "name" : "'Value'" }
       ],
       "capabilities" : [ "GroupNonUniformPartitionedNV" ],
+      "extensions" : [ "SPV_NV_shader_subgroup_partitioned" ],
       "version" : "None"
     }
   ],


### PR DESCRIPTION
This opcode is failing to disassemble, due to this missing "extensions" tag in the JSON.
