### PR TITLE
add cmake option SPIRV_HEADERS_SKIP_INSTALL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,9 +51,18 @@ add_custom_target(install-headers
 
 option(SPIRV_HEADERS_SKIP_EXAMPLES "Skip building examples"
       ${SPIRV_HEADERS_SKIP_EXAMPLES})
+
+option(SPIRV_HEADERS_SKIP_INSTALL "Skip install"
+      ${SPIRV_HEADERS_SKIP_INSTALL})
+
 if(NOT ${SPIRV_HEADERS_SKIP_EXAMPLES})
   set(SPIRV_HEADERS_ENABLE_EXAMPLES ON)
 endif()
+
+if(NOT ${SPIRV_HEADERS_SKIP_INSTALL})
+  set(SPIRV_HEADERS_ENABLE_INSTALL ON)
+endif()
+
 if (SPIRV_HEADERS_ENABLE_EXAMPLES)
   message(STATUS "Building SPIRV-Header examples")
   add_subdirectory(example)
@@ -67,49 +76,52 @@ target_include_directories(${PROJECT_NAME} INTERFACE
 
 # Installation
 
-set(config_install_dir "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
+if (SPIRV_HEADERS_ENABLE_INSTALL)
+    message(STATUS "Installing SPIRV-Header")
 
-set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")
+    set(config_install_dir "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
 
-set(version_config "${generated_dir}/${PROJECT_NAME}ConfigVersion.cmake")
-set(project_config "${generated_dir}/${PROJECT_NAME}Config.cmake")
-set(TARGETS_EXPORT_NAME "${PROJECT_NAME}Targets")
-set(namespace "${PROJECT_NAME}::")
+    set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")
 
-include(CMakePackageConfigHelpers)
-write_basic_package_version_file(
-    "${version_config}"
-    COMPATIBILITY SameMajorVersion
-)
+    set(version_config "${generated_dir}/${PROJECT_NAME}ConfigVersion.cmake")
+    set(project_config "${generated_dir}/${PROJECT_NAME}Config.cmake")
+    set(TARGETS_EXPORT_NAME "${PROJECT_NAME}Targets")
+    set(namespace "${PROJECT_NAME}::")
 
-configure_package_config_file(
-    "cmake/Config.cmake.in"
-    "${project_config}"
-    INSTALL_DESTINATION "${config_install_dir}"
-)
+    include(CMakePackageConfigHelpers)
+    write_basic_package_version_file(
+        "${version_config}"
+        COMPATIBILITY SameMajorVersion
+    )
 
-install(
-    TARGETS ${PROJECT_NAME}
-    EXPORT "${TARGETS_EXPORT_NAME}"
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-)
+    configure_package_config_file(
+        "cmake/Config.cmake.in"
+        "${project_config}"
+        INSTALL_DESTINATION "${config_install_dir}"
+    )
 
-install(
-    DIRECTORY include/spirv
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-)
+    install(
+        TARGETS ${PROJECT_NAME}
+        EXPORT "${TARGETS_EXPORT_NAME}"
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    )
 
-install(
-    FILES "${project_config}" "${version_config}"
-    DESTINATION "${config_install_dir}"
-)
+    install(
+        DIRECTORY include/spirv
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    )
 
-install(
-    EXPORT "${TARGETS_EXPORT_NAME}"
-    NAMESPACE "${namespace}"
-    DESTINATION "${config_install_dir}"
-)
+    install(
+        FILES "${project_config}" "${version_config}"
+        DESTINATION "${config_install_dir}"
+    )
 
+    install(
+        EXPORT "${TARGETS_EXPORT_NAME}"
+        NAMESPACE "${namespace}"
+        DESTINATION "${config_install_dir}"
+    )
+endif()


### PR DESCRIPTION
Add new CMake option SPIRV_HEADERS_SKIP_INSTALL to avoid installing spirv-headers if it is not required by upper component.