### PR TITLE
Add support for texel buffers to clspv non-semantic instruction set

### DIFF
--- a/include/spirv/unified1/NonSemanticClspvReflection.h
+++ b/include/spirv/unified1/NonSemanticClspvReflection.h
@@ -33,7 +33,7 @@ extern "C" {
 #endif
 
 enum {
-    NonSemanticClspvReflectionRevision = 3,
+    NonSemanticClspvReflectionRevision = 4,
     NonSemanticClspvReflectionRevision_BitWidthPadding = 0x7fffffff
 };
 
@@ -71,6 +71,8 @@ enum NonSemanticClspvReflectionInstructions {
     NonSemanticClspvReflectionImageArgumentInfoChannelDataTypePushConstant = 31,
     NonSemanticClspvReflectionImageArgumentInfoChannelOrderUniform = 32,
     NonSemanticClspvReflectionImageArgumentInfoChannelDataTypeUniform = 33,
+    NonSemanticClspvReflectionArgumentStorageTexelBuffer = 34,
+    NonSemanticClspvReflectionArgumentUniformTexelBuffer = 35,
     NonSemanticClspvReflectionInstructionsMax = 0x7fffffff
 };
 

--- a/include/spirv/unified1/extinst.nonsemantic.clspvreflection.grammar.json
+++ b/include/spirv/unified1/extinst.nonsemantic.clspvreflection.grammar.json
@@ -1,5 +1,5 @@
 {
-  "revision" : 3,
+  "revision" : 4,
   "instructions" : [
     {
       "opname" : "Kernel",
@@ -324,6 +324,28 @@
         { "kind" : "IdRef", "name" : "Binding" },
         { "kind" : "IdRef", "name" : "Offset" },
         { "kind" : "IdRef", "name" : "Size" }
+      ]
+    },
+    {
+      "opname" : "ArgumentStorageTexelBuffer",
+      "opcode" : 34,
+      "operands" : [
+        { "kind" : "IdRef", "name" : "Decl" },
+        { "kind" : "IdRef", "name" : "Ordinal" },
+        { "kind" : "IdRef", "name" : "DescriptorSet" },
+        { "kind" : "IdRef", "name" : "Binding" },
+        { "kind" : "IdRef", "name" : "ArgInfo", "quantifier" : "?" }
+      ]
+    },
+    {
+      "opname" : "ArgumentUniformTexelBuffer",
+      "opcode" : 35,
+      "operands" : [
+        { "kind" : "IdRef", "name" : "Decl" },
+        { "kind" : "IdRef", "name" : "Ordinal" },
+        { "kind" : "IdRef", "name" : "DescriptorSet" },
+        { "kind" : "IdRef", "name" : "Binding" },
+        { "kind" : "IdRef", "name" : "ArgInfo", "quantifier" : "?" }
       ]
     }
   ]


### PR DESCRIPTION
Specification change: https://github.com/KhronosGroup/SPIRV-Registry/pull/172

Signed-off-by: Kévin Petit <kpet@free.fr>