### PR TITLE
Add missing capabilities to QuantizationModes and OverflowModes enumerants

### DIFF
--- a/include/spirv/unified1/spirv.core.grammar.json
+++ b/include/spirv/unified1/spirv.core.grammar.json
@@ -10433,35 +10433,51 @@
       "enumerants" : [
         {
           "enumerant" : "TRN",
-          "value" : 0
+          "value" : 0,
+          "capabilities" : [ "ArbitraryPrecisionFixedPointINTEL"],
+          "version" : "None"
         },
         {
           "enumerant" : "TRN_ZERO",
-          "value" : 1
+          "value" : 1,
+          "capabilities" : [ "ArbitraryPrecisionFixedPointINTEL"],
+          "version" : "None"
         },
         {
           "enumerant" : "RND",
-          "value" : 2
+          "value" : 2,
+          "capabilities" : [ "ArbitraryPrecisionFixedPointINTEL"],
+          "version" : "None"
         },
         {
           "enumerant" : "RND_ZERO",
-          "value" : 3
+          "value" : 3,
+          "capabilities" : [ "ArbitraryPrecisionFixedPointINTEL"],
+          "version" : "None"
         },
         {
           "enumerant" : "RND_INF",
-          "value" : 4
+          "value" : 4,
+          "capabilities" : [ "ArbitraryPrecisionFixedPointINTEL"],
+          "version" : "None"
         },
         {
           "enumerant" : "RND_MIN_INF",
-          "value" : 5
+          "value" : 5,
+          "capabilities" : [ "ArbitraryPrecisionFixedPointINTEL"],
+          "version" : "None"
         },
         {
           "enumerant" : "RND_CONV",
-          "value" : 6
+          "value" : 6,
+          "capabilities" : [ "ArbitraryPrecisionFixedPointINTEL"],
+          "version" : "None"
         },
         {
           "enumerant" : "RND_CONV_ODD",
-          "value" : 7
+          "value" : 7,
+          "capabilities" : [ "ArbitraryPrecisionFixedPointINTEL"],
+          "version" : "None"
         }
       ]
     },
@@ -10489,19 +10505,27 @@
       "enumerants" : [
         {
           "enumerant" : "WRAP",
-          "value" : 0
+          "value" : 0,
+          "capabilities" : [ "ArbitraryPrecisionFixedPointINTEL"],
+          "version" : "None"
         },
         {
           "enumerant" : "SAT",
-          "value" : 1
+          "value" : 1,
+          "capabilities" : [ "ArbitraryPrecisionFixedPointINTEL"],
+          "version" : "None"
         },
         {
           "enumerant" : "SAT_ZERO",
-          "value" : 2
+          "value" : 2,
+          "capabilities" : [ "ArbitraryPrecisionFixedPointINTEL"],
+          "version" : "None"
         },
         {
           "enumerant" : "SAT_SYM",
-          "value" : 3
+          "value" : 3,
+          "capabilities" : [ "ArbitraryPrecisionFixedPointINTEL"],
+          "version" : "None"
         }
       ]
     },


### PR DESCRIPTION
Add missing capabilities and '"version" : "None"' to QuantizationModes and OverflowModes enumerants