### PR TITLE
Fix referenced location for package config file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,7 +125,7 @@ if (SPIRV_HEADERS_ENABLE_INSTALL)
         DESTINATION "${config_install_dir}"
     )
 
-    configure_file(${CMAKE_SOURCE_DIR}/SPIRV-Headers.pc.in ${CMAKE_BINARY_DIR}/SPIRV-Headers.pc @ONLY)
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/SPIRV-Headers.pc.in ${CMAKE_BINARY_DIR}/SPIRV-Headers.pc @ONLY)
     install(
         FILES "${CMAKE_BINARY_DIR}/SPIRV-Headers.pc"
         DESTINATION ${CMAKE_INSTALL_DATADIR}/pkgconfig


### PR DESCRIPTION
CMAKE_SOURCE_DIR is the directory containing the top-level CMakeLists.txt file
for the cmake run.  The package file was being referenced as
${CMAKE_SOURCE_DIR}/SPIRV-Headers.pc.in, so if SPIRV-Headers was being
built as part of a larger project, configuration would fail.

Instead, use CMAKE_CURRENT_SOURCE_DIR to reliabley find the pc.in file.