### PR TITLE
Header generator: Check enumerant ordering

### DIFF
--- a/include/spirv/unified1/spirv.core.grammar.json
+++ b/include/spirv/unified1/spirv.core.grammar.json
@@ -10407,34 +10407,16 @@
           "version" : "1.3"
         },
         {
-          "enumerant" : "SubgroupGeMask",
-          "value" : 4417,
-          "capabilities" : [ "SubgroupBallotKHR", "GroupNonUniformBallot" ],
-          "version" : "1.3"
-        },
-        {
-          "enumerant" : "SubgroupGtMask",
-          "value" : 4418,
-          "capabilities" : [ "SubgroupBallotKHR", "GroupNonUniformBallot" ],
-          "version" : "1.3"
-        },
-        {
-          "enumerant" : "SubgroupLeMask",
-          "value" : 4419,
-          "capabilities" : [ "SubgroupBallotKHR", "GroupNonUniformBallot" ],
-          "version" : "1.3"
-        },
-        {
-          "enumerant" : "SubgroupLtMask",
-          "value" : 4420,
-          "capabilities" : [ "SubgroupBallotKHR", "GroupNonUniformBallot" ],
-          "version" : "1.3"
-        },
-        {
           "enumerant" : "SubgroupEqMaskKHR",
           "value" : 4416,
           "capabilities" : [ "SubgroupBallotKHR", "GroupNonUniformBallot" ],
           "extensions" : [ "SPV_KHR_shader_ballot" ],
+          "version" : "1.3"
+        },
+        {
+          "enumerant" : "SubgroupGeMask",
+          "value" : 4417,
+          "capabilities" : [ "SubgroupBallotKHR", "GroupNonUniformBallot" ],
           "version" : "1.3"
         },
         {
@@ -10445,6 +10427,12 @@
           "version" : "1.3"
         },
         {
+          "enumerant" : "SubgroupGtMask",
+          "value" : 4418,
+          "capabilities" : [ "SubgroupBallotKHR", "GroupNonUniformBallot" ],
+          "version" : "1.3"
+        },
+        {
           "enumerant" : "SubgroupGtMaskKHR",
           "value" : 4418,
           "capabilities" : [ "SubgroupBallotKHR", "GroupNonUniformBallot" ],
@@ -10452,10 +10440,22 @@
           "version" : "1.3"
         },
         {
+          "enumerant" : "SubgroupLeMask",
+          "value" : 4419,
+          "capabilities" : [ "SubgroupBallotKHR", "GroupNonUniformBallot" ],
+          "version" : "1.3"
+        },
+        {
           "enumerant" : "SubgroupLeMaskKHR",
           "value" : 4419,
           "capabilities" : [ "SubgroupBallotKHR", "GroupNonUniformBallot" ],
           "extensions" : [ "SPV_KHR_shader_ballot" ],
+          "version" : "1.3"
+        },
+        {
+          "enumerant" : "SubgroupLtMask",
+          "value" : 4420,
+          "capabilities" : [ "SubgroupBallotKHR", "GroupNonUniformBallot" ],
           "version" : "1.3"
         },
         {

--- a/include/spirv/unified1/spirv.cs
+++ b/include/spirv/unified1/spirv.cs
@@ -1106,14 +1106,16 @@ namespace Spv
             Horizontal4Pixels = 0x00000008,
         }
 
-        public enum FPDenormMode {
-          Preserve = 0,
-          FlushToZero = 1,
+        public enum FPDenormMode
+        {
+            Preserve = 0,
+            FlushToZero = 1,
         }
 
-        public enum FPOperationMode {
-          IEEE = 0,
-          ALT = 1,
+        public enum FPOperationMode
+        {
+            IEEE = 0,
+            ALT = 1,
         }
 
         public enum Op

--- a/include/spirv/unified1/spirv.h
+++ b/include/spirv/unified1/spirv.h
@@ -1106,15 +1106,15 @@ typedef enum SpvFragmentShadingRateMask_ {
 } SpvFragmentShadingRateMask;
 
 typedef enum SpvFPDenormMode_ {
-  SpvFPDenormModePreserve = 0,
-  SpvFPDenormModeFlushToZero = 1,
-  SpvFPDenormModeMax = 0x7fffffff,
+    SpvFPDenormModePreserve = 0,
+    SpvFPDenormModeFlushToZero = 1,
+    SpvFPDenormModeMax = 0x7fffffff,
 } SpvFPDenormMode;
 
 typedef enum SpvFPOperationMode_ {
-  SpvFPOperationModeIEEE = 0,
-  SpvFPOperationModeALT = 1,
-  SpvFPOperationModeMax = 0x7fffffff,
+    SpvFPOperationModeIEEE = 0,
+    SpvFPOperationModeALT = 1,
+    SpvFPOperationModeMax = 0x7fffffff,
 } SpvFPOperationMode;
 
 typedef enum SpvOp_ {

--- a/include/spirv/unified1/spirv.hpp
+++ b/include/spirv/unified1/spirv.hpp
@@ -1102,15 +1102,15 @@ enum FragmentShadingRateMask {
 };
 
 enum FPDenormMode {
-  FPDenormModePreserve = 0,
-  FPDenormModeFlushToZero = 1,
-  FPDenormModeMax = 0x7fffffff,
+    FPDenormModePreserve = 0,
+    FPDenormModeFlushToZero = 1,
+    FPDenormModeMax = 0x7fffffff,
 };
 
 enum FPOperationMode {
-  FPOperationModeIEEE = 0,
-  FPOperationModeALT = 1,
-  FPOperationModeMax = 0x7fffffff,
+    FPOperationModeIEEE = 0,
+    FPOperationModeALT = 1,
+    FPOperationModeMax = 0x7fffffff,
 };
 
 enum Op {


### PR DESCRIPTION
In the grammar, enforce ordering rules:
- Instructions must appear in order of their opcode
- Non-instructions: each successive enumerant within a single kind must
  have a value which is either larger than all the previous values
  or equal to one of the previous values.
  We have this convoluted rule for enums because we want to support
  the sequence:
  	4416 SubgroupEqMask
  	4417 SubgroupGeMask
  	4418 SubgroupGtMask
  	4419 SubgroupLeMask
  	4420 SubgroupLtMask
  	4416 SubgroupEqMaskKHR
  	4417 SubgroupGeMaskKHR
  	4418 SubgroupGtMaskKHR
  	4419 SubgroupLeMaskKHR
  	4420 SubgroupLtMaskKHR