### PR TITLE
Add EXT tag to capability to DemoteToHelperInvocationEXT

### DIFF
--- a/include/spirv/unified1/spirv.core.grammar.json
+++ b/include/spirv/unified1/spirv.core.grammar.json
@@ -5029,7 +5029,7 @@
       "opname" : "OpDemoteToHelperInvocationEXT",
       "class"  : "Control-Flow",
       "opcode" : 5380,
-      "capabilities" : [ "DemoteToHelperInvocation" ],
+      "capabilities" : [ "DemoteToHelperInvocationEXT" ],
       "version" : "1.6"
     },
     {


### PR DESCRIPTION
Normally the grammar uses the extension tagged capability names when
talking about extension tagged instructions. Technically speaking
they're the same capability, but it's nice to be consistent.