### PR TITLE
Proposed LoopControl bitfield allocation mechanism in spir-v.xml

### DIFF
--- a/include/spirv/spir-v.xml
+++ b/include/spirv/spir-v.xml
@@ -120,4 +120,25 @@
 
     <ids type="opcode" start="6016" end="4294967295" comment="Opcode range reservable for future use by vendors"/>
 
+
+    <!-- SECTION: SPIR-V Loop Control Bit Reservations -->
+    <!-- Reserve ranges of bits in the loop control bitfield.
+
+         Each vendor determines the use of values in their own ranges.
+         Vendors are not required to disclose those uses.  If the use of a
+         value is included in an extension that is adopted by a Khronos
+         extension or specification, then that value's use may be permanently
+         fixed as if originally reserved in a Khronos range.
+
+         The SPIR Working Group strongly recommends:
+         - Each value is used for only one purpose.
+         - All values in a range should be used before allocating a new range.
+         -->
+
+    <!-- Reserved loop control bits -->
+    <ids type="LoopControl" start="0" end="15" vendor="Khronos" comment="Reserved LoopControl bits, not available to vendors - see the SPIR-V Specification"/>
+    <ids type="LoopControl" start="16" end="18" vendor="Intel" comment="Contact michael.kinsner@intel.com"/>
+    <ids type="LoopControl" start="19" end="30" comment="Unreserved bits reservable for use by vendors"/>
+    <ids type="LoopControl" start="31" end="31" vendor="Khronos" comment="Reserved LoopControl bit, not available to vendors"/>
+
 </registry>


### PR DESCRIPTION
This PR proposes a new section in spir-v.xml, which is used to allocate bits or ranges of bits for LoopControls.  These bit allocations apply to the LoopControl bitfield which is used by OpLoopMerge.

This XML mechanism will allow vendors to acquire bits for loop control extensions, without potential for collisions across vendors and with future SPIR-V specs.

The initial proposed allocation reserves 7 bits in the low range for Khronos use, beyond the loop controls that are already defined in SPIR-V 1.4.  The highest order bit is also reserved for Khronos to use as an extended LoopControl flag (or anything else) in the future.