### PR TITLE
Fix OpExecutionMode json specification

### DIFF
--- a/include/spirv/1.0/spirv.core.grammar.json
+++ b/include/spirv/1.0/spirv.core.grammar.json
@@ -147,8 +147,9 @@
       "opname" : "OpExecutionMode",
       "opcode" : 16,
       "operands" : [
-        { "kind" : "IdRef",         "name" : "'Entry Point'" },
-        { "kind" : "ExecutionMode", "name" : "'Mode'" }
+        { "kind" : "IdRef",                              "name" : "'Entry Point'" },
+        { "kind" : "ExecutionMode",                      "name" : "'Mode'" },
+        { "kind" : "LiteralInteger", "quantifier" : "*", "name" : "'Operands'" }
       ]
     },
     {

--- a/include/spirv/1.1/spirv.core.grammar.json
+++ b/include/spirv/1.1/spirv.core.grammar.json
@@ -147,8 +147,9 @@
       "opname" : "OpExecutionMode",
       "opcode" : 16,
       "operands" : [
-        { "kind" : "IdRef",         "name" : "'Entry Point'" },
-        { "kind" : "ExecutionMode", "name" : "'Mode'" }
+        { "kind" : "IdRef",                              "name" : "'Entry Point'" },
+        { "kind" : "ExecutionMode",                      "name" : "'Mode'" },
+        { "kind" : "LiteralInteger", "quantifier" : "*", "name" : "'Operands'" }
       ]
     },
     {

--- a/include/spirv/1.2/spirv.core.grammar.json
+++ b/include/spirv/1.2/spirv.core.grammar.json
@@ -147,8 +147,9 @@
       "opname" : "OpExecutionMode",
       "opcode" : 16,
       "operands" : [
-        { "kind" : "IdRef",         "name" : "'Entry Point'" },
-        { "kind" : "ExecutionMode", "name" : "'Mode'" }
+        { "kind" : "IdRef",                              "name" : "'Entry Point'" },
+        { "kind" : "ExecutionMode",                      "name" : "'Mode'" },
+        { "kind" : "LiteralInteger", "quantifier" : "*", "name" : "'Operands'" }
       ]
     },
     {
@@ -3118,8 +3119,9 @@
       "opname" : "OpExecutionModeId",
       "opcode" : 331,
       "operands" : [
-        { "kind" : "IdRef",           "name" : "'Entry Point'" },
-        { "kind" : "ExecutionMode",   "name" : "'Mode'" }
+        { "kind" : "IdRef",                     "name" : "'Entry Point'" },
+        { "kind" : "ExecutionMode",             "name" : "'Mode'" },
+        { "kind" : "IdRef", "quantifier" : "*", "name" : "'Operands'" }
       ]
     },
     {

--- a/include/spirv/unified1/spirv.core.grammar.json
+++ b/include/spirv/unified1/spirv.core.grammar.json
@@ -267,8 +267,9 @@
       "class"  : "Mode-Setting",
       "opcode" : 16,
       "operands" : [
-        { "kind" : "IdRef",         "name" : "'Entry Point'" },
-        { "kind" : "ExecutionMode", "name" : "'Mode'" }
+        { "kind" : "IdRef",                              "name" : "'Entry Point'" },
+        { "kind" : "ExecutionMode",                      "name" : "'Mode'" },
+        { "kind" : "LiteralInteger", "quantifier" : "*", "name" : "'Operands'" }
       ]
     },
     {
@@ -3556,7 +3557,8 @@
       "opcode" : 331,
       "operands" : [
         { "kind" : "IdRef", "name" : "'Entry Point'" },
-        { "kind" : "ExecutionMode", "name" : "'Mode'" }
+        { "kind" : "ExecutionMode", "name" : "'Mode'" },
+        { "kind" : "IdRef", "quantifier" : "*", "name" : "'Operands'" }
       ],
       "version" : "1.2"
     },


### PR DESCRIPTION
This instruction takes a list of literals which was missing from the
json specification.

Signed-off-by: Shahbaz Youssefi <ShabbyX@gmail.com>