### PR TITLE
Add SpvGenTwo tools to vendor IDs

### DIFF
--- a/include/spirv/spir-v.xml
+++ b/include/spirv/spir-v.xml
@@ -80,7 +80,8 @@
         <id value="27"  vendor="Embark Studios" tool="Rust GPU Compiler Backend" comment="https://github.com/embarkstudios/rust-gpu"/>
         <id value="28"  vendor="gfx-rs community" tool="Naga" comment="https://github.com/gfx-rs/naga"/>
         <id value="29"  vendor="Mikkosoft Productions" tool="MSP Shader Compiler" comment="Contact Mikko Rasa, tdb@tdb.fi"/>
-        <unused start="30" end="0xFFFF" comment="Tool ID range reservable for future use by vendors"/>
+        <id value="30"  vendor="SpvGenTwo community" tool="SpvGenTwo SPIR-V IR Tools" comment="https://github.com/rAzoR8/SpvGenTwo">
+        <unused start="31" end="0xFFFF" comment="Tool ID range reservable for future use by vendors"/>
     </ids>
 
     <!-- SECTION: SPIR-V Opcodes and Enumerants -->


### PR DESCRIPTION
SpvGenTwo https://github.com/rAzoR8/SpvGenTwo is a SPIR-V IR Builder / Parser toolbox with disassembler, reflector, linker and more.