### PR TITLE
Add a makefile to the top level for convenience

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+rebuild-headers:
+	mkdir -p tools/buildHeaders/build
+	cd tools/buildHeaders/build && cmake .. && cmake --build .
+	cd include/spirv/unified1 && \
+		../../../tools/buildHeaders/build/BuildSpvHeaders -H spirv.core.grammar.json


### PR DESCRIPTION
I found it a bit difficult to figure out how to create the build folder, invoke `cmake`, and correctly invoke the command to rebuild the header files.

This commit adds a makefile to the top level that contains the correct commands, so that a simple `make` in the top level is enough to recompile the header builder and regenerate the headers.