### PR TITLE
Add spirv-headers pkgconfig file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,4 +124,10 @@ if (SPIRV_HEADERS_ENABLE_INSTALL)
         NAMESPACE "${namespace}"
         DESTINATION "${config_install_dir}"
     )
+
+    configure_file(${CMAKE_SOURCE_DIR}/spirv-headers.pc.in ${CMAKE_BINARY_DIR}/spirv-headers.pc @ONLY )
+    install(
+        FILES "${CMAKE_BINARY_DIR}/spirv-headers.pc"
+        DESTINATION ${CMAKE_INSTALL_DATADIR}/pkgconfig
+    )
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,9 +125,9 @@ if (SPIRV_HEADERS_ENABLE_INSTALL)
         DESTINATION "${config_install_dir}"
     )
 
-    configure_file(${CMAKE_SOURCE_DIR}/spirv-headers.pc.in ${CMAKE_BINARY_DIR}/spirv-headers.pc @ONLY)
+    configure_file(${CMAKE_SOURCE_DIR}/SPIRV-Headers.pc.in ${CMAKE_BINARY_DIR}/SPIRV-Headers.pc @ONLY)
     install(
-        FILES "${CMAKE_BINARY_DIR}/spirv-headers.pc"
+        FILES "${CMAKE_BINARY_DIR}/SPIRV-Headers.pc"
         DESTINATION ${CMAKE_INSTALL_DATADIR}/pkgconfig
     )
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,7 +125,7 @@ if (SPIRV_HEADERS_ENABLE_INSTALL)
         DESTINATION "${config_install_dir}"
     )
 
-    configure_file(${CMAKE_SOURCE_DIR}/spirv-headers.pc.in ${CMAKE_BINARY_DIR}/spirv-headers.pc @ONLY )
+    configure_file(${CMAKE_SOURCE_DIR}/spirv-headers.pc.in ${CMAKE_BINARY_DIR}/spirv-headers.pc @ONLY)
     install(
         FILES "${CMAKE_BINARY_DIR}/spirv-headers.pc"
         DESTINATION ${CMAKE_INSTALL_DATADIR}/pkgconfig

--- a/SPIRV-Headers.pc.in
+++ b/SPIRV-Headers.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 
-Name: spirv-headers
+Name: SPIRV-Headers
 Description: Header files from the SPIR-V registry
 Version: @CMAKE_PROJECT_VERSION@
 Requires:

--- a/spirv-headers.pc.in
+++ b/spirv-headers.pc.in
@@ -1,0 +1,9 @@
+prefix=@prefix@
+includedir=@includedir@
+
+Name: spirv-headers
+Description: Header files from the SPIR-V registry
+Version: @VERSION@
+Requires:
+Libs:
+Cflags: -I${includedir}

--- a/spirv-headers.pc.in
+++ b/spirv-headers.pc.in
@@ -1,9 +1,9 @@
-prefix=@prefix@
-includedir=@includedir@
+prefix=@CMAKE_INSTALL_PREFIX@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 
 Name: spirv-headers
 Description: Header files from the SPIR-V registry
-Version: @VERSION@
+Version: @CMAKE_PROJECT_VERSION@
 Requires:
 Libs:
 Cflags: -I${includedir}


### PR DESCRIPTION
With installed pkgconfig file other projects build processes can
detest availability of the spirv-headers and require some minimum
version of the spirv-headers to be present in build environment.

There i many problems when some other packages are failing only
because installed spirv-headers version is to low.
Adding that file will allow to avoid that kind of situations.
