### PR TITLE
Add SpecConstantSubgroupMaxSize to the clspv reflection non-semantic instruction set

### DIFF
--- a/include/spirv/unified1/NonSemanticClspvReflection.h
+++ b/include/spirv/unified1/NonSemanticClspvReflection.h
@@ -33,7 +33,7 @@ extern "C" {
 #endif
 
 enum {
-    NonSemanticClspvReflectionRevision = 1,
+    NonSemanticClspvReflectionRevision = 2,
     NonSemanticClspvReflectionRevision_BitWidthPadding = 0x7fffffff
 };
 
@@ -62,6 +62,7 @@ enum NonSemanticClspvReflectionInstructions {
     NonSemanticClspvReflectionConstantDataUniform = 22,
     NonSemanticClspvReflectionLiteralSampler = 23,
     NonSemanticClspvReflectionPropertyRequiredWorkgroupSize = 24,
+    NonSemanticClspvReflectionSpecConstantSubgroupMaxSize = 25,
     NonSemanticClspvReflectionInstructionsMax = 0x7fffffff
 };
 

--- a/include/spirv/unified1/extinst.nonsemantic.clspvreflection.grammar.json
+++ b/include/spirv/unified1/extinst.nonsemantic.clspvreflection.grammar.json
@@ -1,5 +1,5 @@
 {
-  "revision" : 1,
+  "revision" : 2,
   "instructions" : [
     {
       "opname" : "Kernel",
@@ -231,6 +231,13 @@
         { "kind" : "IdRef", "name" : "X" },
         { "kind" : "IdRef", "name" : "Y" },
         { "kind" : "IdRef", "name" : "Z" }
+      ]
+    },
+    {
+      "opname" : "SpecConstantSubgroupMaxSize",
+      "opcode" : 25,
+      "operands" : [
+        { "kind" : "IdRef", "name" : "Size" }
       ]
     }
   ]


### PR DESCRIPTION
Signed-off-by: Kévin Petit <kpet@free.fr>