### PR TITLE
add None as a possible value for DebugInfoFlags

### DIFF
--- a/include/spirv/unified1/DebugInfo.h
+++ b/include/spirv/unified1/DebugInfo.h
@@ -78,6 +78,7 @@ enum DebugInfoInstructions {
 
 
 enum DebugInfoDebugInfoFlags {
+    DebugInfoNone = 0x0000,
     DebugInfoFlagIsProtected = 0x01,
     DebugInfoFlagIsPrivate = 0x02,
     DebugInfoFlagIsPublic = 0x03,

--- a/include/spirv/unified1/OpenCLDebugInfo100.h
+++ b/include/spirv/unified1/OpenCLDebugInfo100.h
@@ -80,6 +80,7 @@ enum OpenCLDebugInfo100Instructions {
 
 
 enum OpenCLDebugInfo100DebugInfoFlags {
+    OpenCLDebugInfo100None = 0x0000,
     OpenCLDebugInfo100FlagIsProtected = 0x01,
     OpenCLDebugInfo100FlagIsPrivate = 0x02,
     OpenCLDebugInfo100FlagIsPublic = 0x03,

--- a/include/spirv/unified1/extinst.debuginfo.grammar.json
+++ b/include/spirv/unified1/extinst.debuginfo.grammar.json
@@ -377,6 +377,10 @@
       "kind" : "DebugInfoFlags",
       "enumerants" : [
         {
+          "enumerant" : "None",
+          "value" : "0x0000"
+        },
+        {
           "enumerant" : "FlagIsProtected",
           "value" : "0x01"
         },

--- a/include/spirv/unified1/extinst.opencl.debuginfo.100.grammar.json
+++ b/include/spirv/unified1/extinst.opencl.debuginfo.100.grammar.json
@@ -403,6 +403,10 @@
       "kind" : "DebugInfoFlags",
       "enumerants" : [
         {
+          "enumerant" : "None",
+          "value" : "0x0000"
+        },
+        {
           "enumerant" : "FlagIsProtected",
           "value" : "0x01"
         },


### PR DESCRIPTION
It's possible that no debug info flags are needed, in which case the debug info flags will have value `0`.  This case should be disassembled into `None` and then `None` should be assembled back into `0`.  Without this change many SPIR-V modules with debug information cannot be properly disassembled and assembled.

I think this may require a minor spec update as well?  I'll work on that next.

CC: @AlexeySotkin 