### PR TITLE
Define a new Image operand bit mask for non constant offsets

### DIFF
--- a/include/spirv/spir-v.xml
+++ b/include/spirv/spir-v.xml
@@ -251,4 +251,24 @@
     <ids type="MemoryOperand" start="18" end="30" comment="Unreserved bits reservable for use by vendors"/>
     <ids type="MemoryOperand" start="31" end="31" vendor="Khronos" comment="Reserved MemoryOperand bit, not available to vendors"/>
 
+    <!-- SECTION: SPIR-V Image Operand Bit Reservations -->
+    <!-- Reserve ranges of bits in the image operands bitfield.
+
+         Each vendor determines the use of values in their own ranges.
+         Vendors are not required to disclose those uses.  If the use of a
+         value is included in an extension that is adopted by a Khronos
+         extension or specification, then that value's use may be permanently
+         fixed as if originally reserved in a Khronos range.
+
+         The SPIR Working Group strongly recommends:
+         - Each value is used for only one purpose.
+         - All values in a range should be used before allocating a new range.
+         -->
+
+    <!-- Reserved image operand bits -->
+    <ids type="ImageOperand" start="0" end="15" vendor="Khronos" comment="Reserved ImageOperand bits, not available to vendors - see the SPIR-V Specification"/>
+    <ids type="ImageOperand" start="16" end="16" vendor="Nvidia" comment="Contact pmistry@nvidia.com"/>
+    <ids type="ImageOperand" start="17" end="30" comment="Unreserved bits reservable for use by vendors"/>
+    <ids type="ImageOperand" start="31" end="31" vendor="Khronos" comment="Reserved ImageOperand bit, not available to vendors"/>
+
 </registry>

--- a/include/spirv/unified1/spirv.core.grammar.json
+++ b/include/spirv/unified1/spirv.core.grammar.json
@@ -8475,6 +8475,13 @@
           "enumerant" : "ZeroExtend",
           "value" : "0x2000",
           "version" : "1.4"
+        },
+        {
+          "enumerant" : "Offsets",
+          "value" : "0x10000",
+          "parameters" : [
+            { "kind" : "IdRef" }
+          ]
         }
       ]
     },

--- a/include/spirv/unified1/spirv.cs
+++ b/include/spirv/unified1/spirv.cs
@@ -349,6 +349,7 @@ namespace Spv
             VolatileTexelKHR = 11,
             SignExtend = 12,
             ZeroExtend = 13,
+            Offsets = 16,
         }
 
         public enum ImageOperandsMask
@@ -372,6 +373,7 @@ namespace Spv
             VolatileTexelKHR = 0x00000800,
             SignExtend = 0x00001000,
             ZeroExtend = 0x00002000,
+            Offsets = 0x00010000,
         }
 
         public enum FPFastMathModeShift

--- a/include/spirv/unified1/spirv.h
+++ b/include/spirv/unified1/spirv.h
@@ -357,6 +357,7 @@ typedef enum SpvImageOperandsShift_ {
     SpvImageOperandsVolatileTexelKHRShift = 11,
     SpvImageOperandsSignExtendShift = 12,
     SpvImageOperandsZeroExtendShift = 13,
+    SpvImageOperandsOffsetsShift = 16,
     SpvImageOperandsMax = 0x7fffffff,
 } SpvImageOperandsShift;
 
@@ -380,6 +381,7 @@ typedef enum SpvImageOperandsMask_ {
     SpvImageOperandsVolatileTexelKHRMask = 0x00000800,
     SpvImageOperandsSignExtendMask = 0x00001000,
     SpvImageOperandsZeroExtendMask = 0x00002000,
+    SpvImageOperandsOffsetsMask = 0x00010000,
 } SpvImageOperandsMask;
 
 typedef enum SpvFPFastMathModeShift_ {

--- a/include/spirv/unified1/spirv.hpp
+++ b/include/spirv/unified1/spirv.hpp
@@ -353,6 +353,7 @@ enum ImageOperandsShift {
     ImageOperandsVolatileTexelKHRShift = 11,
     ImageOperandsSignExtendShift = 12,
     ImageOperandsZeroExtendShift = 13,
+    ImageOperandsOffsetsShift = 16,
     ImageOperandsMax = 0x7fffffff,
 };
 
@@ -376,6 +377,7 @@ enum ImageOperandsMask {
     ImageOperandsVolatileTexelKHRMask = 0x00000800,
     ImageOperandsSignExtendMask = 0x00001000,
     ImageOperandsZeroExtendMask = 0x00002000,
+    ImageOperandsOffsetsMask = 0x00010000,
 };
 
 enum FPFastMathModeShift {

--- a/include/spirv/unified1/spirv.hpp11
+++ b/include/spirv/unified1/spirv.hpp11
@@ -353,6 +353,7 @@ enum class ImageOperandsShift : unsigned {
     VolatileTexelKHR = 11,
     SignExtend = 12,
     ZeroExtend = 13,
+    Offsets = 16,
     Max = 0x7fffffff,
 };
 
@@ -376,6 +377,7 @@ enum class ImageOperandsMask : unsigned {
     VolatileTexelKHR = 0x00000800,
     SignExtend = 0x00001000,
     ZeroExtend = 0x00002000,
+    Offsets = 0x00010000,
 };
 
 enum class FPFastMathModeShift : unsigned {

--- a/include/spirv/unified1/spirv.json
+++ b/include/spirv/unified1/spirv.json
@@ -395,7 +395,8 @@
                     "VolatileTexel": 11,
                     "VolatileTexelKHR": 11,
                     "SignExtend": 12,
-                    "ZeroExtend": 13
+                    "ZeroExtend": 13,
+                    "Offsets": 16
                 }
             },
             {

--- a/include/spirv/unified1/spirv.lua
+++ b/include/spirv/unified1/spirv.lua
@@ -332,6 +332,7 @@ spv = {
         VolatileTexelKHR = 11,
         SignExtend = 12,
         ZeroExtend = 13,
+        Offsets = 16,
     },
 
     ImageOperandsMask = {
@@ -354,6 +355,7 @@ spv = {
         VolatileTexelKHR = 0x00000800,
         SignExtend = 0x00001000,
         ZeroExtend = 0x00002000,
+        Offsets = 0x00010000,
     },
 
     FPFastMathModeShift = {

--- a/include/spirv/unified1/spirv.py
+++ b/include/spirv/unified1/spirv.py
@@ -332,6 +332,7 @@ spv = {
         'VolatileTexelKHR' : 11,
         'SignExtend' : 12,
         'ZeroExtend' : 13,
+        'Offsets' : 16,
     },
 
     'ImageOperandsMask' : {
@@ -354,6 +355,7 @@ spv = {
         'VolatileTexelKHR' : 0x00000800,
         'SignExtend' : 0x00001000,
         'ZeroExtend' : 0x00002000,
+        'Offsets' : 0x00010000,
     },
 
     'FPFastMathModeShift' : {

--- a/include/spirv/unified1/spv.d
+++ b/include/spirv/unified1/spv.d
@@ -352,6 +352,7 @@ enum ImageOperandsShift : uint
     VolatileTexelKHR = 11,
     SignExtend = 12,
     ZeroExtend = 13,
+    Offsets = 16,
 }
 
 enum ImageOperandsMask : uint
@@ -375,6 +376,7 @@ enum ImageOperandsMask : uint
     VolatileTexelKHR = 0x00000800,
     SignExtend = 0x00001000,
     ZeroExtend = 0x00002000,
+    Offsets = 0x00010000,
 }
 
 enum FPFastMathModeShift : uint


### PR DESCRIPTION
For details refer to https://gitlab.khronos.org/spirv/SPIR-V/-/issues/639
As part of the commit following changes have been introduced:
1. Added a separate section in spirv xml to reserve vendor specific bit masks.
2. Added a new image operand bit mask to support non constant offsets in textureGatherOffsets as defined in GL_NV_gpu_shader5