### PR TITLE
Add Volatile to Memory Semantics, for SPV_KHR_vulkan_memory_model

### DIFF
--- a/include/spirv/unified1/spirv.core.grammar.json
+++ b/include/spirv/unified1/spirv.core.grammar.json
@@ -6120,6 +6120,12 @@
           "value" : "0x4000",
           "capabilities" : [ "VulkanMemoryModelKHR" ],
           "version" : "None"
+        },
+        {
+          "enumerant" : "Volatile",
+          "value" : "0x8000",
+          "capabilities" : [ "VulkanMemoryModelKHR" ],
+          "version" : "None"
         }
       ]
     },

--- a/include/spirv/unified1/spirv.cs
+++ b/include/spirv/unified1/spirv.cs
@@ -453,6 +453,7 @@ namespace Spv
             HlslCounterBufferGOOGLE = 5634,
             HlslSemanticGOOGLE = 5635,
             UserSemantic = 5635,
+            UserTypeGOOGLE = 5636,
         }
 
         public enum BuiltIn
@@ -633,6 +634,7 @@ namespace Spv
             OutputMemoryKHR = 12,
             MakeAvailableKHR = 13,
             MakeVisibleKHR = 14,
+            Volatile = 15,
         }
 
         public enum MemorySemanticsMask
@@ -651,6 +653,7 @@ namespace Spv
             OutputMemoryKHR = 0x00001000,
             MakeAvailableKHR = 0x00002000,
             MakeVisibleKHR = 0x00004000,
+            Volatile = 0x00008000,
         }
 
         public enum MemoryAccessShift

--- a/include/spirv/unified1/spirv.h
+++ b/include/spirv/unified1/spirv.h
@@ -637,6 +637,7 @@ typedef enum SpvMemorySemanticsShift_ {
     SpvMemorySemanticsOutputMemoryKHRShift = 12,
     SpvMemorySemanticsMakeAvailableKHRShift = 13,
     SpvMemorySemanticsMakeVisibleKHRShift = 14,
+    SpvMemorySemanticsVolatileShift = 15,
     SpvMemorySemanticsMax = 0x7fffffff,
 } SpvMemorySemanticsShift;
 
@@ -655,6 +656,7 @@ typedef enum SpvMemorySemanticsMask_ {
     SpvMemorySemanticsOutputMemoryKHRMask = 0x00001000,
     SpvMemorySemanticsMakeAvailableKHRMask = 0x00002000,
     SpvMemorySemanticsMakeVisibleKHRMask = 0x00004000,
+    SpvMemorySemanticsVolatileMask = 0x00008000,
 } SpvMemorySemanticsMask;
 
 typedef enum SpvMemoryAccessShift_ {

--- a/include/spirv/unified1/spirv.hpp
+++ b/include/spirv/unified1/spirv.hpp
@@ -633,6 +633,7 @@ enum MemorySemanticsShift {
     MemorySemanticsOutputMemoryKHRShift = 12,
     MemorySemanticsMakeAvailableKHRShift = 13,
     MemorySemanticsMakeVisibleKHRShift = 14,
+    MemorySemanticsVolatileShift = 15,
     MemorySemanticsMax = 0x7fffffff,
 };
 
@@ -651,6 +652,7 @@ enum MemorySemanticsMask {
     MemorySemanticsOutputMemoryKHRMask = 0x00001000,
     MemorySemanticsMakeAvailableKHRMask = 0x00002000,
     MemorySemanticsMakeVisibleKHRMask = 0x00004000,
+    MemorySemanticsVolatileMask = 0x00008000,
 };
 
 enum MemoryAccessShift {

--- a/include/spirv/unified1/spirv.hpp11
+++ b/include/spirv/unified1/spirv.hpp11
@@ -633,6 +633,7 @@ enum class MemorySemanticsShift : unsigned {
     OutputMemoryKHR = 12,
     MakeAvailableKHR = 13,
     MakeVisibleKHR = 14,
+    Volatile = 15,
     Max = 0x7fffffff,
 };
 
@@ -651,6 +652,7 @@ enum class MemorySemanticsMask : unsigned {
     OutputMemoryKHR = 0x00001000,
     MakeAvailableKHR = 0x00002000,
     MakeVisibleKHR = 0x00004000,
+    Volatile = 0x00008000,
 };
 
 enum class MemoryAccessShift : unsigned {

--- a/include/spirv/unified1/spirv.json
+++ b/include/spirv/unified1/spirv.json
@@ -654,7 +654,8 @@
                     "ImageMemory": 11,
                     "OutputMemoryKHR": 12,
                     "MakeAvailableKHR": 13,
-                    "MakeVisibleKHR": 14
+                    "MakeVisibleKHR": 14,
+                    "Volatile": 15
                 }
             },
             {

--- a/include/spirv/unified1/spirv.lua
+++ b/include/spirv/unified1/spirv.lua
@@ -601,6 +601,7 @@ spv = {
         OutputMemoryKHR = 12,
         MakeAvailableKHR = 13,
         MakeVisibleKHR = 14,
+        Volatile = 15,
     },
 
     MemorySemanticsMask = {
@@ -618,6 +619,7 @@ spv = {
         OutputMemoryKHR = 0x00001000,
         MakeAvailableKHR = 0x00002000,
         MakeVisibleKHR = 0x00004000,
+        Volatile = 0x00008000,
     },
 
     MemoryAccessShift = {

--- a/include/spirv/unified1/spirv.py
+++ b/include/spirv/unified1/spirv.py
@@ -428,7 +428,7 @@ spv = {
         'HlslCounterBufferGOOGLE' : 5634,
         'HlslSemanticGOOGLE' : 5635,
         'UserSemantic' : 5635,
-        'UserTypeGOOGLE' : 5635,
+        'UserTypeGOOGLE' : 5636,
     },
 
     'BuiltIn' : {
@@ -601,6 +601,7 @@ spv = {
         'OutputMemoryKHR' : 12,
         'MakeAvailableKHR' : 13,
         'MakeVisibleKHR' : 14,
+        'Volatile' : 15,
     },
 
     'MemorySemanticsMask' : {
@@ -618,6 +619,7 @@ spv = {
         'OutputMemoryKHR' : 0x00001000,
         'MakeAvailableKHR' : 0x00002000,
         'MakeVisibleKHR' : 0x00004000,
+        'Volatile' : 0x00008000,
     },
 
     'MemoryAccessShift' : {

--- a/include/spirv/unified1/spv.d
+++ b/include/spirv/unified1/spv.d
@@ -456,6 +456,7 @@ enum Decoration : uint
     HlslCounterBufferGOOGLE = 5634,
     HlslSemanticGOOGLE = 5635,
     UserSemantic = 5635,
+    UserTypeGOOGLE = 5636,
 }
 
 enum BuiltIn : uint
@@ -636,6 +637,7 @@ enum MemorySemanticsShift : uint
     OutputMemoryKHR = 12,
     MakeAvailableKHR = 13,
     MakeVisibleKHR = 14,
+    Volatile = 15,
 }
 
 enum MemorySemanticsMask : uint
@@ -654,6 +656,7 @@ enum MemorySemanticsMask : uint
     OutputMemoryKHR = 0x00001000,
     MakeAvailableKHR = 0x00002000,
     MakeVisibleKHR = 0x00004000,
+    Volatile = 0x00008000,
 }
 
 enum MemoryAccessShift : uint


### PR DESCRIPTION
From Khronos-internal issue 476: Update SPV_KHR_vulkan_memory_model
to be able to express volatile OpAtomic* operations.

Also regenerate the language-specific headers.  This step fixes
two problems with UserTypeGOOGLE in those headers.