### PR TITLE
build: use ARCH_INDEPENDENT if possible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,9 +89,14 @@ if (SPIRV_HEADERS_ENABLE_INSTALL)
     set(namespace "${PROJECT_NAME}::")
 
     include(CMakePackageConfigHelpers)
+
+    if (NOT CMAKE_VERSION VERSION_LESS 3.14)
+        set(arch_independent_str ARCH_INDEPENDENT)
+    endif()
     write_basic_package_version_file(
         "${version_config}"
         COMPATIBILITY SameMajorVersion
+        ${arch_independent_str}
     )
 
     configure_package_config_file(


### PR DESCRIPTION
Since this is a header-only library, the CMake Version file should be marked architecture-independent with the [`ARCH_INDEPENDENT`](https://cmake.org/cmake/help/latest/module/CMakePackageConfigHelpers.html#command:write_basic_package_version_file) option. As the option has been added in CMake 3.14 and spriv-headers supports CMake 3.0 the option has to be passed only if supported.