### PR TITLE
Correct grammar for LocalSizeHintId

### DIFF
--- a/include/spirv/unified1/spirv.core.grammar.json
+++ b/include/spirv/unified1/spirv.core.grammar.json
@@ -9445,7 +9445,9 @@
           "value" : 39,
           "capabilities" : [ "Kernel" ],
           "parameters" : [
-            { "kind" : "IdRef", "name" : "'Local Size Hint'" }
+            { "kind" : "IdRef", "name" : "'x size hint'" },
+            { "kind" : "IdRef", "name" : "'y size hint'" },
+            { "kind" : "IdRef", "name" : "'z size hint'" }
           ],
           "version" : "1.2"
         },


### PR DESCRIPTION
It is described in the spec as being the "same as LocalSizeHint mode,
but using <id> operands instead of literals", but the grammar had a
single <id> operand instead of the 3 literals for LocalSizeHint.