### PR TITLE
add 1.5.5 tag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@
 # https://www.khronos.org/registry/spir-v/
 #
 cmake_minimum_required(VERSION 3.0)
-project(SPIRV-Headers VERSION 1.5.1)
+project(SPIRV-Headers VERSION 1.5.5)
 
 # There are two ways to use this project.
 #


### PR DESCRIPTION
correct library version.
Relates to https://github.com/KhronosGroup/SPIRV-Headers/issues/199#issuecomment-932245116

Please, create a git tag 1.5.5, when merged 