### PR TITLE
Add BUILD.gn

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1,0 +1,32 @@
+# Copyright 2020 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+config("spv_headers_public_config") {
+  include_dirs = [ "include" ]
+}
+
+source_set("spv_headers") {
+  sources = [
+    "include/spirv/1.2/GLSL.std.450.h",
+    "include/spirv/1.2/OpenCL.std.h",
+    "include/spirv/1.2/spirv.h",
+    "include/spirv/1.2/spirv.hpp",
+    "include/spirv/unified1/GLSL.std.450.h",
+    "include/spirv/unified1/OpenCL.std.h",
+    "include/spirv/unified1/spirv.h",
+    "include/spirv/unified1/spirv.hpp",
+  ]
+
+  public_configs = [ ":spv_headers_public_config" ]
+}


### PR DESCRIPTION
Allows gn builds to include files from spirv-headers.