### PR TITLE
Add support for StreamingInterfaceINTEL in headers

### DIFF
--- a/include/spirv/unified1/spirv.bf
+++ b/include/spirv/unified1/spirv.bf
@@ -192,6 +192,7 @@ namespace Spv
             NoGlobalOffsetINTEL = 5895,
             NumSIMDWorkitemsINTEL = 5896,
             SchedulerTargetFmaxMhzINTEL = 5903,
+            StreamingInterfaceINTEL = 6154,
             NamedBarrierCountINTEL = 6417,
         }
 

--- a/include/spirv/unified1/spirv.core.grammar.json
+++ b/include/spirv/unified1/spirv.core.grammar.json
@@ -10711,7 +10711,7 @@
           "enumerant" : "StreamingInterfaceINTEL",
           "value" : 6154,
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'streaming_interface'" }
+            { "kind" : "LiteralInteger", "name" : "'StallFreeReturn'" }
           ],
           "capabilities" : [ "FPGAKernelAttributesINTEL" ],
           "version" : "None"

--- a/include/spirv/unified1/spirv.core.grammar.json
+++ b/include/spirv/unified1/spirv.core.grammar.json
@@ -10708,6 +10708,15 @@
           "version" : "None"
         },
         {
+          "enumerant" : "StreamingInterfaceINTEL",
+          "value" : 6154,
+          "parameters" : [
+            { "kind" : "LiteralInteger", "name" : "'streaming_interface'" }
+          ],
+          "capabilities" : [ "FPGAKernelAttributesINTEL" ],
+          "version" : "None"
+        },
+        {
           "enumerant" : "NamedBarrierCountINTEL",
           "value" : 6417,
           "parameters" : [

--- a/include/spirv/unified1/spirv.cs
+++ b/include/spirv/unified1/spirv.cs
@@ -191,6 +191,7 @@ namespace Spv
             NoGlobalOffsetINTEL = 5895,
             NumSIMDWorkitemsINTEL = 5896,
             SchedulerTargetFmaxMhzINTEL = 5903,
+            StreamingInterfaceINTEL = 6154,
             NamedBarrierCountINTEL = 6417,
         }
 

--- a/include/spirv/unified1/spirv.h
+++ b/include/spirv/unified1/spirv.h
@@ -199,6 +199,7 @@ typedef enum SpvExecutionMode_ {
     SpvExecutionModeNoGlobalOffsetINTEL = 5895,
     SpvExecutionModeNumSIMDWorkitemsINTEL = 5896,
     SpvExecutionModeSchedulerTargetFmaxMhzINTEL = 5903,
+    SpvExecutionModeStreamingInterfaceINTEL = 6154,
     SpvExecutionModeNamedBarrierCountINTEL = 6417,
     SpvExecutionModeMax = 0x7fffffff,
 } SpvExecutionMode;

--- a/include/spirv/unified1/spirv.hpp
+++ b/include/spirv/unified1/spirv.hpp
@@ -195,6 +195,7 @@ enum ExecutionMode {
     ExecutionModeNoGlobalOffsetINTEL = 5895,
     ExecutionModeNumSIMDWorkitemsINTEL = 5896,
     ExecutionModeSchedulerTargetFmaxMhzINTEL = 5903,
+    ExecutionModeStreamingInterfaceINTEL = 6154,
     ExecutionModeNamedBarrierCountINTEL = 6417,
     ExecutionModeMax = 0x7fffffff,
 };

--- a/include/spirv/unified1/spirv.hpp11
+++ b/include/spirv/unified1/spirv.hpp11
@@ -195,6 +195,7 @@ enum class ExecutionMode : unsigned {
     NoGlobalOffsetINTEL = 5895,
     NumSIMDWorkitemsINTEL = 5896,
     SchedulerTargetFmaxMhzINTEL = 5903,
+    StreamingInterfaceINTEL = 6154,
     NamedBarrierCountINTEL = 6417,
     Max = 0x7fffffff,
 };

--- a/include/spirv/unified1/spirv.json
+++ b/include/spirv/unified1/spirv.json
@@ -214,6 +214,7 @@
                     "NoGlobalOffsetINTEL": 5895,
                     "NumSIMDWorkitemsINTEL": 5896,
                     "SchedulerTargetFmaxMhzINTEL": 5903,
+                    "StreamingInterfaceINTEL" : 6154,
                     "NamedBarrierCountINTEL": 6417
                 }
             },

--- a/include/spirv/unified1/spirv.json
+++ b/include/spirv/unified1/spirv.json
@@ -214,7 +214,7 @@
                     "NoGlobalOffsetINTEL": 5895,
                     "NumSIMDWorkitemsINTEL": 5896,
                     "SchedulerTargetFmaxMhzINTEL": 5903,
-                    "StreamingInterfaceINTEL" : 6154,
+                    "StreamingInterfaceINTEL": 6154,
                     "NamedBarrierCountINTEL": 6417
                 }
             },

--- a/include/spirv/unified1/spirv.lua
+++ b/include/spirv/unified1/spirv.lua
@@ -182,6 +182,7 @@ spv = {
         NoGlobalOffsetINTEL = 5895,
         NumSIMDWorkitemsINTEL = 5896,
         SchedulerTargetFmaxMhzINTEL = 5903,
+        StreamingInterfaceINTEL = 6154,
         NamedBarrierCountINTEL = 6417,
     },
 

--- a/include/spirv/unified1/spirv.py
+++ b/include/spirv/unified1/spirv.py
@@ -182,6 +182,7 @@ spv = {
         'NoGlobalOffsetINTEL' : 5895,
         'NumSIMDWorkitemsINTEL' : 5896,
         'SchedulerTargetFmaxMhzINTEL' : 5903,
+        'StreamingInterfaceINTEL' : 6154,
         'NamedBarrierCountINTEL' : 6417,
     },
 

--- a/include/spirv/unified1/spv.d
+++ b/include/spirv/unified1/spv.d
@@ -194,6 +194,7 @@ enum ExecutionMode : uint
     NoGlobalOffsetINTEL = 5895,
     NumSIMDWorkitemsINTEL = 5896,
     SchedulerTargetFmaxMhzINTEL = 5903,
+    StreamingInterfaceINTEL = 6154,
     NamedBarrierCountINTEL = 6417,
 }
 


### PR DESCRIPTION
[SPV_INTEL_kernel_attributes.asciidoc](https://github.com/KhronosGroup/SPIRV-Registry/blob/main/extensions/INTEL/SPV_INTEL_kernel_attributes.asciidoc) added support for StreamingInterfaceINTEL, but the enumeration values were never added to the header files.  Add them in.