### PR TITLE
Add MediaBlockIOINTEL decoration declaration

### DIFF
--- a/include/spirv/unified1/spirv.core.grammar.json
+++ b/include/spirv/unified1/spirv.core.grammar.json
@@ -11506,6 +11506,12 @@
           "value" : 6087,
           "capabilities" : [ "VectorComputeINTEL" ],
           "version" : "None"
+        },
+        {
+          "enumerant" : "MediaBlockIOINTEL",
+          "value" : 6140,
+          "capabilities" : [ "VectorComputeINTEL" ],
+          "version" : "None"
         }
       ]
     },

--- a/include/spirv/unified1/spirv.cs
+++ b/include/spirv/unified1/spirv.cs
@@ -542,6 +542,7 @@ namespace Spv
             FunctionFloatingPointModeINTEL = 6080,
             SingleElementVectorINTEL = 6085,
             VectorComputeCallableFunctionINTEL = 6087,
+            MediaBlockIOINTEL = 6140,
         }
 
         public enum BuiltIn

--- a/include/spirv/unified1/spirv.h
+++ b/include/spirv/unified1/spirv.h
@@ -548,6 +548,7 @@ typedef enum SpvDecoration_ {
     SpvDecorationFunctionFloatingPointModeINTEL = 6080,
     SpvDecorationSingleElementVectorINTEL = 6085,
     SpvDecorationVectorComputeCallableFunctionINTEL = 6087,
+    SpvDecorationMediaBlockIOINTEL = 6140,
     SpvDecorationMax = 0x7fffffff,
 } SpvDecoration;
 

--- a/include/spirv/unified1/spirv.hpp
+++ b/include/spirv/unified1/spirv.hpp
@@ -544,6 +544,7 @@ enum Decoration {
     DecorationFunctionFloatingPointModeINTEL = 6080,
     DecorationSingleElementVectorINTEL = 6085,
     DecorationVectorComputeCallableFunctionINTEL = 6087,
+    DecorationMediaBlockIOINTEL = 6140,
     DecorationMax = 0x7fffffff,
 };
 

--- a/include/spirv/unified1/spirv.hpp11
+++ b/include/spirv/unified1/spirv.hpp11
@@ -544,6 +544,7 @@ enum class Decoration : unsigned {
     FunctionFloatingPointModeINTEL = 6080,
     SingleElementVectorINTEL = 6085,
     VectorComputeCallableFunctionINTEL = 6087,
+    MediaBlockIOINTEL = 6140,
     Max = 0x7fffffff,
 };
 

--- a/include/spirv/unified1/spirv.json
+++ b/include/spirv/unified1/spirv.json
@@ -570,7 +570,8 @@
                     "IOPipeStorageINTEL": 5944,
                     "FunctionFloatingPointModeINTEL": 6080,
                     "SingleElementVectorINTEL": 6085,
-                    "VectorComputeCallableFunctionINTEL": 6087
+                    "VectorComputeCallableFunctionINTEL": 6087,
+                    "MediaBlockIOINTEL": 6140
                 }
             },
             {

--- a/include/spirv/unified1/spirv.lua
+++ b/include/spirv/unified1/spirv.lua
@@ -517,6 +517,7 @@ spv = {
         FunctionFloatingPointModeINTEL = 6080,
         SingleElementVectorINTEL = 6085,
         VectorComputeCallableFunctionINTEL = 6087,
+        MediaBlockIOINTEL = 6140,
     },
 
     BuiltIn = {

--- a/include/spirv/unified1/spirv.py
+++ b/include/spirv/unified1/spirv.py
@@ -517,6 +517,7 @@ spv = {
         'FunctionFloatingPointModeINTEL' : 6080,
         'SingleElementVectorINTEL' : 6085,
         'VectorComputeCallableFunctionINTEL' : 6087,
+        'MediaBlockIOINTEL' : 6140,
     },
 
     'BuiltIn' : {

--- a/include/spirv/unified1/spv.d
+++ b/include/spirv/unified1/spv.d
@@ -545,6 +545,7 @@ enum Decoration : uint
     FunctionFloatingPointModeINTEL = 6080,
     SingleElementVectorINTEL = 6085,
     VectorComputeCallableFunctionINTEL = 6087,
+    MediaBlockIOINTEL = 6140,
 }
 
 enum BuiltIn : uint


### PR DESCRIPTION
Declared new MediaBlockIOINTEL decoration added by VectorComputeINTEL
capability (part of SPV_INTEL_vector_compute).

Specification to SPV_INTEL_vector_compute extension can be found here: https://github.com/intel/llvm/pull/1612