### PR TITLE
cmake development configuration package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,14 +44,6 @@ project(SPIRV-Headers)
 #   2. cmake ..
 #   3. cmake --build . --target install
 
-file(GLOB_RECURSE HEADER_FILES
-    RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
-    include/spirv/*)
-foreach(HEADER_FILE ${HEADER_FILES})
-    get_filename_component(HEADER_INSTALL_DIR ${HEADER_FILE} PATH)
-    install(FILES ${HEADER_FILE} DESTINATION ${HEADER_INSTALL_DIR})
-endforeach()
-
 # legacy
 add_custom_target(install-headers
     COMMAND cmake -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/include/spirv
@@ -66,3 +58,60 @@ if (SPIRV_HEADERS_ENABLE_EXAMPLES)
   message(STATUS "Building SPIRV-Header examples")
   add_subdirectory(example)
 endif()
+
+include(GNUInstallDirs)
+add_library(${PROJECT_NAME} INTERFACE)
+target_include_directories(${PROJECT_NAME} INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+
+# Installation
+
+set(config_install_dir "${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/cmake")
+
+set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")
+
+set(version_config "${generated_dir}/${PROJECT_NAME}ConfigVersion.cmake")
+set(project_config "${generated_dir}/${PROJECT_NAME}Config.cmake")
+set(TARGETS_EXPORT_NAME "${PROJECT_NAME}Targets")
+set(namespace "${PROJECT_NAME}::")
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+    "${version_config}"
+    VERSION  "1.4.1"
+    COMPATIBILITY SameMajorVersion
+)
+
+configure_package_config_file(
+    "cmake/Config.cmake.in"
+    "${project_config}"
+    INSTALL_DESTINATION "${config_install_dir}"
+)
+
+install(
+    TARGETS ${PROJECT_NAME}
+    EXPORT "${TARGETS_EXPORT_NAME}"
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+install(
+    DIRECTORY include/spirv
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+install(
+    FILES "${project_config}" "${version_config}"
+    DESTINATION "${config_install_dir}"
+)
+
+install(
+    EXPORT "${TARGETS_EXPORT_NAME}"
+    NAMESPACE "${namespace}"
+    DESTINATION "${config_install_dir}"
+)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@
 # The SPIR-V headers from the SPIR-V Registry
 # https://www.khronos.org/registry/spir-v/
 #
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.0)
 project(SPIRV-Headers)
 
 # There are two ways to use this project.
@@ -63,7 +63,6 @@ include(GNUInstallDirs)
 add_library(${PROJECT_NAME} INTERFACE)
 target_include_directories(${PROJECT_NAME} INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
 # Installation

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@
 # https://www.khronos.org/registry/spir-v/
 #
 cmake_minimum_required(VERSION 3.0)
-project(SPIRV-Headers)
+project(SPIRV-Headers VERSION 1.4.1)
 
 # There are two ways to use this project.
 #
@@ -67,7 +67,7 @@ target_include_directories(${PROJECT_NAME} INTERFACE
 
 # Installation
 
-set(config_install_dir "${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/cmake")
+set(config_install_dir "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
 
 set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")
 
@@ -79,7 +79,6 @@ set(namespace "${PROJECT_NAME}::")
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(
     "${version_config}"
-    VERSION  "1.4.1"
     COMPATIBILITY SameMajorVersion
 )
 

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")
+check_required_components("@PROJECT_NAME@")


### PR DESCRIPTION
Fixes #104

This change generates and installs the following files onto the system
```
-- Installing: /usr/local/lib/cmake/SPIRV-Headers/SPIRV-HeadersConfig.cmake
-- Installing: /usr/local/lib/cmake/SPIRV-Headers/SPIRV-HeadersConfigVersion.cmake
-- Installing: /usr/local/lib/cmake/SPIRV-Headers/SPIRV-HeadersTargets.cmake
```

which makes SPIRV-Headers discoverable after installation by other cmake projects via `find_package`:
```
find_package(SPIRV-Headers 1.4.1 CONFIG REQUIRED)
```