### PR TITLE
registered ID for Shady

### DIFF
--- a/include/spirv/spir-v.xml
+++ b/include/spirv/spir-v.xml
@@ -85,7 +85,8 @@
         <id value="32"  vendor="TornadoVM" tool="SPIRV Beehive Toolkit" comment="https://github.com/beehive-lab/spirv-beehive-toolkit"/>
         <id value="33"  vendor="DragonJoker" tool="ShaderWriter" comment="Contact Sylvain Doremus, https://github.com/DragonJoker/ShaderWriter"/>
         <id value="34"  vendor="Rayan Hatout" tool="SPIRVSmith" comment="Contact Rayan Hatout rayan.hatout@gmail.com, Repo https://github.com/rayanht/SPIRVSmith"/>
-        <unused start="35" end="0xFFFF" comment="Tool ID range reservable for future use by vendors"/>
+        <id value="35"  vendor="Saarland University" tool="Shady" comment="Contact Hugo Devillers devillers@uni-saarland.de, Repo https://github.com/Hugobros3/shady"/>
+        <unused start="36" end="0xFFFF" comment="Tool ID range reservable for future use by vendors"/>
     </ids>
 
     <!-- SECTION: SPIR-V Opcodes and Enumerants -->


### PR DESCRIPTION
Shady is a research compiler / tool for making emitting SPIR-V easier.

Shady includes support for features not currently supported by Vulkan SPIR-V shaders, such as physical pointers into shared and private memory, dynamically structured control flow and real function pointers, supported by a stack.

The purpose of shady is to make it easier to target SPIR-V, by offering convenience features such as a builder API, but also by supporting features that typical general-purpose compilers expect.

Shady achieves this by having a carefully designed intermediate representation that can flexibly represent code in various stages of lowering, and aims to offer a highly configurable set of passes and optimizations that take the most advantage of the particular device found on the machine. This means dynamically JIT'ing code to best match the offered SPIR-V revision, capabilities, extensions and possibly workarounds for certain drivers.

Shady also comes with a simplistic demo front-end, (used for parsing IR from file), as well as some Vulkan runtime support code for querying the device capabilities and feeding that into the compiler, and we have plans to experiment with other targets such as GLSL or OpenCL C, since they share similar restrictions to SPIR-V.

https://github.com/Hugobros3/shady