### PR TITLE
Use /usr/bin/env to avoid hardcoding path to bash

### DIFF
--- a/tools/buildHeaders/bin/makeHeaders
+++ b/tools/buildHeaders/bin/makeHeaders
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 cd ../../include/spirv/unified1
 ../../../tools/buildHeaders/build/install/bin/buildSpvHeaders -H spirv.core.grammar.json


### PR DESCRIPTION
Some systems have bash at a different path, for example macOS, so add an indirection through `env`.