### PR TITLE
update SPIR-V headers for SPV_INTEL_split_barrier

### DIFF
--- a/include/spirv/unified1/spirv.core.grammar.json
+++ b/include/spirv/unified1/spirv.core.grammar.json
@@ -8549,6 +8549,30 @@
       ],
       "capabilities" : [ "LongConstantCompositeINTEL" ],
       "version" : "None"
+    },
+    {
+      "opname" : "OpControlBarrierArriveINTEL",
+      "class"  : "Barrier",
+      "opcode" : 6142,
+      "operands" : [
+        { "kind" : "IdScope",           "name" : "'Execution'" },
+        { "kind" : "IdScope",           "name" : "'Memory'" },
+        { "kind" : "IdMemorySemantics", "name" : "'Semantics'" }
+      ],
+      "capabilities" : [ "SplitBarrierINTEL" ],
+      "version" : "None"
+    },
+    {
+      "opname" : "OpControlBarrierWaitINTEL",
+      "class"  : "Barrier",
+      "opcode" : 6143,
+      "operands" : [
+        { "kind" : "IdScope",           "name" : "'Execution'" },
+        { "kind" : "IdScope",           "name" : "'Memory'" },
+        { "kind" : "IdMemorySemantics", "name" : "'Semantics'" }
+      ],
+      "capabilities" : [ "SplitBarrierINTEL" ],
+      "version" : "None"
     }
   ],
   "operand_kinds" : [
@@ -13880,6 +13904,12 @@
           "enumerant" : "DebugInfoModuleINTEL",
           "value" : 6114,
           "extensions" : [ "SPV_INTEL_debug_module" ],
+          "version" : "None"
+        },
+        {
+          "enumerant" : "SplitBarrierINTEL",
+          "value" : 6141,
+          "extensions" : [ "SPV_INTEL_split_barrier" ],
           "version" : "None"
         }
       ]

--- a/include/spirv/unified1/spirv.cs
+++ b/include/spirv/unified1/spirv.cs
@@ -1087,6 +1087,7 @@ namespace Spv
             OptNoneINTEL = 6094,
             AtomicFloat16AddEXT = 6095,
             DebugInfoModuleINTEL = 6114,
+            SplitBarrierINTEL = 6141,
         }
 
         public enum RayFlagsShift
@@ -1851,6 +1852,8 @@ namespace Spv
             OpTypeStructContinuedINTEL = 6090,
             OpConstantCompositeContinuedINTEL = 6091,
             OpSpecConstantCompositeContinuedINTEL = 6092,
+            OpControlBarrierArriveINTEL = 6142,
+            OpControlBarrierWaitINTEL = 6143,
         }
     }
 }

--- a/include/spirv/unified1/spirv.h
+++ b/include/spirv/unified1/spirv.h
@@ -1087,6 +1087,7 @@ typedef enum SpvCapability_ {
     SpvCapabilityOptNoneINTEL = 6094,
     SpvCapabilityAtomicFloat16AddEXT = 6095,
     SpvCapabilityDebugInfoModuleINTEL = 6114,
+    SpvCapabilitySplitBarrierINTEL = 6141,
     SpvCapabilityMax = 0x7fffffff,
 } SpvCapability;
 
@@ -1849,6 +1850,8 @@ typedef enum SpvOp_ {
     SpvOpTypeStructContinuedINTEL = 6090,
     SpvOpConstantCompositeContinuedINTEL = 6091,
     SpvOpSpecConstantCompositeContinuedINTEL = 6092,
+    SpvOpControlBarrierArriveINTEL = 6142,
+    SpvOpControlBarrierWaitINTEL = 6143,
     SpvOpMax = 0x7fffffff,
 } SpvOp;
 
@@ -2503,6 +2506,8 @@ inline void SpvHasResultAndType(SpvOp opcode, bool *hasResult, bool *hasResultTy
     case SpvOpTypeStructContinuedINTEL: *hasResult = false; *hasResultType = false; break;
     case SpvOpConstantCompositeContinuedINTEL: *hasResult = false; *hasResultType = false; break;
     case SpvOpSpecConstantCompositeContinuedINTEL: *hasResult = false; *hasResultType = false; break;
+    case SpvOpControlBarrierArriveINTEL: *hasResult = false; *hasResultType = false; break;
+    case SpvOpControlBarrierWaitINTEL: *hasResult = false; *hasResultType = false; break;
     }
 }
 #endif /* SPV_ENABLE_UTILITY_CODE */

--- a/include/spirv/unified1/spirv.hpp
+++ b/include/spirv/unified1/spirv.hpp
@@ -1083,6 +1083,7 @@ enum Capability {
     CapabilityOptNoneINTEL = 6094,
     CapabilityAtomicFloat16AddEXT = 6095,
     CapabilityDebugInfoModuleINTEL = 6114,
+    CapabilitySplitBarrierINTEL = 6141,
     CapabilityMax = 0x7fffffff,
 };
 
@@ -1845,6 +1846,8 @@ enum Op {
     OpTypeStructContinuedINTEL = 6090,
     OpConstantCompositeContinuedINTEL = 6091,
     OpSpecConstantCompositeContinuedINTEL = 6092,
+    OpControlBarrierArriveINTEL = 6142,
+    OpControlBarrierWaitINTEL = 6143,
     OpMax = 0x7fffffff,
 };
 
@@ -2499,6 +2502,8 @@ inline void HasResultAndType(Op opcode, bool *hasResult, bool *hasResultType) {
     case OpTypeStructContinuedINTEL: *hasResult = false; *hasResultType = false; break;
     case OpConstantCompositeContinuedINTEL: *hasResult = false; *hasResultType = false; break;
     case OpSpecConstantCompositeContinuedINTEL: *hasResult = false; *hasResultType = false; break;
+    case OpControlBarrierArriveINTEL: *hasResult = false; *hasResultType = false; break;
+    case OpControlBarrierWaitINTEL: *hasResult = false; *hasResultType = false; break;
     }
 }
 #endif /* SPV_ENABLE_UTILITY_CODE */

--- a/include/spirv/unified1/spirv.hpp11
+++ b/include/spirv/unified1/spirv.hpp11
@@ -1083,6 +1083,7 @@ enum class Capability : unsigned {
     OptNoneINTEL = 6094,
     AtomicFloat16AddEXT = 6095,
     DebugInfoModuleINTEL = 6114,
+    SplitBarrierINTEL = 6141,
     Max = 0x7fffffff,
 };
 
@@ -1845,6 +1846,8 @@ enum class Op : unsigned {
     OpTypeStructContinuedINTEL = 6090,
     OpConstantCompositeContinuedINTEL = 6091,
     OpSpecConstantCompositeContinuedINTEL = 6092,
+    OpControlBarrierArriveINTEL = 6142,
+    OpControlBarrierWaitINTEL = 6143,
     Max = 0x7fffffff,
 };
 
@@ -2499,6 +2502,8 @@ inline void HasResultAndType(Op opcode, bool *hasResult, bool *hasResultType) {
     case Op::OpTypeStructContinuedINTEL: *hasResult = false; *hasResultType = false; break;
     case Op::OpConstantCompositeContinuedINTEL: *hasResult = false; *hasResultType = false; break;
     case Op::OpSpecConstantCompositeContinuedINTEL: *hasResult = false; *hasResultType = false; break;
+    case Op::OpControlBarrierArriveINTEL: *hasResult = false; *hasResultType = false; break;
+    case Op::OpControlBarrierWaitINTEL: *hasResult = false; *hasResultType = false; break;
     }
 }
 #endif /* SPV_ENABLE_UTILITY_CODE */

--- a/include/spirv/unified1/spirv.json
+++ b/include/spirv/unified1/spirv.json
@@ -1064,7 +1064,8 @@
                     "LongConstantCompositeINTEL": 6089,
                     "OptNoneINTEL": 6094,
                     "AtomicFloat16AddEXT": 6095,
-                    "DebugInfoModuleINTEL": 6114
+                    "DebugInfoModuleINTEL": 6114,
+                    "SplitBarrierINTEL": 6141
                 }
             },
             {
@@ -1837,7 +1838,9 @@
                     "OpTypeBufferSurfaceINTEL": 6086,
                     "OpTypeStructContinuedINTEL": 6090,
                     "OpConstantCompositeContinuedINTEL": 6091,
-                    "OpSpecConstantCompositeContinuedINTEL": 6092
+                    "OpSpecConstantCompositeContinuedINTEL": 6092,
+                    "OpControlBarrierArriveINTEL": 6142,
+                    "OpControlBarrierWaitINTEL": 6143
                 }
             }
         ]

--- a/include/spirv/unified1/spirv.lua
+++ b/include/spirv/unified1/spirv.lua
@@ -1045,6 +1045,7 @@ spv = {
         OptNoneINTEL = 6094,
         AtomicFloat16AddEXT = 6095,
         DebugInfoModuleINTEL = 6114,
+        SplitBarrierINTEL = 6141,
     },
 
     RayFlagsShift = {
@@ -1796,6 +1797,8 @@ spv = {
         OpTypeStructContinuedINTEL = 6090,
         OpConstantCompositeContinuedINTEL = 6091,
         OpSpecConstantCompositeContinuedINTEL = 6092,
+        OpControlBarrierArriveINTEL = 6142,
+        OpControlBarrierWaitINTEL = 6143,
     },
 
 }

--- a/include/spirv/unified1/spirv.py
+++ b/include/spirv/unified1/spirv.py
@@ -1045,6 +1045,7 @@ spv = {
         'OptNoneINTEL' : 6094,
         'AtomicFloat16AddEXT' : 6095,
         'DebugInfoModuleINTEL' : 6114,
+        'SplitBarrierINTEL' : 6141,
     },
 
     'RayFlagsShift' : {
@@ -1796,6 +1797,8 @@ spv = {
         'OpTypeStructContinuedINTEL' : 6090,
         'OpConstantCompositeContinuedINTEL' : 6091,
         'OpSpecConstantCompositeContinuedINTEL' : 6092,
+        'OpControlBarrierArriveINTEL' : 6142,
+        'OpControlBarrierWaitINTEL' : 6143,
     },
 
 }

--- a/include/spirv/unified1/spv.d
+++ b/include/spirv/unified1/spv.d
@@ -1090,6 +1090,7 @@ enum Capability : uint
     OptNoneINTEL = 6094,
     AtomicFloat16AddEXT = 6095,
     DebugInfoModuleINTEL = 6114,
+    SplitBarrierINTEL = 6141,
 }
 
 enum RayFlagsShift : uint
@@ -1854,6 +1855,8 @@ enum Op : uint
     OpTypeStructContinuedINTEL = 6090,
     OpConstantCompositeContinuedINTEL = 6091,
     OpSpecConstantCompositeContinuedINTEL = 6092,
+    OpControlBarrierArriveINTEL = 6142,
+    OpControlBarrierWaitINTEL = 6143,
 }
 
 


### PR DESCRIPTION
This PR has header changes for an upcoming Intel extension SPV_INTEL_split_barrier.