### PR TITLE
remove HitTKHR alias

### DIFF
--- a/include/spirv/unified1/spirv.core.grammar.json
+++ b/include/spirv/unified1/spirv.core.grammar.json
@@ -10431,15 +10431,8 @@
         {
           "enumerant" : "HitTNV",
           "value" : 5332,
-          "capabilities" : [ "RayTracingNV" , "RayTracingKHR" ],
-          "extensions" : [ "SPV_NV_ray_tracing" , "SPV_KHR_ray_tracing" ],
-          "version" : "None"
-        },
-        {
-          "enumerant" : "HitTKHR",
-          "value" : 5332,
-          "capabilities" : [ "RayTracingNV" , "RayTracingKHR" ],
-          "extensions" : [ "SPV_NV_ray_tracing" , "SPV_KHR_ray_tracing" ],
+          "capabilities" : [ "RayTracingNV" ],
+          "extensions" : [ "SPV_NV_ray_tracing" ],
           "version" : "None"
         },
         {

--- a/include/spirv/unified1/spirv.cs
+++ b/include/spirv/unified1/spirv.cs
@@ -612,7 +612,6 @@ namespace Spv
             ObjectToWorldNV = 5330,
             WorldToObjectKHR = 5331,
             WorldToObjectNV = 5331,
-            HitTKHR = 5332,
             HitTNV = 5332,
             HitKindKHR = 5333,
             HitKindNV = 5333,

--- a/include/spirv/unified1/spirv.h
+++ b/include/spirv/unified1/spirv.h
@@ -618,7 +618,6 @@ typedef enum SpvBuiltIn_ {
     SpvBuiltInObjectToWorldNV = 5330,
     SpvBuiltInWorldToObjectKHR = 5331,
     SpvBuiltInWorldToObjectNV = 5331,
-    SpvBuiltInHitTKHR = 5332,
     SpvBuiltInHitTNV = 5332,
     SpvBuiltInHitKindKHR = 5333,
     SpvBuiltInHitKindNV = 5333,

--- a/include/spirv/unified1/spirv.hpp
+++ b/include/spirv/unified1/spirv.hpp
@@ -614,7 +614,6 @@ enum BuiltIn {
     BuiltInObjectToWorldNV = 5330,
     BuiltInWorldToObjectKHR = 5331,
     BuiltInWorldToObjectNV = 5331,
-    BuiltInHitTKHR = 5332,
     BuiltInHitTNV = 5332,
     BuiltInHitKindKHR = 5333,
     BuiltInHitKindNV = 5333,

--- a/include/spirv/unified1/spirv.hpp11
+++ b/include/spirv/unified1/spirv.hpp11
@@ -614,7 +614,6 @@ enum class BuiltIn : unsigned {
     ObjectToWorldNV = 5330,
     WorldToObjectKHR = 5331,
     WorldToObjectNV = 5331,
-    HitTKHR = 5332,
     HitTNV = 5332,
     HitKindKHR = 5333,
     HitKindNV = 5333,

--- a/include/spirv/unified1/spirv.json
+++ b/include/spirv/unified1/spirv.json
@@ -647,7 +647,6 @@
                     "ObjectToWorldNV": 5330,
                     "WorldToObjectKHR": 5331,
                     "WorldToObjectNV": 5331,
-                    "HitTKHR": 5332,
                     "HitTNV": 5332,
                     "HitKindKHR": 5333,
                     "HitKindNV": 5333,

--- a/include/spirv/unified1/spirv.lua
+++ b/include/spirv/unified1/spirv.lua
@@ -586,7 +586,6 @@ spv = {
         ObjectToWorldNV = 5330,
         WorldToObjectKHR = 5331,
         WorldToObjectNV = 5331,
-        HitTKHR = 5332,
         HitTNV = 5332,
         HitKindKHR = 5333,
         HitKindNV = 5333,

--- a/include/spirv/unified1/spirv.py
+++ b/include/spirv/unified1/spirv.py
@@ -586,7 +586,6 @@ spv = {
         'ObjectToWorldNV' : 5330,
         'WorldToObjectKHR' : 5331,
         'WorldToObjectNV' : 5331,
-        'HitTKHR' : 5332,
         'HitTNV' : 5332,
         'HitKindKHR' : 5333,
         'HitKindNV' : 5333,

--- a/include/spirv/unified1/spv.d
+++ b/include/spirv/unified1/spv.d
@@ -615,7 +615,6 @@ enum BuiltIn : uint
     ObjectToWorldNV = 5330,
     WorldToObjectKHR = 5331,
     WorldToObjectNV = 5331,
-    HitTKHR = 5332,
     HitTNV = 5332,
     HitKindKHR = 5333,
     HitKindNV = 5333,


### PR DESCRIPTION
It was not added to the SPV_KHR_ray_tracing extension since it is just
an alias of RayTMaxKHR.