### PR TITLE
Update ClspvReflection non-semantic instruction set

### DIFF
--- a/include/spirv/unified1/NonSemanticClspvReflection.h
+++ b/include/spirv/unified1/NonSemanticClspvReflection.h
@@ -33,7 +33,7 @@ extern "C" {
 #endif
 
 enum {
-    NonSemanticClspvReflectionRevision = 4,
+    NonSemanticClspvReflectionRevision = 5,
     NonSemanticClspvReflectionRevision_BitWidthPadding = 0x7fffffff
 };
 
@@ -73,7 +73,19 @@ enum NonSemanticClspvReflectionInstructions {
     NonSemanticClspvReflectionImageArgumentInfoChannelDataTypeUniform = 33,
     NonSemanticClspvReflectionArgumentStorageTexelBuffer = 34,
     NonSemanticClspvReflectionArgumentUniformTexelBuffer = 35,
+    NonSemanticClspvReflectionConstantDataPointerPushConstant = 36,
+    NonSemanticClspvReflectionProgramScopeVariablePointerPushConstant = 37,
+    NonSemanticClspvReflectionPrintfInfo = 38,
+    NonSemanticClspvReflectionPrintfBufferStorageBuffer = 39,
+    NonSemanticClspvReflectionPrintfBufferPointerPushConstant = 40,
     NonSemanticClspvReflectionInstructionsMax = 0x7fffffff
+};
+
+
+enum NonSemanticClspvReflectionKernelPropertyFlags {
+    NonSemanticClspvReflectionNone = 0x0,
+    NonSemanticClspvReflectionMayUsePrintf = 0x1,
+    NonSemanticClspvReflectionKernelPropertyFlagsMax = 0x7fffffff
 };
 
 

--- a/include/spirv/unified1/extinst.nonsemantic.clspvreflection.grammar.json
+++ b/include/spirv/unified1/extinst.nonsemantic.clspvreflection.grammar.json
@@ -1,12 +1,15 @@
 {
-  "revision" : 4,
+  "revision" : 5,
   "instructions" : [
     {
       "opname" : "Kernel",
       "opcode" : 1,
       "operands" : [
         { "kind" : "IdRef", "name" : "Kernel" },
-        { "kind" : "IdRef", "name" : "Name" }
+        { "kind" : "IdRef", "name" : "Name" },
+        { "kind" : "IdRef", "name" : "NumArguments"},
+        { "kind" : "IdRef", "name" : "Flags" },
+        { "kind" : "IdRef", "name" : "Attributes" }
       ]
     },
     {
@@ -346,6 +349,67 @@
         { "kind" : "IdRef", "name" : "DescriptorSet" },
         { "kind" : "IdRef", "name" : "Binding" },
         { "kind" : "IdRef", "name" : "ArgInfo", "quantifier" : "?" }
+      ]
+    },
+    {
+      "opname" : "ConstantDataPointerPushConstant",
+      "opcode" : 36,
+      "operands" : [
+        { "kind" : "IdRef", "name" : "Offset"},
+        { "kind" : "IdRef", "name" : "Size"},
+        { "kind" : "IdRef", "name" : "Data" }
+      ]
+    },
+    {
+      "opname" : "ProgramScopeVariablePointerPushConstant",
+      "opcode" : 37,
+      "operands" : [
+        { "kind" : "IdRef", "name" : "Offset"},
+        { "kind" : "IdRef", "name" : "Size"},
+        { "kind" : "IdRef", "name" : "Data" }
+      ]
+    },
+    {
+      "opname" : "PrintfInfo",
+      "opcode" : 38,
+      "operands" : [
+        { "kind" : "IdRef", "name" : "PrintfID" },
+        { "kind" : "IdRef", "name" : "FormatString" },
+        { "kind" : "IdRef", "quantifier" : "*", "name" : "ArgumentSizes"}
+      ]
+    },
+    {
+      "opname" : "PrintfBufferStorageBuffer",
+      "opcode" : 39,
+      "operands" : [
+        { "kind" : "IdRef", "name" : "DescriptorSet" },
+        { "kind" : "IdRef", "name" : "Binding" },
+        { "kind" : "IdRef", "name" : "BufferSize"}
+      ]
+    },
+    {
+    "opname" : "PrintfBufferPointerPushConstant",
+    "opcode" : 40,
+    "operands" : [
+      { "kind" : "IdRef", "name" : "Offset" },
+      { "kind" : "IdRef", "name" : "Size"},
+      { "kind" : "IdRef", "name" : "BufferSize"}
+      ]
+    }
+  ],
+  "operand_kinds" : [
+    {
+      "category" : "BitEnum",
+      "kind" : "KernelPropertyFlags",
+      "enumerants" : [
+        {
+          "enumerant" : "None",
+          "value" : "0x0"
+        },
+        {
+          "enumerant" : "MayUsePrintf",
+          "value" : "0x1"
+        }
       ]
     }
   ]


### PR DESCRIPTION
Add support to the clspv reflection non-semantic instruction set for:
* Printf builtin
* Device address push constants for module-scope constants and program-scope global variables
* NumArguments, Flags, and Attributes for the Kernel instruction

This contribution is being made by Codeplay on behalf of Samsung.