### PR TITLE
Bump the SPIR-V version to 1.5

### DIFF
--- a/include/spirv/unified1/spirv.cs
+++ b/include/spirv/unified1/spirv.cs
@@ -48,7 +48,7 @@ namespace Spv
     public static class Specification
     {
         public const uint MagicNumber = 0x07230203;
-        public const uint Version = 0x00010400;
+        public const uint Version = 0x00010500;
         public const uint Revision = 1;
         public const uint OpCodeMask = 0xffff;
         public const uint WordCountShift = 16;

--- a/include/spirv/unified1/spirv.h
+++ b/include/spirv/unified1/spirv.h
@@ -53,7 +53,7 @@
 
 typedef unsigned int SpvId;
 
-#define SPV_VERSION 0x10400
+#define SPV_VERSION 0x10500
 #define SPV_REVISION 1
 
 static const unsigned int SpvMagicNumber = 0x07230203;

--- a/include/spirv/unified1/spirv.hpp
+++ b/include/spirv/unified1/spirv.hpp
@@ -49,7 +49,7 @@ namespace spv {
 
 typedef unsigned int Id;
 
-#define SPV_VERSION 0x10400
+#define SPV_VERSION 0x10500
 #define SPV_REVISION 1
 
 static const unsigned int MagicNumber = 0x07230203;

--- a/include/spirv/unified1/spirv.hpp11
+++ b/include/spirv/unified1/spirv.hpp11
@@ -49,7 +49,7 @@ namespace spv {
 
 typedef unsigned int Id;
 
-#define SPV_VERSION 0x10400
+#define SPV_VERSION 0x10500
 #define SPV_REVISION 1
 
 static const unsigned int MagicNumber = 0x07230203;

--- a/include/spirv/unified1/spirv.json
+++ b/include/spirv/unified1/spirv.json
@@ -54,7 +54,7 @@
                 ]
             ],
             "MagicNumber": 119734787,
-            "Version": 66560,
+            "Version": 66816,
             "Revision": 1,
             "OpCodeMask": 65535,
             "WordCountShift": 16

--- a/include/spirv/unified1/spirv.lua
+++ b/include/spirv/unified1/spirv.lua
@@ -44,7 +44,7 @@
 
 spv = {
     MagicNumber = 0x07230203,
-    Version = 0x00010400,
+    Version = 0x00010500,
     Revision = 1,
     OpCodeMask = 0xffff,
     WordCountShift = 16,

--- a/include/spirv/unified1/spirv.py
+++ b/include/spirv/unified1/spirv.py
@@ -44,7 +44,7 @@
 
 spv = {
     'MagicNumber' : 0x07230203,
-    'Version' : 0x00010400,
+    'Version' : 0x00010500,
     'Revision' : 1,
     'OpCodeMask' : 0xffff,
     'WordCountShift' : 16,

--- a/include/spirv/unified1/spv.d
+++ b/include/spirv/unified1/spv.d
@@ -51,7 +51,7 @@
 module spv;
 
 enum uint MagicNumber = 0x07230203;
-enum uint Version = 0x00010400;
+enum uint Version = 0x00010500;
 enum uint Revision = 1;
 enum uint OpCodeMask = 0xffff;
 enum uint WordCountShift = 16;


### PR DESCRIPTION
I think the commit 63d4d272f6e5b3cb9bb2bb50718a886a3eef4dab does not bump SPIR-V version. Please correct me if I'm wrong.