### PR TITLE
Propose bit allocation mechanism for the FP Fast Math Mode bitfield

### DIFF
--- a/include/spirv/spir-v.xml
+++ b/include/spirv/spir-v.xml
@@ -143,4 +143,22 @@
     <ids type="LoopControl" start="23" end="30" comment="Unreserved bits reservable for use by vendors"/>
     <ids type="LoopControl" start="31" end="31" vendor="Khronos" comment="Reserved LoopControl bit, not available to vendors"/>
 
+
+    <!-- SECTION: SPIR-V FP Fast Math Mode Bit Reservations -->
+    <!-- Reserve ranges of bits in the “FP Fast Math Mode” bitfield.
+         Each vendor determines the use of values in their own ranges.
+         Vendors are not required to disclose those uses.  If the use of a
+         value is included in an extension that is adopted by a Khronos
+         extension or specification, then that value's use may be permanently
+         fixed as if originally reserved in a Khronos range.
+         The SPIR Working Group strongly recommends:
+         - Each value is used for only one purpose.
+         - All values in a range should be used before allocating a new range.
+         -->
+
+    <!-- Reserved FP fast math mode bits -->
+    <ids type="FPFastMathMode" start="0" end="15" vendor="Khronos" comment="Reserved FPFastMathMode bits, not available to vendors - see the SPIR-V Specification"/>
+    <ids type="FPFastMathMode" start="16" end="17" vendor="Intel" comment="Contact michael.kinsner@intel.com"/>
+    <ids type="FPFastMathMode" start="18" end="31" comment="Unreserved bits reservable for use by vendors"/>
+
 </registry>


### PR DESCRIPTION
Intel would like to use some FP fast math mode bitfield values for what will start as a vendor extension.  As far as we know there is no way to manage allocation of bits across vendors, so this PR adds a section to the XML with the same mechanism as was previously added for the loop control bitfield.