### PR TITLE
Add support for the execution mode RegisterMapInterfaceINTEL

### DIFF
--- a/include/spirv/unified1/spirv.bf
+++ b/include/spirv/unified1/spirv.bf
@@ -194,7 +194,6 @@ namespace Spv
             SchedulerTargetFmaxMhzINTEL = 5903,
             StreamingInterfaceINTEL = 6154,
             RegisterMapInterfaceINTEL = 6160,
-            FPGAKernelAttributesv2INTEL = 6161,
             NamedBarrierCountINTEL = 6417,
         }
 
@@ -1149,6 +1148,7 @@ namespace Spv
             AtomicFloat16AddEXT = 6095,
             DebugInfoModuleINTEL = 6114,
             SplitBarrierINTEL = 6141,
+            FPGAKernelAttributesv2INTEL = 6161,
             FPGAArgumentInterfacesINTEL = 6174,
             GroupUniformArithmeticKHR = 6400,
         }

--- a/include/spirv/unified1/spirv.bf
+++ b/include/spirv/unified1/spirv.bf
@@ -193,6 +193,7 @@ namespace Spv
             NumSIMDWorkitemsINTEL = 5896,
             SchedulerTargetFmaxMhzINTEL = 5903,
             StreamingInterfaceINTEL = 6154,
+            RegisterMapInterfaceINTEL = 6160,
             NamedBarrierCountINTEL = 6417,
         }
 

--- a/include/spirv/unified1/spirv.bf
+++ b/include/spirv/unified1/spirv.bf
@@ -1117,6 +1117,7 @@ namespace Spv
             FPGALoopControlsINTEL = 5888,
             KernelAttributesINTEL = 5892,
             FPGAKernelAttributesINTEL = 5897,
+            FPGAKernelAttributesv2INTEL = 6161,
             FPGAMemoryAccessesINTEL = 5898,
             FPGAClusterAttributesINTEL = 5904,
             LoopFuseINTEL = 5906,

--- a/include/spirv/unified1/spirv.bf
+++ b/include/spirv/unified1/spirv.bf
@@ -194,6 +194,7 @@ namespace Spv
             SchedulerTargetFmaxMhzINTEL = 5903,
             StreamingInterfaceINTEL = 6154,
             RegisterMapInterfaceINTEL = 6160,
+            FPGAKernelAttributesv2INTEL = 6161,
             NamedBarrierCountINTEL = 6417,
         }
 
@@ -1117,7 +1118,6 @@ namespace Spv
             FPGALoopControlsINTEL = 5888,
             KernelAttributesINTEL = 5892,
             FPGAKernelAttributesINTEL = 5897,
-            FPGAKernelAttributesv2INTEL = 6161,
             FPGAMemoryAccessesINTEL = 5898,
             FPGAClusterAttributesINTEL = 5904,
             LoopFuseINTEL = 5906,

--- a/include/spirv/unified1/spirv.core.grammar.json
+++ b/include/spirv/unified1/spirv.core.grammar.json
@@ -10719,7 +10719,7 @@
           "enumerant" : "RegisterMapInterfaceINTEL",
           "value" : 6160,
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'AcceptDownstreamStall'" }
+            { "kind" : "LiteralInteger", "name" : "'WaitForDoneWrite'" }
           ],
           "capabilities" : [ "FPGAKernelAttributesv2INTEL" ],
           "version" : "None"

--- a/include/spirv/unified1/spirv.core.grammar.json
+++ b/include/spirv/unified1/spirv.core.grammar.json
@@ -10725,13 +10725,6 @@
           "version" : "None"
         },
         {
-          "enumerant" : "FPGAKernelAttributesv2INTEL",
-          "value" : 6161,
-          "capabilities" : [ "FPGAKernelAttributesINTEL" ],
-          "extensions" : [ "SPV_INTEL_kernel_attributes" ],
-          "version" : "None"
-        },
-        {
           "enumerant" : "NamedBarrierCountINTEL",
           "value" : 6417,
           "parameters" : [
@@ -14907,6 +14900,13 @@
           "enumerant" : "SplitBarrierINTEL",
           "value" : 6141,
           "extensions" : [ "SPV_INTEL_split_barrier" ],
+          "version" : "None"
+        },
+        {
+          "enumerant" : "FPGAKernelAttributesv2INTEL",
+          "value" : 6161,
+          "capabilities" : [ "FPGAKernelAttributesINTEL" ],
+          "extensions" : [ "SPV_INTEL_kernel_attributes" ],
           "version" : "None"
         },
         {

--- a/include/spirv/unified1/spirv.core.grammar.json
+++ b/include/spirv/unified1/spirv.core.grammar.json
@@ -10716,6 +10716,15 @@
           "version" : "None"
         },
         {
+          "enumerant" : "RegisterMapInterfaceINTEL",
+          "value" : 6160,
+          "parameters" : [
+            { "kind" : "LiteralInteger", "name" : "'AcceptDownstreamStall'" }
+          ],
+          "capabilities" : [ "FPGAKernelAttributesv2INTEL" ],
+          "version" : "None"
+        },
+        {
           "enumerant" : "NamedBarrierCountINTEL",
           "value" : 6417,
           "parameters" : [
@@ -14705,6 +14714,12 @@
         {
           "enumerant" : "FPGAKernelAttributesINTEL",
           "value" : 5897,
+          "extensions" : [ "SPV_INTEL_kernel_attributes" ],
+          "version" : "None"
+        },
+        {
+          "enumerant" : "FPGAKernelAttributesv2INTEL",
+          "value" : 6161,
           "extensions" : [ "SPV_INTEL_kernel_attributes" ],
           "version" : "None"
         },

--- a/include/spirv/unified1/spirv.core.grammar.json
+++ b/include/spirv/unified1/spirv.core.grammar.json
@@ -10725,6 +10725,13 @@
           "version" : "None"
         },
         {
+          "enumerant" : "FPGAKernelAttributesv2INTEL",
+          "value" : 6161,
+          "capabilities" : [ "FPGAKernelAttributesINTEL" ],
+          "extensions" : [ "SPV_INTEL_kernel_attributes" ],
+          "version" : "None"
+        },
+        {
           "enumerant" : "NamedBarrierCountINTEL",
           "value" : 6417,
           "parameters" : [
@@ -14714,13 +14721,6 @@
         {
           "enumerant" : "FPGAKernelAttributesINTEL",
           "value" : 5897,
-          "extensions" : [ "SPV_INTEL_kernel_attributes" ],
-          "version" : "None"
-        },
-        {
-          "enumerant" : "FPGAKernelAttributesv2INTEL",
-          "value" : 6161,
-          "capabilities" : [ "FPGAKernelAttributesINTEL" ],
           "extensions" : [ "SPV_INTEL_kernel_attributes" ],
           "version" : "None"
         },

--- a/include/spirv/unified1/spirv.cs
+++ b/include/spirv/unified1/spirv.cs
@@ -193,6 +193,7 @@ namespace Spv
             SchedulerTargetFmaxMhzINTEL = 5903,
             StreamingInterfaceINTEL = 6154,
             RegisterMapInterfaceINTEL = 6160,
+            FPGAKernelAttributesv2INTEL = 6161,
             NamedBarrierCountINTEL = 6417,
         }
 
@@ -1116,7 +1117,6 @@ namespace Spv
             FPGALoopControlsINTEL = 5888,
             KernelAttributesINTEL = 5892,
             FPGAKernelAttributesINTEL = 5897,
-            FPGAKernelAttributesv2INTEL = 6161,
             FPGAMemoryAccessesINTEL = 5898,
             FPGAClusterAttributesINTEL = 5904,
             LoopFuseINTEL = 5906,

--- a/include/spirv/unified1/spirv.cs
+++ b/include/spirv/unified1/spirv.cs
@@ -192,6 +192,7 @@ namespace Spv
             NumSIMDWorkitemsINTEL = 5896,
             SchedulerTargetFmaxMhzINTEL = 5903,
             StreamingInterfaceINTEL = 6154,
+            RegisterMapInterfaceINTEL = 6160,
             NamedBarrierCountINTEL = 6417,
         }
 

--- a/include/spirv/unified1/spirv.cs
+++ b/include/spirv/unified1/spirv.cs
@@ -1116,6 +1116,7 @@ namespace Spv
             FPGALoopControlsINTEL = 5888,
             KernelAttributesINTEL = 5892,
             FPGAKernelAttributesINTEL = 5897,
+            FPGAKernelAttributesv2INTEL = 6161,
             FPGAMemoryAccessesINTEL = 5898,
             FPGAClusterAttributesINTEL = 5904,
             LoopFuseINTEL = 5906,

--- a/include/spirv/unified1/spirv.cs
+++ b/include/spirv/unified1/spirv.cs
@@ -193,7 +193,6 @@ namespace Spv
             SchedulerTargetFmaxMhzINTEL = 5903,
             StreamingInterfaceINTEL = 6154,
             RegisterMapInterfaceINTEL = 6160,
-            FPGAKernelAttributesv2INTEL = 6161,
             NamedBarrierCountINTEL = 6417,
         }
 
@@ -1148,6 +1147,7 @@ namespace Spv
             AtomicFloat16AddEXT = 6095,
             DebugInfoModuleINTEL = 6114,
             SplitBarrierINTEL = 6141,
+            FPGAKernelAttributesv2INTEL = 6161,
             FPGAArgumentInterfacesINTEL = 6174,
             GroupUniformArithmeticKHR = 6400,
         }

--- a/include/spirv/unified1/spirv.h
+++ b/include/spirv/unified1/spirv.h
@@ -201,7 +201,6 @@ typedef enum SpvExecutionMode_ {
     SpvExecutionModeSchedulerTargetFmaxMhzINTEL = 5903,
     SpvExecutionModeStreamingInterfaceINTEL = 6154,
     SpvExecutionModeRegisterMapInterfaceINTEL = 6160,
-    SpvExecutionModeFPGAKernelAttributesv2INTEL = 6161,
     SpvExecutionModeNamedBarrierCountINTEL = 6417,
     SpvExecutionModeMax = 0x7fffffff,
 } SpvExecutionMode;
@@ -1148,6 +1147,7 @@ typedef enum SpvCapability_ {
     SpvCapabilityAtomicFloat16AddEXT = 6095,
     SpvCapabilityDebugInfoModuleINTEL = 6114,
     SpvCapabilitySplitBarrierINTEL = 6141,
+    SpvCapabilityFPGAKernelAttributesv2INTEL = 6161,
     SpvCapabilityFPGAArgumentInterfacesINTEL = 6174,
     SpvCapabilityGroupUniformArithmeticKHR = 6400,
     SpvCapabilityMax = 0x7fffffff,

--- a/include/spirv/unified1/spirv.h
+++ b/include/spirv/unified1/spirv.h
@@ -201,6 +201,7 @@ typedef enum SpvExecutionMode_ {
     SpvExecutionModeSchedulerTargetFmaxMhzINTEL = 5903,
     SpvExecutionModeStreamingInterfaceINTEL = 6154,
     SpvExecutionModeRegisterMapInterfaceINTEL = 6160,
+    SpvExecutionModeFPGAKernelAttributesv2INTEL = 6161,
     SpvExecutionModeNamedBarrierCountINTEL = 6417,
     SpvExecutionModeMax = 0x7fffffff,
 } SpvExecutionMode;
@@ -1116,7 +1117,6 @@ typedef enum SpvCapability_ {
     SpvCapabilityFPGALoopControlsINTEL = 5888,
     SpvCapabilityKernelAttributesINTEL = 5892,
     SpvCapabilityFPGAKernelAttributesINTEL = 5897,
-    SpvCapabilityFPGAKernelAttributesv2INTEL = 6161,
     SpvCapabilityFPGAMemoryAccessesINTEL = 5898,
     SpvCapabilityFPGAClusterAttributesINTEL = 5904,
     SpvCapabilityLoopFuseINTEL = 5906,

--- a/include/spirv/unified1/spirv.h
+++ b/include/spirv/unified1/spirv.h
@@ -200,6 +200,7 @@ typedef enum SpvExecutionMode_ {
     SpvExecutionModeNumSIMDWorkitemsINTEL = 5896,
     SpvExecutionModeSchedulerTargetFmaxMhzINTEL = 5903,
     SpvExecutionModeStreamingInterfaceINTEL = 6154,
+    SpvExecutionModeRegisterMapInterfaceINTEL = 6160,
     SpvExecutionModeNamedBarrierCountINTEL = 6417,
     SpvExecutionModeMax = 0x7fffffff,
 } SpvExecutionMode;

--- a/include/spirv/unified1/spirv.h
+++ b/include/spirv/unified1/spirv.h
@@ -1116,6 +1116,7 @@ typedef enum SpvCapability_ {
     SpvCapabilityFPGALoopControlsINTEL = 5888,
     SpvCapabilityKernelAttributesINTEL = 5892,
     SpvCapabilityFPGAKernelAttributesINTEL = 5897,
+    SpvCapabilityFPGAKernelAttributesv2INTEL = 6161,
     SpvCapabilityFPGAMemoryAccessesINTEL = 5898,
     SpvCapabilityFPGAClusterAttributesINTEL = 5904,
     SpvCapabilityLoopFuseINTEL = 5906,

--- a/include/spirv/unified1/spirv.hpp
+++ b/include/spirv/unified1/spirv.hpp
@@ -196,6 +196,7 @@ enum ExecutionMode {
     ExecutionModeNumSIMDWorkitemsINTEL = 5896,
     ExecutionModeSchedulerTargetFmaxMhzINTEL = 5903,
     ExecutionModeStreamingInterfaceINTEL = 6154,
+    ExecutionModeRegisterMapInterfaceINTEL = 6160,
     ExecutionModeNamedBarrierCountINTEL = 6417,
     ExecutionModeMax = 0x7fffffff,
 };

--- a/include/spirv/unified1/spirv.hpp
+++ b/include/spirv/unified1/spirv.hpp
@@ -197,7 +197,6 @@ enum ExecutionMode {
     ExecutionModeSchedulerTargetFmaxMhzINTEL = 5903,
     ExecutionModeStreamingInterfaceINTEL = 6154,
     ExecutionModeRegisterMapInterfaceINTEL = 6160,
-    ExecutionModeFPGAKernelAttributesv2INTEL = 6161,
     ExecutionModeNamedBarrierCountINTEL = 6417,
     ExecutionModeMax = 0x7fffffff,
 };
@@ -1144,6 +1143,7 @@ enum Capability {
     CapabilityAtomicFloat16AddEXT = 6095,
     CapabilityDebugInfoModuleINTEL = 6114,
     CapabilitySplitBarrierINTEL = 6141,
+    CapabilityFPGAKernelAttributesv2INTEL = 6161,
     CapabilityFPGAArgumentInterfacesINTEL = 6174,
     CapabilityGroupUniformArithmeticKHR = 6400,
     CapabilityMax = 0x7fffffff,

--- a/include/spirv/unified1/spirv.hpp
+++ b/include/spirv/unified1/spirv.hpp
@@ -1112,6 +1112,7 @@ enum Capability {
     CapabilityFPGALoopControlsINTEL = 5888,
     CapabilityKernelAttributesINTEL = 5892,
     CapabilityFPGAKernelAttributesINTEL = 5897,
+    CapabilityFPGAKernelAttributesv2INTEL = 6161,
     CapabilityFPGAMemoryAccessesINTEL = 5898,
     CapabilityFPGAClusterAttributesINTEL = 5904,
     CapabilityLoopFuseINTEL = 5906,

--- a/include/spirv/unified1/spirv.hpp
+++ b/include/spirv/unified1/spirv.hpp
@@ -197,6 +197,7 @@ enum ExecutionMode {
     ExecutionModeSchedulerTargetFmaxMhzINTEL = 5903,
     ExecutionModeStreamingInterfaceINTEL = 6154,
     ExecutionModeRegisterMapInterfaceINTEL = 6160,
+    ExecutionModeFPGAKernelAttributesv2INTEL = 6161,
     ExecutionModeNamedBarrierCountINTEL = 6417,
     ExecutionModeMax = 0x7fffffff,
 };
@@ -1112,7 +1113,6 @@ enum Capability {
     CapabilityFPGALoopControlsINTEL = 5888,
     CapabilityKernelAttributesINTEL = 5892,
     CapabilityFPGAKernelAttributesINTEL = 5897,
-    CapabilityFPGAKernelAttributesv2INTEL = 6161,
     CapabilityFPGAMemoryAccessesINTEL = 5898,
     CapabilityFPGAClusterAttributesINTEL = 5904,
     CapabilityLoopFuseINTEL = 5906,

--- a/include/spirv/unified1/spirv.hpp11
+++ b/include/spirv/unified1/spirv.hpp11
@@ -1112,6 +1112,7 @@ enum class Capability : unsigned {
     FPGALoopControlsINTEL = 5888,
     KernelAttributesINTEL = 5892,
     FPGAKernelAttributesINTEL = 5897,
+    FPGAKernelAttributesv2INTEL = 6161,
     FPGAMemoryAccessesINTEL = 5898,
     FPGAClusterAttributesINTEL = 5904,
     LoopFuseINTEL = 5906,

--- a/include/spirv/unified1/spirv.hpp11
+++ b/include/spirv/unified1/spirv.hpp11
@@ -196,6 +196,7 @@ enum class ExecutionMode : unsigned {
     NumSIMDWorkitemsINTEL = 5896,
     SchedulerTargetFmaxMhzINTEL = 5903,
     StreamingInterfaceINTEL = 6154,
+    RegisterMapInterfaceINTEL = 6160,
     NamedBarrierCountINTEL = 6417,
     Max = 0x7fffffff,
 };

--- a/include/spirv/unified1/spirv.hpp11
+++ b/include/spirv/unified1/spirv.hpp11
@@ -197,6 +197,7 @@ enum class ExecutionMode : unsigned {
     SchedulerTargetFmaxMhzINTEL = 5903,
     StreamingInterfaceINTEL = 6154,
     RegisterMapInterfaceINTEL = 6160,
+    FPGAKernelAttributesv2INTEL = 6161,
     NamedBarrierCountINTEL = 6417,
     Max = 0x7fffffff,
 };
@@ -1112,7 +1113,6 @@ enum class Capability : unsigned {
     FPGALoopControlsINTEL = 5888,
     KernelAttributesINTEL = 5892,
     FPGAKernelAttributesINTEL = 5897,
-    FPGAKernelAttributesv2INTEL = 6161,
     FPGAMemoryAccessesINTEL = 5898,
     FPGAClusterAttributesINTEL = 5904,
     LoopFuseINTEL = 5906,

--- a/include/spirv/unified1/spirv.hpp11
+++ b/include/spirv/unified1/spirv.hpp11
@@ -197,7 +197,6 @@ enum class ExecutionMode : unsigned {
     SchedulerTargetFmaxMhzINTEL = 5903,
     StreamingInterfaceINTEL = 6154,
     RegisterMapInterfaceINTEL = 6160,
-    FPGAKernelAttributesv2INTEL = 6161,
     NamedBarrierCountINTEL = 6417,
     Max = 0x7fffffff,
 };
@@ -1144,6 +1143,7 @@ enum class Capability : unsigned {
     AtomicFloat16AddEXT = 6095,
     DebugInfoModuleINTEL = 6114,
     SplitBarrierINTEL = 6141,
+    FPGAKernelAttributesv2INTEL = 6161,
     FPGAArgumentInterfacesINTEL = 6174,
     GroupUniformArithmeticKHR = 6400,
     Max = 0x7fffffff,

--- a/include/spirv/unified1/spirv.json
+++ b/include/spirv/unified1/spirv.json
@@ -1092,6 +1092,7 @@
                     "FPGALoopControlsINTEL": 5888,
                     "KernelAttributesINTEL": 5892,
                     "FPGAKernelAttributesINTEL": 5897,
+                    "FPGAKernelAttributesv2INTEL": 6161,
                     "FPGAMemoryAccessesINTEL": 5898,
                     "FPGAClusterAttributesINTEL": 5904,
                     "LoopFuseINTEL": 5906,

--- a/include/spirv/unified1/spirv.json
+++ b/include/spirv/unified1/spirv.json
@@ -216,7 +216,6 @@
                     "SchedulerTargetFmaxMhzINTEL": 5903,
                     "StreamingInterfaceINTEL": 6154,
                     "RegisterMapInterfaceINTEL": 6160,
-                    "FPGAKernelAttributesv2INTEL": 6161,
                     "NamedBarrierCountINTEL": 6417
                 }
             },
@@ -1124,6 +1123,7 @@
                     "AtomicFloat16AddEXT": 6095,
                     "DebugInfoModuleINTEL": 6114,
                     "SplitBarrierINTEL": 6141,
+                    "FPGAKernelAttributesv2INTEL": 6161,
                     "FPGAArgumentInterfacesINTEL": 6174,
                     "GroupUniformArithmeticKHR": 6400
                 }

--- a/include/spirv/unified1/spirv.json
+++ b/include/spirv/unified1/spirv.json
@@ -215,6 +215,7 @@
                     "NumSIMDWorkitemsINTEL": 5896,
                     "SchedulerTargetFmaxMhzINTEL": 5903,
                     "StreamingInterfaceINTEL": 6154,
+                    "RegisterMapInterfaceINTEL": 6160,
                     "NamedBarrierCountINTEL": 6417
                 }
             },

--- a/include/spirv/unified1/spirv.json
+++ b/include/spirv/unified1/spirv.json
@@ -216,6 +216,7 @@
                     "SchedulerTargetFmaxMhzINTEL": 5903,
                     "StreamingInterfaceINTEL": 6154,
                     "RegisterMapInterfaceINTEL": 6160,
+                    "FPGAKernelAttributesv2INTEL": 6161,
                     "NamedBarrierCountINTEL": 6417
                 }
             },
@@ -1092,7 +1093,6 @@
                     "FPGALoopControlsINTEL": 5888,
                     "KernelAttributesINTEL": 5892,
                     "FPGAKernelAttributesINTEL": 5897,
-                    "FPGAKernelAttributesv2INTEL": 6161,
                     "FPGAMemoryAccessesINTEL": 5898,
                     "FPGAClusterAttributesINTEL": 5904,
                     "LoopFuseINTEL": 5906,

--- a/include/spirv/unified1/spirv.lua
+++ b/include/spirv/unified1/spirv.lua
@@ -183,6 +183,7 @@ spv = {
         NumSIMDWorkitemsINTEL = 5896,
         SchedulerTargetFmaxMhzINTEL = 5903,
         StreamingInterfaceINTEL = 6154,
+        RegisterMapInterfaceINTEL = 6160,
         NamedBarrierCountINTEL = 6417,
     },
 

--- a/include/spirv/unified1/spirv.lua
+++ b/include/spirv/unified1/spirv.lua
@@ -184,6 +184,7 @@ spv = {
         SchedulerTargetFmaxMhzINTEL = 5903,
         StreamingInterfaceINTEL = 6154,
         RegisterMapInterfaceINTEL = 6160,
+        FPGAKernelAttributesv2INTEL = 6161,
         NamedBarrierCountINTEL = 6417,
     },
 
@@ -1074,7 +1075,6 @@ spv = {
         FPGALoopControlsINTEL = 5888,
         KernelAttributesINTEL = 5892,
         FPGAKernelAttributesINTEL = 5897,
-        FPGAKernelAttributesv2INTEL = 6161,
         FPGAMemoryAccessesINTEL = 5898,
         FPGAClusterAttributesINTEL = 5904,
         LoopFuseINTEL = 5906,

--- a/include/spirv/unified1/spirv.lua
+++ b/include/spirv/unified1/spirv.lua
@@ -184,7 +184,6 @@ spv = {
         SchedulerTargetFmaxMhzINTEL = 5903,
         StreamingInterfaceINTEL = 6154,
         RegisterMapInterfaceINTEL = 6160,
-        FPGAKernelAttributesv2INTEL = 6161,
         NamedBarrierCountINTEL = 6417,
     },
 
@@ -1106,6 +1105,7 @@ spv = {
         AtomicFloat16AddEXT = 6095,
         DebugInfoModuleINTEL = 6114,
         SplitBarrierINTEL = 6141,
+        FPGAKernelAttributesv2INTEL = 6161,
         FPGAArgumentInterfacesINTEL = 6174,
         GroupUniformArithmeticKHR = 6400,
     },

--- a/include/spirv/unified1/spirv.lua
+++ b/include/spirv/unified1/spirv.lua
@@ -1074,6 +1074,7 @@ spv = {
         FPGALoopControlsINTEL = 5888,
         KernelAttributesINTEL = 5892,
         FPGAKernelAttributesINTEL = 5897,
+        FPGAKernelAttributesv2INTEL = 6161,
         FPGAMemoryAccessesINTEL = 5898,
         FPGAClusterAttributesINTEL = 5904,
         LoopFuseINTEL = 5906,

--- a/include/spirv/unified1/spirv.py
+++ b/include/spirv/unified1/spirv.py
@@ -1074,6 +1074,7 @@ spv = {
         'FPGALoopControlsINTEL' : 5888,
         'KernelAttributesINTEL' : 5892,
         'FPGAKernelAttributesINTEL' : 5897,
+        'FPGAKernelAttributesv2INTEL' : 6161,
         'FPGAMemoryAccessesINTEL' : 5898,
         'FPGAClusterAttributesINTEL' : 5904,
         'LoopFuseINTEL' : 5906,

--- a/include/spirv/unified1/spirv.py
+++ b/include/spirv/unified1/spirv.py
@@ -184,6 +184,7 @@ spv = {
         'SchedulerTargetFmaxMhzINTEL' : 5903,
         'StreamingInterfaceINTEL' : 6154,
         'RegisterMapInterfaceINTEL' : 6160,
+        'FPGAKernelAttributesv2INTEL' : 6161,
         'NamedBarrierCountINTEL' : 6417,
     },
 
@@ -1074,7 +1075,6 @@ spv = {
         'FPGALoopControlsINTEL' : 5888,
         'KernelAttributesINTEL' : 5892,
         'FPGAKernelAttributesINTEL' : 5897,
-        'FPGAKernelAttributesv2INTEL' : 6161,
         'FPGAMemoryAccessesINTEL' : 5898,
         'FPGAClusterAttributesINTEL' : 5904,
         'LoopFuseINTEL' : 5906,

--- a/include/spirv/unified1/spirv.py
+++ b/include/spirv/unified1/spirv.py
@@ -183,6 +183,7 @@ spv = {
         'NumSIMDWorkitemsINTEL' : 5896,
         'SchedulerTargetFmaxMhzINTEL' : 5903,
         'StreamingInterfaceINTEL' : 6154,
+        'RegisterMapInterfaceINTEL' : 6160,
         'NamedBarrierCountINTEL' : 6417,
     },
 

--- a/include/spirv/unified1/spirv.py
+++ b/include/spirv/unified1/spirv.py
@@ -184,7 +184,6 @@ spv = {
         'SchedulerTargetFmaxMhzINTEL' : 5903,
         'StreamingInterfaceINTEL' : 6154,
         'RegisterMapInterfaceINTEL' : 6160,
-        'FPGAKernelAttributesv2INTEL' : 6161,
         'NamedBarrierCountINTEL' : 6417,
     },
 
@@ -1106,6 +1105,7 @@ spv = {
         'AtomicFloat16AddEXT' : 6095,
         'DebugInfoModuleINTEL' : 6114,
         'SplitBarrierINTEL' : 6141,
+        'FPGAKernelAttributesv2INTEL' : 6161,
         'FPGAArgumentInterfacesINTEL' : 6174,
         'GroupUniformArithmeticKHR' : 6400,
     },

--- a/include/spirv/unified1/spv.d
+++ b/include/spirv/unified1/spv.d
@@ -196,6 +196,7 @@ enum ExecutionMode : uint
     SchedulerTargetFmaxMhzINTEL = 5903,
     StreamingInterfaceINTEL = 6154,
     RegisterMapInterfaceINTEL = 6160,
+    FPGAKernelAttributesv2INTEL = 6161,
     NamedBarrierCountINTEL = 6417,
 }
 
@@ -1119,7 +1120,6 @@ enum Capability : uint
     FPGALoopControlsINTEL = 5888,
     KernelAttributesINTEL = 5892,
     FPGAKernelAttributesINTEL = 5897,
-    FPGAKernelAttributesv2INTEL = 6161,
     FPGAMemoryAccessesINTEL = 5898,
     FPGAClusterAttributesINTEL = 5904,
     LoopFuseINTEL = 5906,

--- a/include/spirv/unified1/spv.d
+++ b/include/spirv/unified1/spv.d
@@ -196,7 +196,6 @@ enum ExecutionMode : uint
     SchedulerTargetFmaxMhzINTEL = 5903,
     StreamingInterfaceINTEL = 6154,
     RegisterMapInterfaceINTEL = 6160,
-    FPGAKernelAttributesv2INTEL = 6161,
     NamedBarrierCountINTEL = 6417,
 }
 
@@ -1151,6 +1150,7 @@ enum Capability : uint
     AtomicFloat16AddEXT = 6095,
     DebugInfoModuleINTEL = 6114,
     SplitBarrierINTEL = 6141,
+    FPGAKernelAttributesv2INTEL = 6161,
     FPGAArgumentInterfacesINTEL = 6174,
     GroupUniformArithmeticKHR = 6400,
 }

--- a/include/spirv/unified1/spv.d
+++ b/include/spirv/unified1/spv.d
@@ -195,6 +195,7 @@ enum ExecutionMode : uint
     NumSIMDWorkitemsINTEL = 5896,
     SchedulerTargetFmaxMhzINTEL = 5903,
     StreamingInterfaceINTEL = 6154,
+    RegisterMapInterfaceINTEL = 6160,
     NamedBarrierCountINTEL = 6417,
 }
 

--- a/include/spirv/unified1/spv.d
+++ b/include/spirv/unified1/spv.d
@@ -1119,6 +1119,7 @@ enum Capability : uint
     FPGALoopControlsINTEL = 5888,
     KernelAttributesINTEL = 5892,
     FPGAKernelAttributesINTEL = 5897,
+    FPGAKernelAttributesv2INTEL = 6161,
     FPGAMemoryAccessesINTEL = 5898,
     FPGAClusterAttributesINTEL = 5904,
     LoopFuseINTEL = 5906,


### PR DESCRIPTION
(Previous PR #309 was closed automatically by git when I synced my fork with Khronos repo - since I synced with the git hub UI and that required discarding my commit)

[This SPIRV extension update](https://github.com/KhronosGroup/SPIRV-Registry/pull/176) will be introducing the new execution mode RegisterMapInterfaceINTEL. This PR adds support for this new mode.

#### NOTE
This execution mode is being added to an existing extension `SPV_INTEL_kernel_attributes` and is guarded by a new capability `FPGAKernelAttributesv2INTEL` which implicitly defines the existing capability `FPGAKernelAttributesINTEL`.