### PR TITLE
add function control bitfield reservation section

### DIFF
--- a/include/spirv/spir-v.xml
+++ b/include/spirv/spir-v.xml
@@ -185,6 +185,27 @@
     <ids type="LoopControl" start="31" end="31" vendor="Khronos" comment="Reserved LoopControl bit, not available to vendors"/>
 
 
+    <!-- SECTION: SPIR-V Function Control Bit Reservations -->
+    <!-- Reserve ranges of bits in the function control bitfield.
+
+         Each vendor determines the use of values in their own ranges.
+         Vendors are not required to disclose those uses.  If the use of a
+         value is included in an extension that is adopted by a Khronos
+         extension or specification, then that value's use may be permanently
+         fixed as if originally reserved in a Khronos range.
+
+         The SPIR Working Group strongly recommends:
+         - Each value is used for only one purpose.
+         - All values in a range should be used before allocating a new range.
+         -->
+
+    <!-- Reserved function control bits -->
+    <ids type="FunctionControl" start="0" end="15" vendor="Khronos" comment="Reserved FunctionControl bits, not available to vendors - see the SPIR-V Specification"/>
+    <ids type="FunctionControl" start="16" end="16" vendor="Intel" comment="Contact ben.ashbaugh@intel.com"/>
+    <ids type="FunctionControl" start="17" end="30" comment="Unreserved bits reservable for use by vendors"/>
+    <ids type="FunctionControl" start="31" end="31" vendor="Khronos" comment="Reserved FunctionControl bit, not available to vendors"/>
+
+
     <!-- SECTION: SPIR-V FP Fast Math Mode Bit Reservations -->
     <!-- Reserve ranges of bits in the "FP Fast Math Mode" bitfield.
          Each vendor determines the use of values in their own ranges.


### PR DESCRIPTION
Add a section to the XML file for function control bitfield reservations and reserve bit 16 for an upcoming Intel extension.

This new section uses the same layout and strategy as the existing sections for loop control and fp fast math mode bitfield reservations.
