### PR TITLE
Revert "Merge pull request #301 from alan-baker/hpp1"

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -32,14 +32,12 @@ source_set("spv_headers") {
     "include/spirv/1.2/OpenCL.std.h",
     "include/spirv/1.2/spirv.h",
     "include/spirv/1.2/spirv.hpp",
-    "include/spirv/1.2/spirv.hpp11",
     "include/spirv/unified1/GLSL.std.450.h",
     "include/spirv/unified1/NonSemanticClspvReflection.h",
     "include/spirv/unified1/NonSemanticDebugPrintf.h",
     "include/spirv/unified1/OpenCL.std.h",
     "include/spirv/unified1/spirv.h",
     "include/spirv/unified1/spirv.hpp",
-    "include/spirv/unified1/spirv.hpp11",
   ]
 
   public_configs = [ ":spv_headers_public_config" ]


### PR DESCRIPTION
This reverts commit 747031e10dea9e6c5651bf11957a9dbcd379fa47, reversing changes made to 85a1ed200d50660786c1a88d9166e871123cce39.

In other words, don't add the .hpp11 files to the BUILD.gn That's because GN doesn't recognize .hpp11 extension as a C/C++ header file.

See https://bugs.chromium.org/p/gn/issues/detail?id=311

Instead, client dependencies should #include the .hpp11 file directly even though that seems to hide it away from GN's visibility. That seems wrong, but it does work.