### PR TITLE
Register magic number for SPIRVSmith

### DIFF
--- a/include/spirv/spir-v.xml
+++ b/include/spirv/spir-v.xml
@@ -84,7 +84,8 @@
         <id value="31"  vendor="Google" tool="Skia SkSL" comment="Contact Ethan Nicholas, ethannicholas@google.com"/>
         <id value="32"  vendor="TornadoVM" tool="SPIRV Beehive Toolkit" comment="https://github.com/beehive-lab/spirv-beehive-toolkit"/>
         <id value="33"  vendor="DragonJoker" tool="ShaderWriter" comment="Contact Sylvain Doremus, https://github.com/DragonJoker/ShaderWriter"/>
-        <unused start="34" end="0xFFFF" comment="Tool ID range reservable for future use by vendors"/>
+        <id value="34"  vendor="Rayan Hatout" tool="SPIRVSmith" comment="Contact Rayan Hatout rayan.hatout@gmail.com, Repo https://github.com/rayanht/SPIRVSmith"/>
+        <unused start="35" end="0xFFFF" comment="Tool ID range reservable for future use by vendors"/>
     </ids>
 
     <!-- SECTION: SPIR-V Opcodes and Enumerants -->


### PR DESCRIPTION
This PR registers a generator magic number for [SPIRVSmith](https://github.com/rayanht/SPIRVSmith). SPIRVSmith is a differential testing tool that aims to find bug in SPIR-V consumers by fuzzing the SPIR-V Assembly language.