### PR TITLE
Remove the need to install buildSpvHeaders

### DIFF
--- a/tools/buildHeaders/bin/makeHeaders
+++ b/tools/buildHeaders/bin/makeHeaders
@@ -3,5 +3,5 @@
 python3 bin/makeExtinstHeaders.py
 
 cd ../../include/spirv/unified1
-../../../tools/buildHeaders/build/install/bin/buildSpvHeaders -H spirv.core.grammar.json
+../../../tools/buildHeaders/build/buildSpvHeaders -H spirv.core.grammar.json
 dos2unix spirv.* SpirV.* spv.*


### PR DESCRIPTION
The README file currently doesn't mention the need to call the install
target. Use the built binary directly.

If requiring installation makes sense for other reasons, I'm happy to edit the
the README instead.

Signed-off-by: Kevin Petit <kevin.petit@arm.com>