### PR TITLE
Enable Groups capability by the extension SPV_AMD_shader_ballot

### DIFF
--- a/include/spirv/unified1/spirv.core.grammar.json
+++ b/include/spirv/unified1/spirv.core.grammar.json
@@ -8404,7 +8404,8 @@
         },
         {
           "enumerant" : "Groups",
-          "value" : 18
+          "value" : 18,
+          "extensions" : [ "SPV_AMD_shader_ballot" ]
         },
         {
           "enumerant" : "DeviceEnqueue",


### PR DESCRIPTION
This is to address the issue: https://github.com/KhronosGroup/glslang/issues/1763.