### PR TITLE
Change operand name in OpReadClockKHR to match extension

### DIFF
--- a/include/spirv/unified1/spirv.core.grammar.json
+++ b/include/spirv/unified1/spirv.core.grammar.json
@@ -4552,7 +4552,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope", "name" : "'Execution'" }
+        { "kind" : "IdScope", "name" : "'Scope'" }
       ],
       "capabilities" : [ "ShaderClockKHR" ],
       "extensions" : [ "SPV_KHR_shader_clock" ],


### PR DESCRIPTION
* The grammar was not updated when revision 3 of SPV_KHR_shader_clock
  was published
  * That revision renamed the *Execution* operand to *Scope*

See [SPV_KHR_shader_clock](http://htmlpreview.github.io/?https://github.com/KhronosGroup/SPIRV-Registry/blob/master/extensions/KHR/SPV_KHR_shader_clock.html).