### PR TITLE
Register the Xenia emulator as a generator

### DIFF
--- a/include/spirv/spir-v.xml
+++ b/include/spirv/spir-v.xml
@@ -76,7 +76,8 @@
         <id value="23"  vendor="Google" tool="Tint Compiler" comment="Contact David Neto, dneto@google.com"/>
         <id value="24"  vendor="Google" tool="ANGLE Shader Compiler" comment="Contact Shahbaz Youssefi, syoussefi@google.com"/>
         <id value="25"  vendor="Netease Games" tool="Messiah Shader Compiler" comment="Contact Yuwen Wu, atyuwen@gmail.com"/>
-        <unused start="26" end="0xFFFF" comment="Tool ID range reservable for future use by vendors"/>
+        <id value="26"  vendor="Xenia" tool="Xenia Emulator Microcode Translator" comment="Contact Vitaliy Kuzmin, triang3l@yandex.ru, https://github.com/xenia-project/xenia"/>
+        <unused start="27" end="0xFFFF" comment="Tool ID range reservable for future use by vendors"/>
     </ids>
 
     <!-- SECTION: SPIR-V Opcodes and Enumerants -->


### PR DESCRIPTION
An inconvenient way to be honest, would be much better if this was a string in shader modules (like in DXBC, which isn't even really supposed to be emitted by anything but Microsoft's tools)… [Xenia](https://github.com/xenia-project/xenia) is an Xbox 360 emulator capable of running hundreds of commercial games, we are currently in the process of rewriting its Vulkan rendering backend, which includes a translator from ATI Xenos microcode to SPIR-V, plus emission of emulation-specific SPIR-V code (such as fragment shader interlock-based programmable pixel packing/blending). No references to the Xbox 360 or the Xenos made in the file or the commit message, so no potential trademark violation is done.