### PR TITLE
Remove duplicated cases in favor of 'aliases' fields

### DIFF
--- a/include/spirv/unified1/spirv.core.grammar.json
+++ b/include/spirv/unified1/spirv.core.grammar.json
@@ -4902,31 +4902,8 @@
       "version" : "1.4"
     },
     {
-      "opname" : "OpDecorateStringGOOGLE",
-      "class"  : "Annotation",
-      "opcode" : 5632,
-      "operands" : [
-        { "kind" : "IdRef",         "name" : "'Target'" },
-        { "kind" : "Decoration" }
-      ],
-      "extensions" : [ "SPV_GOOGLE_decorate_string", "SPV_GOOGLE_hlsl_functionality1" ],
-      "version" : "1.4"
-    },
-    {
       "opname" : "OpMemberDecorateString",
       "aliases" : ["OpMemberDecorateStringGOOGLE"],
-      "class"  : "Annotation",
-      "opcode" : 5633,
-      "operands" : [
-        { "kind" : "IdRef",          "name" : "'Struct Type'" },
-        { "kind" : "LiteralInteger", "name" : "'Member'" },
-        { "kind" : "Decoration" }
-      ],
-      "extensions" : [ "SPV_GOOGLE_decorate_string", "SPV_GOOGLE_hlsl_functionality1" ],
-      "version" : "1.4"
-    },
-    {
-      "opname" : "OpMemberDecorateStringGOOGLE",
       "class"  : "Annotation",
       "opcode" : 5633,
       "operands" : [
@@ -6537,28 +6514,8 @@
           "version" : "1.5"
         },
         {
-          "enumerant" : "MakeTexelAvailableKHR",
-          "value" : "0x0100",
-          "capabilities" : [ "VulkanMemoryModel" ],
-          "parameters" : [
-            { "kind" : "IdScope" }
-          ],
-          "extensions" : [ "SPV_KHR_vulkan_memory_model" ],
-          "version" : "1.5"
-        },
-        {
           "enumerant" : "MakeTexelVisible",
           "aliases" : ["MakeTexelVisibleKHR"],
-          "value" : "0x0200",
-          "capabilities" : [ "VulkanMemoryModel" ],
-          "parameters" : [
-            { "kind" : "IdScope" }
-          ],
-          "extensions" : [ "SPV_KHR_vulkan_memory_model" ],
-          "version" : "1.5"
-        },
-        {
-          "enumerant" : "MakeTexelVisibleKHR",
           "value" : "0x0200",
           "capabilities" : [ "VulkanMemoryModel" ],
           "parameters" : [
@@ -6576,22 +6533,8 @@
           "version" : "1.5"
         },
         {
-          "enumerant" : "NonPrivateTexelKHR",
-          "value" : "0x0400",
-          "capabilities" : [ "VulkanMemoryModel" ],
-          "extensions" : [ "SPV_KHR_vulkan_memory_model" ],
-          "version" : "1.5"
-        },
-        {
           "enumerant" : "VolatileTexel",
           "aliases" : ["VolatileTexelKHR"],
-          "value" : "0x0800",
-          "capabilities" : [ "VulkanMemoryModel" ],
-          "extensions" : [ "SPV_KHR_vulkan_memory_model" ],
-          "version" : "1.5"
-        },
-        {
-          "enumerant" : "VolatileTexelKHR",
           "value" : "0x0800",
           "capabilities" : [ "VulkanMemoryModel" ],
           "extensions" : [ "SPV_KHR_vulkan_memory_model" ],
@@ -6769,10 +6712,6 @@
           "value" : "0x0000"
         },
         {
-          "enumerant" : "None",
-          "value" : "0x0000"
-        },
-        {
           "enumerant" : "Acquire",
           "value" : "0x0002"
         },
@@ -6823,13 +6762,6 @@
           "version" : "1.5"
         },
         {
-          "enumerant" : "OutputMemoryKHR",
-          "value" : "0x1000",
-          "capabilities" : [ "VulkanMemoryModel" ],
-          "extensions" : [ "SPV_KHR_vulkan_memory_model" ],
-          "version" : "1.5"
-        },
-        {
           "enumerant" : "MakeAvailable",
           "aliases" : ["MakeAvailableKHR"],
           "value" : "0x2000",
@@ -6838,22 +6770,8 @@
           "version" : "1.5"
         },
         {
-          "enumerant" : "MakeAvailableKHR",
-          "value" : "0x2000",
-          "capabilities" : [ "VulkanMemoryModel" ],
-          "extensions" : [ "SPV_KHR_vulkan_memory_model" ],
-          "version" : "1.5"
-        },
-        {
           "enumerant" : "MakeVisible",
           "aliases" : ["MakeVisibleKHR"],
-          "value" : "0x4000",
-          "capabilities" : [ "VulkanMemoryModel" ],
-          "extensions" : [ "SPV_KHR_vulkan_memory_model" ],
-          "version" : "1.5"
-        },
-        {
-          "enumerant" : "MakeVisibleKHR",
           "value" : "0x4000",
           "capabilities" : [ "VulkanMemoryModel" ],
           "extensions" : [ "SPV_KHR_vulkan_memory_model" ],
@@ -6903,16 +6821,6 @@
           "version" : "1.5"
         },
         {
-          "enumerant" : "MakePointerAvailableKHR",
-          "value" : "0x0008",
-          "parameters" : [
-            { "kind" : "IdScope" }
-          ],
-          "capabilities" : [ "VulkanMemoryModel" ],
-          "extensions" : [ "SPV_KHR_vulkan_memory_model" ],
-          "version" : "1.5"
-        },
-        {
           "enumerant" : "MakePointerVisible",
           "aliases" : ["MakePointerVisibleKHR"],
           "value" : "0x0010",
@@ -6924,25 +6832,8 @@
           "version" : "1.5"
         },
         {
-          "enumerant" : "MakePointerVisibleKHR",
-          "value" : "0x0010",
-          "parameters" : [
-            { "kind" : "IdScope" }
-          ],
-          "capabilities" : [ "VulkanMemoryModel" ],
-          "extensions" : [ "SPV_KHR_vulkan_memory_model" ],
-          "version" : "1.5"
-        },
-        {
           "enumerant" : "NonPrivatePointer",
           "aliases" : ["NonPrivatePointerKHR"],
-          "value" : "0x0020",
-          "capabilities" : [ "VulkanMemoryModel" ],
-          "extensions" : [ "SPV_KHR_vulkan_memory_model" ],
-          "version" : "1.5"
-        },
-        {
-          "enumerant" : "NonPrivatePointerKHR",
           "value" : "0x0020",
           "capabilities" : [ "VulkanMemoryModel" ],
           "extensions" : [ "SPV_KHR_vulkan_memory_model" ],
@@ -7109,13 +7000,6 @@
           "extensions" : [ "SPV_EXT_physical_storage_buffer", "SPV_KHR_physical_storage_buffer" ],
           "capabilities" : [ "PhysicalStorageBufferAddresses" ],
           "version" : "1.5"
-        },
-        {
-          "enumerant" : "PhysicalStorageBuffer64EXT",
-          "value" : 5348,
-          "extensions" : [ "SPV_EXT_physical_storage_buffer" ],
-          "capabilities" : [ "PhysicalStorageBufferAddresses" ],
-          "version" : "1.5"
         }
       ]
     },
@@ -7141,13 +7025,6 @@
         {
           "enumerant" : "Vulkan",
           "aliases" : ["VulkanKHR"],
-          "value" : 3,
-          "capabilities" : [ "VulkanMemoryModel" ],
-          "extensions" : [ "SPV_KHR_vulkan_memory_model" ],
-          "version" : "1.5"
-        },
-        {
-          "enumerant" : "VulkanKHR",
           "value" : 3,
           "capabilities" : [ "VulkanMemoryModel" ],
           "extensions" : [ "SPV_KHR_vulkan_memory_model" ],
@@ -7651,13 +7528,6 @@
           "aliases" : ["PhysicalStorageBufferEXT"],
           "value" : 5349,
           "extensions" : [ "SPV_EXT_physical_storage_buffer", "SPV_KHR_physical_storage_buffer" ],
-          "capabilities" : [ "PhysicalStorageBufferAddresses" ],
-          "version" : "1.5"
-        },
-        {
-          "enumerant" : "PhysicalStorageBufferEXT",
-          "value" : 5349,
-          "extensions" : [ "SPV_EXT_physical_storage_buffer" ],
           "capabilities" : [ "PhysicalStorageBufferAddresses" ],
           "version" : "1.5"
         }
@@ -8648,13 +8518,6 @@
           "version" : "1.5"
         },
         {
-          "enumerant" : "NonUniformEXT",
-          "value" : 5300,
-          "capabilities" : [ "ShaderNonUniform" ],
-          "extensions" : [ "SPV_EXT_descriptor_indexing" ],
-          "version" : "1.5"
-        },
-        {
           "enumerant" : "RestrictPointer",
           "aliases" : ["RestrictPointerEXT"],
           "value" : 5355,
@@ -8663,25 +8526,11 @@
           "version" : "1.5"
         },
         {
-          "enumerant" : "RestrictPointerEXT",
-          "value" : 5355,
-          "capabilities" : [ "PhysicalStorageBufferAddresses" ],
-          "extensions" : [ "SPV_EXT_physical_storage_buffer" ],
-          "version" : "1.5"
-        },
-        {
           "enumerant" : "AliasedPointer",
           "aliases" : ["AliasedPointerEXT"],
           "value" : 5356,
           "capabilities" : [ "PhysicalStorageBufferAddresses" ],
           "extensions" : [ "SPV_EXT_physical_storage_buffer", "SPV_KHR_physical_storage_buffer" ],
-          "version" : "1.5"
-        },
-        {
-          "enumerant" : "AliasedPointerEXT",
-          "value" : 5356,
-          "capabilities" : [ "PhysicalStorageBufferAddresses" ],
-          "extensions" : [ "SPV_EXT_physical_storage_buffer" ],
           "version" : "1.5"
         },
         {
@@ -8695,15 +8544,6 @@
           "version" : "1.4"
         },
         {
-          "enumerant" : "HlslCounterBufferGOOGLE",
-          "value" : 5634,
-          "parameters" : [
-            { "kind" : "IdRef", "name" : "'Counter Buffer'" }
-          ],
-          "extensions" : [ "SPV_GOOGLE_hlsl_functionality1" ],
-          "version" : "None"
-        },
-        {
           "enumerant" : "UserSemantic",
           "aliases" : ["HlslSemanticGOOGLE"],
           "value" : 5635,
@@ -8712,15 +8552,6 @@
           ],
           "extensions" : [ "SPV_GOOGLE_hlsl_functionality1" ],
           "version" : "1.4"
-        },
-        {
-          "enumerant" : "HlslSemanticGOOGLE",
-          "value" : 5635,
-          "parameters" : [
-            { "kind" : "LiteralString", "name" : "'Semantic'" }
-          ],
-          "extensions" : [ "SPV_GOOGLE_hlsl_functionality1" ],
-          "version" : "None"
         },
         {
           "enumerant" : "UserTypeGOOGLE",
@@ -8977,41 +8808,6 @@
           "version" : "1.3"
         },
         {
-          "enumerant" : "SubgroupEqMaskKHR",
-          "value" : 4416,
-          "capabilities" : [ "SubgroupBallotKHR", "GroupNonUniformBallot" ],
-          "extensions" : [ "SPV_KHR_shader_ballot" ],
-          "version" : "1.3"
-        },
-        {
-          "enumerant" : "SubgroupGeMaskKHR",
-          "value" : 4417,
-          "capabilities" : [ "SubgroupBallotKHR", "GroupNonUniformBallot" ],
-          "extensions" : [ "SPV_KHR_shader_ballot" ],
-          "version" : "1.3"
-        },
-        {
-          "enumerant" : "SubgroupGtMaskKHR",
-          "value" : 4418,
-          "capabilities" : [ "SubgroupBallotKHR", "GroupNonUniformBallot" ],
-          "extensions" : [ "SPV_KHR_shader_ballot" ],
-          "version" : "1.3"
-        },
-        {
-          "enumerant" : "SubgroupLeMaskKHR",
-          "value" : 4419,
-          "capabilities" : [ "SubgroupBallotKHR", "GroupNonUniformBallot" ],
-          "extensions" : [ "SPV_KHR_shader_ballot" ],
-          "version" : "1.3"
-        },
-        {
-          "enumerant" : "SubgroupLtMaskKHR",
-          "value" : 4420,
-          "capabilities" : [ "SubgroupBallotKHR", "GroupNonUniformBallot" ],
-          "extensions" : [ "SPV_KHR_shader_ballot" ],
-          "version" : "1.3"
-        },
-        {
           "enumerant" : "BaseVertex",
           "value" : 4424,
           "capabilities" : [ "DrawParameters" ],
@@ -9216,25 +9012,11 @@
           "version" : "None"
         },
         {
-          "enumerant" : "FragmentSizeNV",
-          "value" : 5292 ,
-          "capabilities" : [ "ShadingRateNV", "FragmentDensityEXT" ],
-          "extensions" : [ "SPV_NV_shading_rate", "SPV_EXT_fragment_invocation_density" ],
-          "version" : "None"
-        },
-        {
           "enumerant" : "FragInvocationCountEXT",
           "aliases" : ["InvocationsPerPixelNV"],
           "value" : 5293,
           "capabilities" : [ "FragmentDensityEXT", "ShadingRateNV" ],
           "extensions" : [ "SPV_EXT_fragment_invocation_density", "SPV_NV_shading_rate" ],
-          "version" : "None"
-        },
-        {
-          "enumerant" : "InvocationsPerPixelNV",
-          "value" : 5293,
-          "capabilities" : [ "ShadingRateNV", "FragmentDensityEXT" ],
-          "extensions" : [ "SPV_NV_shading_rate", "SPV_EXT_fragment_invocation_density" ],
           "version" : "None"
         },
         {
@@ -9392,12 +9174,6 @@
         {
           "enumerant" : "QueueFamily",
           "aliases" : ["QueueFamilyKHR"],
-          "value" : 5,
-          "capabilities" : [ "VulkanMemoryModel" ],
-          "version" : "1.5"
-        },
-        {
-          "enumerant" : "QueueFamilyKHR",
           "value" : 5,
           "capabilities" : [ "VulkanMemoryModel" ],
           "version" : "1.5"
@@ -9848,22 +9624,6 @@
           "version" : "1.3"
         },
         {
-          "enumerant" : "StorageUniformBufferBlock16",
-          "value" : 4433,
-          "extensions" : [ "SPV_KHR_16bit_storage" ],
-          "version" : "1.3"
-        },
-        {
-          "enumerant" : "UniformAndStorageBuffer16BitAccess",
-          "value" : 4434,
-          "capabilities" : [
-            "StorageBuffer16BitAccess",
-            "StorageUniformBufferBlock16"
-          ],
-          "extensions" : [ "SPV_KHR_16bit_storage" ],
-          "version" : "1.3"
-        },
-        {
           "enumerant" : "StorageUniform16",
           "aliases" : ["UniformAndStorageBuffer16BitAccess"],
           "value" : 4434,
@@ -10039,13 +9799,6 @@
           "version" : "None"
         },
         {
-          "enumerant" : "ShaderViewportIndexLayerNV",
-          "value" : 5254,
-          "capabilities" : [ "MultiViewport" ],
-          "extensions" : [ "SPV_NV_viewport_array2" ],
-          "version" : "None"
-        },
-        {
           "enumerant" : "ShaderViewportMaskNV",
           "value" : 5255,
           "capabilities" : [ "ShaderViewportIndexLayerNV" ],
@@ -10107,13 +9860,6 @@
           "version" : "None"
         },
         {
-          "enumerant" : "ShadingRateNV",
-          "value" : 5291,
-          "capabilities" : [ "Shader" ],
-          "extensions" : [ "SPV_NV_shading_rate", "SPV_EXT_fragment_invocation_density" ],
-          "version" : "None"
-        },
-        {
           "enumerant" : "GroupNonUniformPartitionedNV",
           "value" : 5297,
           "extensions" : [ "SPV_NV_shader_subgroup_partitioned" ],
@@ -10128,22 +9874,8 @@
           "version" : "1.5"
         },
         {
-          "enumerant" : "ShaderNonUniformEXT",
-          "value" : 5301,
-          "capabilities" : [ "Shader" ],
-          "extensions" : [ "SPV_EXT_descriptor_indexing" ],
-          "version" : "1.5"
-        },
-        {
           "enumerant" : "RuntimeDescriptorArray",
           "aliases" : ["RuntimeDescriptorArrayEXT"],
-          "value" : 5302,
-          "capabilities" : [ "Shader" ],
-          "extensions" : [ "SPV_EXT_descriptor_indexing" ],
-          "version" : "1.5"
-        },
-        {
-          "enumerant" : "RuntimeDescriptorArrayEXT",
           "value" : 5302,
           "capabilities" : [ "Shader" ],
           "extensions" : [ "SPV_EXT_descriptor_indexing" ],
@@ -10158,22 +9890,8 @@
           "version" : "1.5"
         },
         {
-          "enumerant" : "InputAttachmentArrayDynamicIndexingEXT",
-          "value" : 5303,
-          "capabilities" : [ "InputAttachment" ],
-          "extensions" : [ "SPV_EXT_descriptor_indexing" ],
-          "version" : "1.5"
-        },
-        {
           "enumerant" : "UniformTexelBufferArrayDynamicIndexing",
           "aliases" : ["UniformTexelBufferArrayDynamicIndexingEXT"],
-          "value" : 5304,
-          "capabilities" : [ "SampledBuffer" ],
-          "extensions" : [ "SPV_EXT_descriptor_indexing" ],
-          "version" : "1.5"
-        },
-        {
-          "enumerant" : "UniformTexelBufferArrayDynamicIndexingEXT",
           "value" : 5304,
           "capabilities" : [ "SampledBuffer" ],
           "extensions" : [ "SPV_EXT_descriptor_indexing" ],
@@ -10188,22 +9906,8 @@
           "version" : "1.5"
         },
         {
-          "enumerant" : "StorageTexelBufferArrayDynamicIndexingEXT",
-          "value" : 5305,
-          "capabilities" : [ "ImageBuffer" ],
-          "extensions" : [ "SPV_EXT_descriptor_indexing" ],
-          "version" : "1.5"
-        },
-        {
           "enumerant" : "UniformBufferArrayNonUniformIndexing",
           "aliases" : ["UniformBufferArrayNonUniformIndexingEXT"],
-          "value" : 5306,
-          "capabilities" : [ "ShaderNonUniform" ],
-          "extensions" : [ "SPV_EXT_descriptor_indexing" ],
-          "version" : "1.5"
-        },
-        {
-          "enumerant" : "UniformBufferArrayNonUniformIndexingEXT",
           "value" : 5306,
           "capabilities" : [ "ShaderNonUniform" ],
           "extensions" : [ "SPV_EXT_descriptor_indexing" ],
@@ -10218,22 +9922,8 @@
           "version" : "1.5"
         },
         {
-          "enumerant" : "SampledImageArrayNonUniformIndexingEXT",
-          "value" : 5307,
-          "capabilities" : [ "ShaderNonUniform" ],
-          "extensions" : [ "SPV_EXT_descriptor_indexing" ],
-          "version" : "1.5"
-        },
-        {
           "enumerant" : "StorageBufferArrayNonUniformIndexing",
           "aliases" : ["StorageBufferArrayNonUniformIndexingEXT"],
-          "value" : 5308,
-          "capabilities" : [ "ShaderNonUniform" ],
-          "extensions" : [ "SPV_EXT_descriptor_indexing" ],
-          "version" : "1.5"
-        },
-        {
-          "enumerant" : "StorageBufferArrayNonUniformIndexingEXT",
           "value" : 5308,
           "capabilities" : [ "ShaderNonUniform" ],
           "extensions" : [ "SPV_EXT_descriptor_indexing" ],
@@ -10248,22 +9938,8 @@
           "version" : "1.5"
         },
         {
-          "enumerant" : "StorageImageArrayNonUniformIndexingEXT",
-          "value" : 5309,
-          "capabilities" : [ "ShaderNonUniform" ],
-          "extensions" : [ "SPV_EXT_descriptor_indexing" ],
-          "version" : "1.5"
-        },
-        {
           "enumerant" : "InputAttachmentArrayNonUniformIndexing",
           "aliases" : ["InputAttachmentArrayNonUniformIndexingEXT"],
-          "value" : 5310,
-          "capabilities" : [ "InputAttachment", "ShaderNonUniform" ],
-          "extensions" : [ "SPV_EXT_descriptor_indexing" ],
-          "version" : "1.5"
-        },
-        {
-          "enumerant" : "InputAttachmentArrayNonUniformIndexingEXT",
           "value" : 5310,
           "capabilities" : [ "InputAttachment", "ShaderNonUniform" ],
           "extensions" : [ "SPV_EXT_descriptor_indexing" ],
@@ -10278,22 +9954,8 @@
           "version" : "1.5"
         },
         {
-          "enumerant" : "UniformTexelBufferArrayNonUniformIndexingEXT",
-          "value" : 5311,
-          "capabilities" : [ "SampledBuffer", "ShaderNonUniform" ],
-          "extensions" : [ "SPV_EXT_descriptor_indexing" ],
-          "version" : "1.5"
-        },
-        {
           "enumerant" : "StorageTexelBufferArrayNonUniformIndexing",
           "aliases" : ["StorageTexelBufferArrayNonUniformIndexingEXT"],
-          "value" : 5312,
-          "capabilities" : [ "ImageBuffer", "ShaderNonUniform" ],
-          "extensions" : [ "SPV_EXT_descriptor_indexing" ],
-          "version" : "1.5"
-        },
-        {
-          "enumerant" : "StorageTexelBufferArrayNonUniformIndexingEXT",
           "value" : 5312,
           "capabilities" : [ "ImageBuffer", "ShaderNonUniform" ],
           "extensions" : [ "SPV_EXT_descriptor_indexing" ],
@@ -10314,20 +9976,8 @@
           "version" : "1.5"
         },
         {
-          "enumerant" : "VulkanMemoryModelKHR",
-          "value" : 5345,
-          "extensions" : [ "SPV_KHR_vulkan_memory_model" ],
-          "version" : "1.5"
-        },
-        {
           "enumerant" : "VulkanMemoryModelDeviceScope",
           "aliases" : ["VulkanMemoryModelDeviceScopeKHR"],
-          "value" : 5346,
-          "extensions" : [ "SPV_KHR_vulkan_memory_model" ],
-          "version" : "1.5"
-        },
-        {
-          "enumerant" : "VulkanMemoryModelDeviceScopeKHR",
           "value" : 5346,
           "extensions" : [ "SPV_KHR_vulkan_memory_model" ],
           "version" : "1.5"
@@ -10338,13 +9988,6 @@
           "value" : 5347,
           "capabilities" : [ "Shader" ],
           "extensions" : [ "SPV_EXT_physical_storage_buffer", "SPV_KHR_physical_storage_buffer" ],
-          "version" : "1.5"
-        },
-        {
-          "enumerant" : "PhysicalStorageBufferAddressesEXT",
-          "value" : 5347,
-          "capabilities" : [ "Shader" ],
-          "extensions" : [ "SPV_EXT_physical_storage_buffer" ],
           "version" : "1.5"
         },
         {

--- a/include/spirv/unified1/spirv.core.grammar.json
+++ b/include/spirv/unified1/spirv.core.grammar.json
@@ -4891,6 +4891,7 @@
     },
     {
       "opname" : "OpDecorateString",
+      "aliases" : ["OpDecorateStringGOOGLE"],
       "class"  : "Annotation",
       "opcode" : 5632,
       "operands" : [
@@ -4913,6 +4914,7 @@
     },
     {
       "opname" : "OpMemberDecorateString",
+      "aliases" : ["OpMemberDecorateStringGOOGLE"],
       "class"  : "Annotation",
       "opcode" : 5633,
       "operands" : [
@@ -6525,11 +6527,13 @@
         },
         {
           "enumerant" : "MakeTexelAvailable",
+          "aliases" : ["MakeTexelAvailableKHR"],
           "value" : "0x0100",
           "capabilities" : [ "VulkanMemoryModel" ],
           "parameters" : [
             { "kind" : "IdScope" }
           ],
+          "extensions" : [ "SPV_KHR_vulkan_memory_model" ],
           "version" : "1.5"
         },
         {
@@ -6544,11 +6548,13 @@
         },
         {
           "enumerant" : "MakeTexelVisible",
+          "aliases" : ["MakeTexelVisibleKHR"],
           "value" : "0x0200",
           "capabilities" : [ "VulkanMemoryModel" ],
           "parameters" : [
             { "kind" : "IdScope" }
           ],
+          "extensions" : [ "SPV_KHR_vulkan_memory_model" ],
           "version" : "1.5"
         },
         {
@@ -6563,8 +6569,10 @@
         },
         {
           "enumerant" : "NonPrivateTexel",
+          "aliases" : ["NonPrivateTexelKHR"],
           "value" : "0x0400",
           "capabilities" : [ "VulkanMemoryModel" ],
+          "extensions" : [ "SPV_KHR_vulkan_memory_model" ],
           "version" : "1.5"
         },
         {
@@ -6576,8 +6584,10 @@
         },
         {
           "enumerant" : "VolatileTexel",
+          "aliases" : ["VolatileTexelKHR"],
           "value" : "0x0800",
           "capabilities" : [ "VulkanMemoryModel" ],
+          "extensions" : [ "SPV_KHR_vulkan_memory_model" ],
           "version" : "1.5"
         },
         {
@@ -6755,6 +6765,7 @@
       "enumerants" : [
         {
           "enumerant" : "Relaxed",
+          "aliases": ["None"],
           "value" : "0x0000"
         },
         {
@@ -6805,8 +6816,10 @@
         },
         {
           "enumerant" : "OutputMemory",
+          "aliases" : ["OutputMemoryKHR"],
           "value" : "0x1000",
           "capabilities" : [ "VulkanMemoryModel" ],
+          "extensions" : [ "SPV_KHR_vulkan_memory_model" ],
           "version" : "1.5"
         },
         {
@@ -6818,8 +6831,10 @@
         },
         {
           "enumerant" : "MakeAvailable",
+          "aliases" : ["MakeAvailableKHR"],
           "value" : "0x2000",
           "capabilities" : [ "VulkanMemoryModel" ],
+          "extensions" : [ "SPV_KHR_vulkan_memory_model" ],
           "version" : "1.5"
         },
         {
@@ -6831,8 +6846,10 @@
         },
         {
           "enumerant" : "MakeVisible",
+          "aliases" : ["MakeVisibleKHR"],
           "value" : "0x4000",
           "capabilities" : [ "VulkanMemoryModel" ],
+          "extensions" : [ "SPV_KHR_vulkan_memory_model" ],
           "version" : "1.5"
         },
         {
@@ -6876,11 +6893,13 @@
         },
         {
           "enumerant" : "MakePointerAvailable",
+          "aliases" : ["MakePointerAvailableKHR"],
           "value" : "0x0008",
           "parameters" : [
             { "kind" : "IdScope" }
           ],
           "capabilities" : [ "VulkanMemoryModel" ],
+          "extensions" : [ "SPV_KHR_vulkan_memory_model" ],
           "version" : "1.5"
         },
         {
@@ -6895,11 +6914,13 @@
         },
         {
           "enumerant" : "MakePointerVisible",
+          "aliases" : ["MakePointerVisibleKHR"],
           "value" : "0x0010",
           "parameters" : [
             { "kind" : "IdScope" }
           ],
           "capabilities" : [ "VulkanMemoryModel" ],
+          "extensions" : [ "SPV_KHR_vulkan_memory_model" ],
           "version" : "1.5"
         },
         {
@@ -6914,8 +6935,10 @@
         },
         {
           "enumerant" : "NonPrivatePointer",
+          "aliases" : ["NonPrivatePointerKHR"],
           "value" : "0x0020",
           "capabilities" : [ "VulkanMemoryModel" ],
+          "extensions" : [ "SPV_KHR_vulkan_memory_model" ],
           "version" : "1.5"
         },
         {
@@ -7081,6 +7104,7 @@
         },
         {
           "enumerant" : "PhysicalStorageBuffer64",
+          "aliases" : ["PhysicalStorageBuffer64EXT"],
           "value" : 5348,
           "extensions" : [ "SPV_EXT_physical_storage_buffer", "SPV_KHR_physical_storage_buffer" ],
           "capabilities" : [ "PhysicalStorageBufferAddresses" ],
@@ -7116,8 +7140,10 @@
         },
         {
           "enumerant" : "Vulkan",
+          "aliases" : ["VulkanKHR"],
           "value" : 3,
           "capabilities" : [ "VulkanMemoryModel" ],
+          "extensions" : [ "SPV_KHR_vulkan_memory_model" ],
           "version" : "1.5"
         },
         {
@@ -7622,6 +7648,7 @@
         },
         {
           "enumerant" : "PhysicalStorageBuffer",
+          "aliases" : ["PhysicalStorageBufferEXT"],
           "value" : 5349,
           "extensions" : [ "SPV_EXT_physical_storage_buffer", "SPV_KHR_physical_storage_buffer" ],
           "capabilities" : [ "PhysicalStorageBufferAddresses" ],
@@ -8614,8 +8641,10 @@
         },
         {
           "enumerant" : "NonUniform",
+          "aliases" : ["NonUniformEXT"],
           "value" : 5300,
           "capabilities" : [ "ShaderNonUniform" ],
+          "extensions" : [ "SPV_EXT_descriptor_indexing" ],
           "version" : "1.5"
         },
         {
@@ -8627,6 +8656,7 @@
         },
         {
           "enumerant" : "RestrictPointer",
+          "aliases" : ["RestrictPointerEXT"],
           "value" : 5355,
           "capabilities" : [ "PhysicalStorageBufferAddresses" ],
           "extensions" : [ "SPV_EXT_physical_storage_buffer", "SPV_KHR_physical_storage_buffer" ],
@@ -8641,6 +8671,7 @@
         },
         {
           "enumerant" : "AliasedPointer",
+          "aliases" : ["AliasedPointerEXT"],
           "value" : 5356,
           "capabilities" : [ "PhysicalStorageBufferAddresses" ],
           "extensions" : [ "SPV_EXT_physical_storage_buffer", "SPV_KHR_physical_storage_buffer" ],
@@ -8655,10 +8686,12 @@
         },
         {
           "enumerant" : "CounterBuffer",
+          "aliases" : ["HlslCounterBufferGOOGLE"],
           "value" : 5634,
           "parameters" : [
             { "kind" : "IdRef", "name" : "'Counter Buffer'" }
           ],
+          "extensions" : [ "SPV_GOOGLE_hlsl_functionality1" ],
           "version" : "1.4"
         },
         {
@@ -8672,10 +8705,12 @@
         },
         {
           "enumerant" : "UserSemantic",
+          "aliases" : ["HlslSemanticGOOGLE"],
           "value" : 5635,
           "parameters" : [
             { "kind" : "LiteralString", "name" : "'Semantic'" }
           ],
+          "extensions" : [ "SPV_GOOGLE_hlsl_functionality1" ],
           "version" : "1.4"
         },
         {
@@ -8903,32 +8938,42 @@
         },
         {
           "enumerant" : "SubgroupEqMask",
+          "aliases" : ["SubgroupEqMaskKHR"],
           "value" : 4416,
           "capabilities" : [ "SubgroupBallotKHR", "GroupNonUniformBallot" ],
+          "extensions" : [ "SPV_KHR_shader_ballot" ],
           "version" : "1.3"
         },
         {
           "enumerant" : "SubgroupGeMask",
+          "aliases" : ["SubgroupGeMaskKHR"],
           "value" : 4417,
           "capabilities" : [ "SubgroupBallotKHR", "GroupNonUniformBallot" ],
+          "extensions" : [ "SPV_KHR_shader_ballot" ],
           "version" : "1.3"
         },
         {
           "enumerant" : "SubgroupGtMask",
+          "aliases" : ["SubgroupGtMaskKHR"],
           "value" : 4418,
           "capabilities" : [ "SubgroupBallotKHR", "GroupNonUniformBallot" ],
+          "extensions" : [ "SPV_KHR_shader_ballot" ],
           "version" : "1.3"
         },
         {
           "enumerant" : "SubgroupLeMask",
+          "aliases" : ["SubgroupLeMaskKHR"],
           "value" : 4419,
           "capabilities" : [ "SubgroupBallotKHR", "GroupNonUniformBallot" ],
+          "extensions" : [ "SPV_KHR_shader_ballot" ],
           "version" : "1.3"
         },
         {
           "enumerant" : "SubgroupLtMask",
+          "aliases" : ["SubgroupLtMaskKHR"],
           "value" : 4420,
           "capabilities" : [ "SubgroupBallotKHR", "GroupNonUniformBallot" ],
+          "extensions" : [ "SPV_KHR_shader_ballot" ],
           "version" : "1.3"
         },
         {
@@ -9164,6 +9209,7 @@
         },
         {
           "enumerant" : "FragSizeEXT",
+          "aliases" : ["FragmentSizeNV"],
           "value" : 5292 ,
           "capabilities" : [ "FragmentDensityEXT", "ShadingRateNV" ],
           "extensions" : [ "SPV_EXT_fragment_invocation_density", "SPV_NV_shading_rate" ],
@@ -9178,6 +9224,7 @@
         },
         {
           "enumerant" : "FragInvocationCountEXT",
+          "aliases" : ["InvocationsPerPixelNV"],
           "value" : 5293,
           "capabilities" : [ "FragmentDensityEXT", "ShadingRateNV" ],
           "extensions" : [ "SPV_EXT_fragment_invocation_density", "SPV_NV_shading_rate" ],
@@ -9344,6 +9391,7 @@
         },
         {
           "enumerant" : "QueueFamily",
+          "aliases" : ["QueueFamilyKHR"],
           "value" : 5,
           "capabilities" : [ "VulkanMemoryModel" ],
           "version" : "1.5"
@@ -9794,6 +9842,7 @@
         },
         {
           "enumerant" : "StorageBuffer16BitAccess",
+          "aliases" : ["StorageUniformBufferBlock16"],
           "value" : 4433,
           "extensions" : [ "SPV_KHR_16bit_storage" ],
           "version" : "1.3"
@@ -9816,6 +9865,7 @@
         },
         {
           "enumerant" : "StorageUniform16",
+          "aliases" : ["UniformAndStorageBuffer16BitAccess"],
           "value" : 4434,
           "capabilities" : [
             "StorageBuffer16BitAccess",
@@ -9982,9 +10032,10 @@
         },
         {
           "enumerant" : "ShaderViewportIndexLayerEXT",
+          "aliases" : ["ShaderViewportIndexLayerNV"],
           "value" : 5254,
           "capabilities" : [ "MultiViewport" ],
-          "extensions" : [ "SPV_EXT_shader_viewport_index_layer" ],
+          "extensions" : [ "SPV_EXT_shader_viewport_index_layer", "SPV_NV_viewport_array2" ],
           "version" : "None"
         },
         {
@@ -10049,6 +10100,7 @@
         },
         {
           "enumerant" : "FragmentDensityEXT",
+          "aliases" : ["ShadingRateNV"],
           "value" : 5291,
           "capabilities" : [ "Shader" ],
           "extensions" : [ "SPV_EXT_fragment_invocation_density", "SPV_NV_shading_rate" ],
@@ -10069,8 +10121,10 @@
         },
         {
           "enumerant" : "ShaderNonUniform",
+          "aliases" : ["ShaderNonUniformEXT"],
           "value" : 5301,
           "capabilities" : [ "Shader" ],
+          "extensions" : [ "SPV_EXT_descriptor_indexing" ],
           "version" : "1.5"
         },
         {
@@ -10082,8 +10136,10 @@
         },
         {
           "enumerant" : "RuntimeDescriptorArray",
+          "aliases" : ["RuntimeDescriptorArrayEXT"],
           "value" : 5302,
           "capabilities" : [ "Shader" ],
+          "extensions" : [ "SPV_EXT_descriptor_indexing" ],
           "version" : "1.5"
         },
         {
@@ -10095,8 +10151,10 @@
         },
         {
           "enumerant" : "InputAttachmentArrayDynamicIndexing",
+          "aliases" : ["InputAttachmentArrayDynamicIndexingEXT"],
           "value" : 5303,
           "capabilities" : [ "InputAttachment" ],
+          "extensions" : [ "SPV_EXT_descriptor_indexing" ],
           "version" : "1.5"
         },
         {
@@ -10108,8 +10166,10 @@
         },
         {
           "enumerant" : "UniformTexelBufferArrayDynamicIndexing",
+          "aliases" : ["UniformTexelBufferArrayDynamicIndexingEXT"],
           "value" : 5304,
           "capabilities" : [ "SampledBuffer" ],
+          "extensions" : [ "SPV_EXT_descriptor_indexing" ],
           "version" : "1.5"
         },
         {
@@ -10121,8 +10181,10 @@
         },
         {
           "enumerant" : "StorageTexelBufferArrayDynamicIndexing",
+          "aliases" : ["StorageTexelBufferArrayDynamicIndexingEXT"],
           "value" : 5305,
           "capabilities" : [ "ImageBuffer" ],
+          "extensions" : [ "SPV_EXT_descriptor_indexing" ],
           "version" : "1.5"
         },
         {
@@ -10134,8 +10196,10 @@
         },
         {
           "enumerant" : "UniformBufferArrayNonUniformIndexing",
+          "aliases" : ["UniformBufferArrayNonUniformIndexingEXT"],
           "value" : 5306,
           "capabilities" : [ "ShaderNonUniform" ],
+          "extensions" : [ "SPV_EXT_descriptor_indexing" ],
           "version" : "1.5"
         },
         {
@@ -10147,8 +10211,10 @@
         },
         {
           "enumerant" : "SampledImageArrayNonUniformIndexing",
+          "aliases" : ["SampledImageArrayNonUniformIndexingEXT"],
           "value" : 5307,
           "capabilities" : [ "ShaderNonUniform" ],
+          "extensions" : [ "SPV_EXT_descriptor_indexing" ],
           "version" : "1.5"
         },
         {
@@ -10160,8 +10226,10 @@
         },
         {
           "enumerant" : "StorageBufferArrayNonUniformIndexing",
+          "aliases" : ["StorageBufferArrayNonUniformIndexingEXT"],
           "value" : 5308,
           "capabilities" : [ "ShaderNonUniform" ],
+          "extensions" : [ "SPV_EXT_descriptor_indexing" ],
           "version" : "1.5"
         },
         {
@@ -10173,8 +10241,10 @@
         },
         {
           "enumerant" : "StorageImageArrayNonUniformIndexing",
+          "aliases" : ["StorageImageArrayNonUniformIndexingEXT"],
           "value" : 5309,
           "capabilities" : [ "ShaderNonUniform" ],
+          "extensions" : [ "SPV_EXT_descriptor_indexing" ],
           "version" : "1.5"
         },
         {
@@ -10186,8 +10256,10 @@
         },
         {
           "enumerant" : "InputAttachmentArrayNonUniformIndexing",
+          "aliases" : ["InputAttachmentArrayNonUniformIndexingEXT"],
           "value" : 5310,
           "capabilities" : [ "InputAttachment", "ShaderNonUniform" ],
+          "extensions" : [ "SPV_EXT_descriptor_indexing" ],
           "version" : "1.5"
         },
         {
@@ -10199,8 +10271,10 @@
         },
         {
           "enumerant" : "UniformTexelBufferArrayNonUniformIndexing",
+          "aliases" : ["UniformTexelBufferArrayNonUniformIndexingEXT"],
           "value" : 5311,
           "capabilities" : [ "SampledBuffer", "ShaderNonUniform" ],
+          "extensions" : [ "SPV_EXT_descriptor_indexing" ],
           "version" : "1.5"
         },
         {
@@ -10212,8 +10286,10 @@
         },
         {
           "enumerant" : "StorageTexelBufferArrayNonUniformIndexing",
+          "aliases" : ["StorageTexelBufferArrayNonUniformIndexingEXT"],
           "value" : 5312,
           "capabilities" : [ "ImageBuffer", "ShaderNonUniform" ],
+          "extensions" : [ "SPV_EXT_descriptor_indexing" ],
           "version" : "1.5"
         },
         {
@@ -10232,7 +10308,9 @@
         },
         {
           "enumerant" : "VulkanMemoryModel",
+          "aliases" : ["VulkanMemoryModelKHR"],
           "value" : 5345,
+          "extensions" : [ "SPV_KHR_vulkan_memory_model" ],
           "version" : "1.5"
         },
         {
@@ -10243,7 +10321,9 @@
         },
         {
           "enumerant" : "VulkanMemoryModelDeviceScope",
+          "aliases" : ["VulkanMemoryModelDeviceScopeKHR"],
           "value" : 5346,
+          "extensions" : [ "SPV_KHR_vulkan_memory_model" ],
           "version" : "1.5"
         },
         {
@@ -10254,6 +10334,7 @@
         },
         {
           "enumerant" : "PhysicalStorageBufferAddresses",
+          "aliases" : ["PhysicalStorageBufferAddressesEXT"],
           "value" : 5347,
           "capabilities" : [ "Shader" ],
           "extensions" : [ "SPV_EXT_physical_storage_buffer", "SPV_KHR_physical_storage_buffer" ],


### PR DESCRIPTION
This is built on top of #138: the first commit is from #138, so only the second one is interesting here.