### PR TITLE
Push FPDenormMode, FPOperationMode to the end

### DIFF
--- a/include/spirv/unified1/spirv.cs
+++ b/include/spirv/unified1/spirv.cs
@@ -403,18 +403,6 @@ namespace Spv
             RTN = 3,
         }
 
-        public enum FPDenormMode
-        {
-            Preserve = 0,
-            FlushToZero = 1,
-        }
-
-        public enum FPOperationMode
-        {
-            IEEE = 0,
-            ALT = 1,
-        }
-
         public enum LinkageType
         {
             Export = 0,
@@ -1113,6 +1101,16 @@ namespace Spv
             Vertical4Pixels = 0x00000002,
             Horizontal2Pixels = 0x00000004,
             Horizontal4Pixels = 0x00000008,
+        }
+
+        public enum FPDenormMode {
+          Preserve = 0,
+          FlushToZero = 1,
+        }
+
+        public enum FPOperationMode {
+          IEEE = 0,
+          ALT = 1,
         }
 
         public enum Op

--- a/include/spirv/unified1/spirv.h
+++ b/include/spirv/unified1/spirv.h
@@ -410,18 +410,6 @@ typedef enum SpvFPRoundingMode_ {
     SpvFPRoundingModeMax = 0x7fffffff,
 } SpvFPRoundingMode;
 
-typedef enum SpvFPDenormMode_ {
-    SpvFPDenormModePreserve = 0,
-    SpvFPDenormModeFlushToZero = 1,
-    SpvFPDenormModeMax = 0x7fffffff,
-} SpvFPDenormMode;
-
-typedef enum SpvFPOperationMode_ {
-    SpvFPOperationModeIEEE = 0,
-    SpvFPOperationModeALT = 1,
-    SpvFPOperationModeMax = 0x7fffffff,
-} SpvFPOperationMode;
-
 typedef enum SpvLinkageType_ {
     SpvLinkageTypeExport = 0,
     SpvLinkageTypeImport = 1,
@@ -1113,6 +1101,18 @@ typedef enum SpvFragmentShadingRateMask_ {
     SpvFragmentShadingRateHorizontal2PixelsMask = 0x00000004,
     SpvFragmentShadingRateHorizontal4PixelsMask = 0x00000008,
 } SpvFragmentShadingRateMask;
+
+typedef enum SpvFPDenormMode_ {
+  SpvFPDenormModePreserve = 0,
+  SpvFPDenormModeFlushToZero = 1,
+  SpvFPDenormModeMax = 0x7fffffff,
+} SpvFPDenormMode;
+
+typedef enum SpvFPOperationMode_ {
+  SpvFPOperationModeIEEE = 0,
+  SpvFPOperationModeALT = 1,
+  SpvFPOperationModeMax = 0x7fffffff,
+} SpvFPOperationMode;
 
 typedef enum SpvOp_ {
     SpvOpNop = 0,

--- a/include/spirv/unified1/spirv.hpp
+++ b/include/spirv/unified1/spirv.hpp
@@ -406,18 +406,6 @@ enum FPRoundingMode {
     FPRoundingModeMax = 0x7fffffff,
 };
 
-enum FPDenormMode {
-    FPDenormModePreserve = 0,
-    FPDenormModeFlushToZero = 1,
-    FPDenormModeMax = 0x7fffffff,
-};
-
-enum FPOperationMode {
-    FPOperationModeIEEE = 0,
-    FPOperationModeALT = 1,
-    FPOperationModeMax = 0x7fffffff,
-};
-
 enum LinkageType {
     LinkageTypeExport = 0,
     LinkageTypeImport = 1,
@@ -1108,6 +1096,18 @@ enum FragmentShadingRateMask {
     FragmentShadingRateVertical4PixelsMask = 0x00000002,
     FragmentShadingRateHorizontal2PixelsMask = 0x00000004,
     FragmentShadingRateHorizontal4PixelsMask = 0x00000008,
+};
+
+enum FPDenormMode {
+  FPDenormModePreserve = 0,
+  FPDenormModeFlushToZero = 1,
+  FPDenormModeMax = 0x7fffffff,
+};
+
+enum FPOperationMode {
+  FPOperationModeIEEE = 0,
+  FPOperationModeALT = 1,
+  FPOperationModeMax = 0x7fffffff,
 };
 
 enum Op {

--- a/include/spirv/unified1/spirv.hpp11
+++ b/include/spirv/unified1/spirv.hpp11
@@ -406,18 +406,6 @@ enum class FPRoundingMode : unsigned {
     Max = 0x7fffffff,
 };
 
-enum class FPDenormMode : unsigned {
-    Preserve = 0,
-    FlushToZero = 1,
-    Max = 0x7fffffff,
-};
-
-enum class FPOperationMode : unsigned {
-    IEEE = 0,
-    ALT = 1,
-    Max = 0x7fffffff,
-};
-
 enum class LinkageType : unsigned {
     Export = 0,
     Import = 1,
@@ -1108,6 +1096,18 @@ enum class FragmentShadingRateMask : unsigned {
     Vertical4Pixels = 0x00000002,
     Horizontal2Pixels = 0x00000004,
     Horizontal4Pixels = 0x00000008,
+};
+
+enum class FPDenormMode : unsigned {
+    Preserve = 0,
+    FlushToZero = 1,
+    Max = 0x7fffffff,
+};
+
+enum class FPOperationMode : unsigned {
+    IEEE = 0,
+    ALT = 1,
+    Max = 0x7fffffff,
 };
 
 enum class Op : unsigned {

--- a/include/spirv/unified1/spirv.json
+++ b/include/spirv/unified1/spirv.json
@@ -422,24 +422,6 @@
                 }
             },
             {
-                "Name": "FPDenormMode",
-                "Type": "Value",
-                "Values":
-                {
-                    "Preserve": 0,
-                    "FlushToZero": 1
-                }
-            },
-            {
-                "Name": "FPOperationMode",
-                "Type": "Value",
-                "Values":
-                {
-                    "IEEE": 0,
-                    "ALT": 1
-                }
-            },
-            {
                 "Name": "LinkageType",
                 "Type": "Value",
                 "Values":
@@ -1093,6 +1075,24 @@
                     "Vertical4Pixels": 1,
                     "Horizontal2Pixels": 2,
                     "Horizontal4Pixels": 3
+                }
+            },
+            {
+                "Name": "FPDenormMode",
+                "Type": "Value",
+                "Values":
+                {
+                    "Preserve": 0,
+                    "FlushToZero": 1
+                }
+            },
+            {
+                "Name": "FPOperationMode",
+                "Type": "Value",
+                "Values":
+                {
+                    "IEEE": 0,
+                    "ALT": 1
                 }
             },
             {

--- a/include/spirv/unified1/spirv.lua
+++ b/include/spirv/unified1/spirv.lua
@@ -382,16 +382,6 @@ spv = {
         RTN = 3,
     },
 
-    FPDenormMode = {
-        Preserve = 0,
-        FlushToZero = 1,
-    },
-
-    FPOperationMode = {
-        IEEE = 0,
-        ALT = 1,
-    },
-
     LinkageType = {
         Export = 0,
         Import = 1,
@@ -1062,6 +1052,16 @@ spv = {
         Vertical4Pixels = 0x00000002,
         Horizontal2Pixels = 0x00000004,
         Horizontal4Pixels = 0x00000008,
+    },
+
+    FPDenormMode = {
+        Preserve = 0,
+        FlushToZero = 1,
+    },
+
+    FPOperationMode = {
+        IEEE = 0,
+        ALT = 1,
     },
 
     Op = {

--- a/include/spirv/unified1/spirv.py
+++ b/include/spirv/unified1/spirv.py
@@ -382,16 +382,6 @@ spv = {
         'RTN' : 3,
     },
 
-    'FPDenormMode' : {
-        'Preserve' : 0,
-        'FlushToZero' : 1,
-    },
-
-    'FPOperationMode' : {
-        'IEEE' : 0,
-        'ALT' : 1,
-    },
-
     'LinkageType' : {
         'Export' : 0,
         'Import' : 1,
@@ -1062,6 +1052,16 @@ spv = {
         'Vertical4Pixels' : 0x00000002,
         'Horizontal2Pixels' : 0x00000004,
         'Horizontal4Pixels' : 0x00000008,
+    },
+
+    'FPDenormMode' : {
+        'Preserve' : 0,
+        'FlushToZero' : 1,
+    },
+
+    'FPOperationMode' : {
+        'IEEE' : 0,
+        'ALT' : 1,
     },
 
     'Op' : {

--- a/include/spirv/unified1/spv.d
+++ b/include/spirv/unified1/spv.d
@@ -406,18 +406,6 @@ enum FPRoundingMode : uint
     RTN = 3,
 }
 
-enum FPDenormMode : uint
-{
-    Preserve = 0,
-    FlushToZero = 1,
-}
-
-enum FPOperationMode : uint
-{
-    IEEE = 0,
-    ALT = 1,
-}
-
 enum LinkageType : uint
 {
     Export = 0,
@@ -1116,6 +1104,18 @@ enum FragmentShadingRateMask : uint
     Vertical4Pixels = 0x00000002,
     Horizontal2Pixels = 0x00000004,
     Horizontal4Pixels = 0x00000008,
+}
+
+enum FPDenormMode : uint
+{
+    Preserve = 0,
+    FlushToZero = 1,
+}
+
+enum FPOperationMode : uint
+{
+    IEEE = 0,
+    ALT = 1,
 }
 
 enum Op : uint

--- a/tools/buildHeaders/jsonToSpirv.h
+++ b/tools/buildHeaders/jsonToSpirv.h
@@ -41,6 +41,8 @@ std::pair<bool, std::string> ReadFile(const std::string& path);
 void jsonToSpirv(const std::string& jsonPath, bool buildingHeaders);
 
 // For parameterizing operands.
+// The ordering here affects the printing order in the SPIR-V specification.
+// Please add new operand classes at the end.
 enum OperandClass {
     OperandNone,
     OperandId,
@@ -69,8 +71,6 @@ enum OperandClass {
     OperandImageOperands,
     OperandFPFastMath,
     OperandFPRoundingMode,
-    OperandFPDenormMode,
-    OperandFPOperationMode,
     OperandLinkageType,
     OperandAccessQualifier,
     OperandFuncParamAttr,
@@ -91,6 +91,8 @@ enum OperandClass {
     OperandRayQueryCommittedIntersectionType,
     OperandRayQueryCandidateIntersectionType,
     OperandFragmentShadingRate,
+    OperandFPDenormMode,
+    OperandFPOperationMode,
 
     OperandOpcode,
 


### PR DESCRIPTION
This is a cosmetic change for the benefit of generating the SPIR-V spec.
It reorders the "FP Denorm Mode" and "FP Operation Mode" so they are
the last sections in chapter 3 before the instruction listing.
They become 3.37 and 3.38. The idea is to preserve the section numbering
for earlier sections. For example, keep 3.31 as the Capability section.