### PR TITLE
decouple SPV_KHR_shader_clock from the Shader capability

### DIFF
--- a/include/spirv/unified1/spirv.core.grammar.json
+++ b/include/spirv/unified1/spirv.core.grammar.json
@@ -4751,7 +4751,6 @@
         { "kind" : "IdScope", "name" : "'Scope'" }
       ],
       "capabilities" : [ "ShaderClockKHR" ],
-      "extensions" : [ "SPV_KHR_shader_clock" ],
       "version" : "None"
     },
     {
@@ -14056,7 +14055,6 @@
         {
           "enumerant" : "ShaderClockKHR",
           "value" : 5055,
-          "capabilities" : [ "Shader" ],
           "extensions" : [ "SPV_KHR_shader_clock" ],
           "version" : "None"
         },


### PR DESCRIPTION
Fixes the SPIR-V grammar file to decouple the SPV_KHR_shader_clock extension from the Shader capability.  This coupling was likely from an earlier unpublished version of this extension, and no coupling exists in the published extension specification.

[Here](http://htmlpreview.github.io/?https://github.com/KhronosGroup/SPIRV-Registry/blob/main/extensions/KHR/SPV_KHR_shader_clock.html) is the SPV_KHR_shader_clock extension specification, for reference.

Fixes internal issue #721.