### PR TITLE
cmake: Install cmake files to CMAKE_INSTALL_DATADIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,7 @@ target_include_directories(${PROJECT_NAME} INTERFACE
 if (SPIRV_HEADERS_ENABLE_INSTALL)
     message(STATUS "Installing SPIRV-Header")
 
-    set(config_install_dir "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
+    set(config_install_dir "${CMAKE_INSTALL_DATADIR}/cmake/${PROJECT_NAME}")
 
     set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")
 


### PR DESCRIPTION
I understand that SPIRV-Headers is not architecture specific and installs only header and cmake files. Given this I do not think the cmake files should be installed to `CMAKE_INSTALL_LIBDIR` and should use `CMAKE_INSTALL_DATADIR` instead so that resulting packages can be truly marked as `noarch`.