### PR TITLE
Compare enum names rather than values to determine last element

### DIFF
--- a/include/spirv/unified1/spirv.json
+++ b/include/spirv/unified1/spirv.json
@@ -481,7 +481,7 @@
                     "AliasedPointerEXT": 5356,
                     "CounterBuffer": 5634,
                     "HlslCounterBufferGOOGLE": 5634,
-                    "HlslSemanticGOOGLE": 5635
+                    "HlslSemanticGOOGLE": 5635,
                     "UserSemantic": 5635
                 }
             },

--- a/tools/buildHeaders/header.cpp
+++ b/tools/buildHeaders/header.cpp
@@ -347,7 +347,7 @@ namespace {
                 bool printMax = (style != enumMask && maxEnum.size() > 0);
 
                 for (const auto& v : sorted)
-                    out << enumFmt(opPrefix, v, style, !printMax && v.first == sorted.back().first);
+                    out << enumFmt(opPrefix, v, style, !printMax && v.second == sorted.back().second);
 
                 if (printMax)
                     out << maxEnum;


### PR DESCRIPTION
When looping over elements in an enum they are compared by value to determine if this is the last element.  The json writer uses the last element flag to decide if it should add a comma to the end of the line.

However, in the case where the last element has two aliases (such as HlslSemanticGOOGLE and UserSemantic both having the value 5635) this means they are both flagged as the last element.  The json writer fails to emit a comma for the second to last, producing invalid json.

Comparing by name instead fixes this.