### PR TITLE
Include bool type if not already defined

### DIFF
--- a/include/spirv/unified1/spirv.h
+++ b/include/spirv/unified1/spirv.h
@@ -1843,8 +1843,8 @@ typedef enum SpvOp_ {
 } SpvOp;
 
 #ifdef SPV_ENABLE_UTILITY_CODE
-#if !defined(__cplusplus) && !defined(bool)
-# include <stdbool.h>
+#ifndef __cplusplus
+#include <stdbool.h>
 #endif
 inline void SpvHasResultAndType(SpvOp opcode, bool *hasResult, bool *hasResultType) {
     *hasResult = *hasResultType = false;

--- a/include/spirv/unified1/spirv.h
+++ b/include/spirv/unified1/spirv.h
@@ -1843,6 +1843,9 @@ typedef enum SpvOp_ {
 } SpvOp;
 
 #ifdef SPV_ENABLE_UTILITY_CODE
+#if !defined(__cplusplus) && !defined(bool)
+# include <stdbool.h>
+#endif
 inline void SpvHasResultAndType(SpvOp opcode, bool *hasResult, bool *hasResultType) {
     *hasResult = *hasResultType = false;
     switch (opcode) {

--- a/include/spirv/unified1/spirv.hpp
+++ b/include/spirv/unified1/spirv.hpp
@@ -1839,8 +1839,8 @@ enum Op {
 };
 
 #ifdef SPV_ENABLE_UTILITY_CODE
-#if !defined(__cplusplus) && !defined(bool)
-# include <stdbool.h>
+#ifndef __cplusplus
+#include <stdbool.h>
 #endif
 inline void HasResultAndType(Op opcode, bool *hasResult, bool *hasResultType) {
     *hasResult = *hasResultType = false;

--- a/include/spirv/unified1/spirv.hpp
+++ b/include/spirv/unified1/spirv.hpp
@@ -1839,6 +1839,9 @@ enum Op {
 };
 
 #ifdef SPV_ENABLE_UTILITY_CODE
+#if !defined(__cplusplus) && !defined(bool)
+# include <stdbool.h>
+#endif
 inline void HasResultAndType(Op opcode, bool *hasResult, bool *hasResultType) {
     *hasResult = *hasResultType = false;
     switch (opcode) {

--- a/include/spirv/unified1/spirv.hpp11
+++ b/include/spirv/unified1/spirv.hpp11
@@ -1839,6 +1839,9 @@ enum class Op : unsigned {
 };
 
 #ifdef SPV_ENABLE_UTILITY_CODE
+#if !defined(__cplusplus) && !defined(bool)
+# include <stdbool.h>
+#endif
 inline void HasResultAndType(Op opcode, bool *hasResult, bool *hasResultType) {
     *hasResult = *hasResultType = false;
     switch (opcode) {

--- a/include/spirv/unified1/spirv.hpp11
+++ b/include/spirv/unified1/spirv.hpp11
@@ -1839,8 +1839,8 @@ enum class Op : unsigned {
 };
 
 #ifdef SPV_ENABLE_UTILITY_CODE
-#if !defined(__cplusplus) && !defined(bool)
-# include <stdbool.h>
+#ifndef __cplusplus
+#include <stdbool.h>
 #endif
 inline void HasResultAndType(Op opcode, bool *hasResult, bool *hasResultType) {
     *hasResult = *hasResultType = false;

--- a/tools/buildHeaders/header.cpp
+++ b/tools/buildHeaders/header.cpp
@@ -513,6 +513,9 @@ namespace {
                 }
 
                 out << "#ifdef SPV_ENABLE_UTILITY_CODE" << std::endl;
+                out << "#ifndef __cplusplus" << std::endl;
+                out << "#include <stdbool.h>" << std::endl;
+                out << "#endif" << std::endl;
                 out << "inline void " << pre() << "HasResultAndType(" << pre() << opName << " opcode, bool *hasResult, bool *hasResultType) {" << std::endl;
                 out << "    *hasResult = *hasResultType = false;" << std::endl;
                 out << "    switch (opcode) {" << std::endl;


### PR DESCRIPTION
The bool type is not defined in C by default.