### PR TITLE
Fix grammar for PackedVectorFormat

### DIFF
--- a/include/spirv/unified1/spirv.core.grammar.json
+++ b/include/spirv/unified1/spirv.core.grammar.json
@@ -13509,7 +13509,7 @@
         {
           "enumerant" : "PackedVectorFormat4x8BitKHR",
           "value" : 0,
-          "capabilities" : [ "DotProductInput4x8BitPackedKHR" ],
+          "extensions" : [ "SPV_KHR_integer_dot_product" ],
           "version" : "None"
         }
       ]


### PR DESCRIPTION
PackedVectorFormat4x8BitKHR should be enabled by the SPV_KHR_integer_dot_product
extension that first introduced it and not the DotProductInput4x8BitPackedKHR capability,
as per the extension specification.

See http://htmlpreview.github.io/?https://github.com/KhronosGroup/SPIRV-Registry/blob/master/extensions/KHR/SPV_KHR_integer_dot_product.html

Signed-off-by: Kevin Petit <kevin.petit@arm.com>