### PR TITLE
OpCopyMemory and OpCopyMemorySized grammar type fixed.

### DIFF
--- a/include/spirv/unified1/spirv.core.grammar.json
+++ b/include/spirv/unified1/spirv.core.grammar.json
@@ -682,7 +682,6 @@
         { "kind" : "IdRef",                            "name" : "'Target'" },
         { "kind" : "IdRef",                            "name" : "'Source'" },
         { "kind" : "MemoryAccess", "quantifier" : "?" },
-        { "kind" : "MemoryAccess", "quantifier" : "?" }
       ]
     },
     {
@@ -694,7 +693,6 @@
         { "kind" : "IdRef",                            "name" : "'Source'" },
         { "kind" : "IdRef",                            "name" : "'Size'" },
         { "kind" : "MemoryAccess", "quantifier" : "?" },
-        { "kind" : "MemoryAccess", "quantifier" : "?" }
       ],
       "capabilities" : [ "Addresses" ]
     },


### PR DESCRIPTION
It seems that OpCopyMemory and OpCopyMemorySized has duplicated MemoryAccess access operand.