### PR TITLE
Add change to workaround enum range issue

### DIFF
--- a/include/spirv/unified1/spirv.hpp
+++ b/include/spirv/unified1/spirv.hpp
@@ -742,6 +742,7 @@ enum LoopControlMask {
     LoopControlMaxInterleavingINTELMask = 0x00200000,
     LoopControlSpeculatedIterationsINTELMask = 0x00400000,
     LoopControlNoFusionINTELMask = 0x00800000,
+    LoopControlMax = 0x7fffffff,
 };
 
 enum FunctionControlShift {

--- a/include/spirv/unified1/spirv.hpp
+++ b/include/spirv/unified1/spirv.hpp
@@ -742,7 +742,7 @@ enum LoopControlMask {
     LoopControlMaxInterleavingINTELMask = 0x00200000,
     LoopControlSpeculatedIterationsINTELMask = 0x00400000,
     LoopControlNoFusionINTELMask = 0x00800000,
-    LoopControlMax = 0x7fffffff,
+    LoopControlMaskMax = 0x7fffffff,
 };
 
 enum FunctionControlShift {


### PR DESCRIPTION
Clients of LoopControlMask enum may try to 'extend' the enum by adding new masks. However, the new mask will lie outside the allowed range of values for this enum. In this change, we intend to increase the enum range.
Signed-off-by: Arvind Sudarsanam <arvind.sudarsanam@intel.com>