### PR TITLE
Change the "SpvOpMax" to a 16 bit value (some compilers warn against …

### DIFF
--- a/include/spirv/unified1/spirv.h
+++ b/include/spirv/unified1/spirv.h
@@ -1804,7 +1804,7 @@ typedef enum SpvOp_ {
     SpvOpTypeStructContinuedINTEL = 6090,
     SpvOpConstantCompositeContinuedINTEL = 6091,
     SpvOpSpecConstantCompositeContinuedINTEL = 6092,
-    SpvOpMax = 0x7fffffff,
+    SpvOpMax = 0x7fff,
 } SpvOp;
 
 #ifdef SPV_ENABLE_UTILITY_CODE

--- a/include/spirv/unified1/spirv.hpp
+++ b/include/spirv/unified1/spirv.hpp
@@ -1800,7 +1800,7 @@ enum Op {
     OpTypeStructContinuedINTEL = 6090,
     OpConstantCompositeContinuedINTEL = 6091,
     OpSpecConstantCompositeContinuedINTEL = 6092,
-    OpMax = 0x7fffffff,
+    OpMax = 0x7fff,
 };
 
 #ifdef SPV_ENABLE_UTILITY_CODE

--- a/include/spirv/unified1/spirv.hpp11
+++ b/include/spirv/unified1/spirv.hpp11
@@ -1800,7 +1800,7 @@ enum class Op : unsigned {
     OpTypeStructContinuedINTEL = 6090,
     OpConstantCompositeContinuedINTEL = 6091,
     OpSpecConstantCompositeContinuedINTEL = 6092,
-    Max = 0x7fffffff,
+    Max = 0x7fff,
 };
 
 #ifdef SPV_ENABLE_UTILITY_CODE

--- a/tools/buildHeaders/header.cpp
+++ b/tools/buildHeaders/header.cpp
@@ -82,6 +82,7 @@ namespace {
             enumShift,
             enumMask,
             enumHex,
+            enumShortHex,
         };
 
         static std::string styleStr(enumStyle_t s) {
@@ -163,6 +164,8 @@ namespace {
             return fmtNum("0x%08x", 1<<v);
         case enumHex:
             return fmtNum("0x%08x", v);
+        case enumShortHex:
+            return fmtNum("0x%04x", v);
         default:
             return std::to_string(v);
         }
@@ -343,7 +346,10 @@ namespace {
 
                 const auto sorted = getSortedVals((*opClass)["Values"]);
 
-                std::string maxEnum = maxEnumFmt(opName, valpair_t(0x7FFFFFFF, "Max"), enumHex);
+                // Opcodes are only 16 bits by definition. Use only short unsigned value
+                std::string maxEnum = opName == "Op" ?
+                    maxEnumFmt(opName, valpair_t(0x7fff, "Max"), enumShortHex) : 
+                    maxEnumFmt(opName, valpair_t(0x7FFFFFFF, "Max"), enumHex);
 
                 bool printMax = (style != enumMask && maxEnum.size() > 0);
 


### PR DESCRIPTION
…comparing 16 bit opcode to the larger 32 bit enumerant).

See 3.37:
Opcode is the low-order 16 bits of word 0 of the instruction, holding its opcode enumerant.