### PR TITLE
Add missing 'extensions' field for some NVIDIA symbols

### DIFF
--- a/include/spirv/unified1/spirv.core.grammar.json
+++ b/include/spirv/unified1/spirv.core.grammar.json
@@ -5550,12 +5550,14 @@
           "enumerant" : "OverrideCoverageNV",
           "value" : 5248,
           "capabilities" : [ "SampleMaskOverrideCoverageNV" ],
+          "extensions" : [ "SPV_NV_sample_mask_override_coverage" ],
           "version" : "None"
         },
         {
           "enumerant" : "PassthroughNV",
           "value" : 5250,
           "capabilities" : [ "GeometryShaderPassthroughNV" ],
+          "extensions" : [ "SPV_NV_geometry_shader_passthrough" ],
           "version" : "None"
         },
         {
@@ -5568,6 +5570,7 @@
           "enumerant" : "SecondaryViewportRelativeNV",
           "value" : 5256,
           "capabilities" : [ "ShaderStereoViewNV" ],
+          "extensions" : [ "SPV_NV_stereo_view_rendering" ],
           "version" : "None",
           "parameters" : [
             { "kind" : "LiteralInteger", "name" : "'Offset'" }
@@ -5960,12 +5963,14 @@
           "enumerant" : "SecondaryPositionNV",
           "value" : 5257,
           "capabilities" : [ "ShaderStereoViewNV" ],
+          "extensions" : [ "SPV_NV_stereo_view_rendering" ],
           "version" : "None"
         },
         {
           "enumerant" : "SecondaryViewportMaskNV",
           "value" : 5258,
           "capabilities" : [ "ShaderStereoViewNV" ],
+          "extensions" : [ "SPV_NV_stereo_view_rendering" ],
           "version" : "None"
         },
         {
@@ -6043,17 +6048,23 @@
         {
           "enumerant" : "PartitionedReduceNV",
           "value" : 6,
-          "capabilities" : [ "GroupNonUniformPartitionedNV" ]
+          "capabilities" : [ "GroupNonUniformPartitionedNV" ],
+          "extensions" : [ "SPV_NV_shader_subgroup_partitioned" ],
+          "version" : "None"
         },
         {
           "enumerant" : "PartitionedInclusiveScanNV",
           "value" : 7,
-          "capabilities" : [ "GroupNonUniformPartitionedNV" ]
+          "capabilities" : [ "GroupNonUniformPartitionedNV" ],
+          "extensions" : [ "SPV_NV_shader_subgroup_partitioned" ],
+          "version" : "None"
         },
         {
           "enumerant" : "PartitionedExclusiveScanNV",
           "value" : 8,
-          "capabilities" : [ "GroupNonUniformPartitionedNV" ]
+          "capabilities" : [ "GroupNonUniformPartitionedNV" ],
+          "extensions" : [ "SPV_NV_shader_subgroup_partitioned" ],
+          "version" : "None"
         }
       ]
     },


### PR DESCRIPTION
* SPV_NV_sample_mask_override_coverage
* SPV_NV_geometry_shader_passthrough
* SPV_NV_stereo_view_rendering
* SPV_NV_shader_subgroup_partitioned