### PR TITLE
Fix Vulkan memory model's extension specification

### DIFF
--- a/include/spirv/unified1/spirv.core.grammar.json
+++ b/include/spirv/unified1/spirv.core.grammar.json
@@ -7118,6 +7118,7 @@
           "enumerant" : "Vulkan",
           "value" : 3,
           "capabilities" : [ "VulkanMemoryModel" ],
+          "extensions" : [ "SPV_KHR_vulkan_memory_model" ],
           "version" : "1.5"
         },
         {


### PR DESCRIPTION
VulkanKHR becomes Vulkan since SPIR-V 1.5; so Vulkan is just a symbol
duplicate of VulkanKHR. It should have all properties like VulkanKHR,
including the enabling extension.