### PR TITLE
Update clspv reflection non-semantic instruction set

### DIFF
--- a/include/spirv/unified1/NonSemanticClspvReflection.h
+++ b/include/spirv/unified1/NonSemanticClspvReflection.h
@@ -33,7 +33,7 @@ extern "C" {
 #endif
 
 enum {
-    NonSemanticClspvReflectionRevision = 2,
+    NonSemanticClspvReflectionRevision = 3,
     NonSemanticClspvReflectionRevision_BitWidthPadding = 0x7fffffff
 };
 
@@ -63,6 +63,14 @@ enum NonSemanticClspvReflectionInstructions {
     NonSemanticClspvReflectionLiteralSampler = 23,
     NonSemanticClspvReflectionPropertyRequiredWorkgroupSize = 24,
     NonSemanticClspvReflectionSpecConstantSubgroupMaxSize = 25,
+    NonSemanticClspvReflectionArgumentPointerPushConstant = 26,
+    NonSemanticClspvReflectionArgumentPointerUniform = 27,
+    NonSemanticClspvReflectionProgramScopeVariablesStorageBuffer = 28,
+    NonSemanticClspvReflectionProgramScopeVariablePointerRelocation = 29,
+    NonSemanticClspvReflectionImageArgumentInfoChannelOrderPushConstant = 30,
+    NonSemanticClspvReflectionImageArgumentInfoChannelDataTypePushConstant = 31,
+    NonSemanticClspvReflectionImageArgumentInfoChannelOrderUniform = 32,
+    NonSemanticClspvReflectionImageArgumentInfoChannelDataTypeUniform = 33,
     NonSemanticClspvReflectionInstructionsMax = 0x7fffffff
 };
 

--- a/include/spirv/unified1/extinst.nonsemantic.clspvreflection.grammar.json
+++ b/include/spirv/unified1/extinst.nonsemantic.clspvreflection.grammar.json
@@ -1,5 +1,5 @@
 {
-  "revision" : 2,
+  "revision" : 3,
   "instructions" : [
     {
       "opname" : "Kernel",
@@ -237,6 +237,92 @@
       "opname" : "SpecConstantSubgroupMaxSize",
       "opcode" : 25,
       "operands" : [
+        { "kind" : "IdRef", "name" : "Size" }
+      ]
+    },
+    {
+      "opname" : "ArgumentPointerPushConstant",
+      "opcode" : 26,
+      "operands": [
+        { "kind" : "IdRef", "name" : "Kernel" },
+        { "kind" : "IdRef", "name" : "Ordinal" },
+        { "kind" : "IdRef", "name" : "Offset" },
+        { "kind" : "IdRef", "name" : "Size" },
+        { "kind" : "IdRef", "name" : "ArgInfo", "quantifier" : "?" }
+      ]
+    },
+    {
+      "opname" : "ArgumentPointerUniform",
+      "opcode" : 27,
+      "operands": [
+        { "kind" : "IdRef", "name" : "Kernel" },
+        { "kind" : "IdRef", "name" : "Ordinal" },
+        { "kind" : "IdRef", "name" : "DescriptorSet" },
+        { "kind" : "IdRef", "name" : "Binding" },
+        { "kind" : "IdRef", "name" : "Offset" },
+        { "kind" : "IdRef", "name" : "Size" },
+        { "kind" : "IdRef", "name" : "ArgInfo", "quantifier" : "?" }
+      ]
+    },
+    {
+      "opname" : "ProgramScopeVariablesStorageBuffer",
+      "opcode" : 28,
+      "operands": [
+        { "kind" : "IdRef", "name" : "DescriptorSet" },
+        { "kind" : "IdRef", "name" : "Binding" },
+        { "kind" : "IdRef", "name" : "Data" }
+      ]
+    },
+    {
+      "opname" : "ProgramScopeVariablePointerRelocation",
+      "opcode" : 29,
+      "operands": [
+        { "kind" : "IdRef", "name" : "ObjectOffset" },
+        { "kind" : "IdRef", "name" : "PointerOffset" },
+        { "kind" : "IdRef", "name" : "PointerSize" }
+      ]
+    },
+    {
+      "opname" : "ImageArgumentInfoChannelOrderPushConstant",
+      "opcode" : 30,
+      "operands": [
+        { "kind" : "IdRef", "name" : "Kernel" },
+        { "kind" : "IdRef", "name" : "Ordinal" },
+        { "kind" : "IdRef", "name" : "Offset" },
+        { "kind" : "IdRef", "name" : "Size" }
+      ]
+    },
+    {
+      "opname" : "ImageArgumentInfoChannelDataTypePushConstant",
+      "opcode" : 31,
+      "operands": [
+        { "kind" : "IdRef", "name" : "Kernel" },
+        { "kind" : "IdRef", "name" : "Ordinal" },
+        { "kind" : "IdRef", "name" : "Offset" },
+        { "kind" : "IdRef", "name" : "Size" }
+      ]
+    },
+    {
+      "opname" : "ImageArgumentInfoChannelOrderUniform",
+      "opcode" : 32,
+      "operands": [
+        { "kind" : "IdRef", "name" : "Kernel" },
+        { "kind" : "IdRef", "name" : "Ordinal" },
+        { "kind" : "IdRef", "name" : "DescriptorSet" },
+        { "kind" : "IdRef", "name" : "Binding" },
+        { "kind" : "IdRef", "name" : "Offset" },
+        { "kind" : "IdRef", "name" : "Size" }
+      ]
+    },
+    {
+      "opname" : "ImageArgumentInfoChannelDataTypeUniform",
+      "opcode" : 33,
+      "operands": [
+        { "kind" : "IdRef", "name" : "Kernel" },
+        { "kind" : "IdRef", "name" : "Ordinal" },
+        { "kind" : "IdRef", "name" : "DescriptorSet" },
+        { "kind" : "IdRef", "name" : "Binding" },
+        { "kind" : "IdRef", "name" : "Offset" },
         { "kind" : "IdRef", "name" : "Size" }
       ]
     }


### PR DESCRIPTION
Add support for:

- Pointer arguments
- Program scope variables
- Image channel order and data type queries

Signed-off-by: Kévin Petit <kpet@free.fr>