### PR TITLE
Simplify enabling capabilities for image Dim

### DIFF
--- a/include/spirv/unified1/spirv.core.grammar.json
+++ b/include/spirv/unified1/spirv.core.grammar.json
@@ -11032,12 +11032,11 @@
         {
           "enumerant" : "1D",
           "value" : 0,
-          "capabilities" : [ "Sampled1D", "Image1D" ]
+          "capabilities" : [ "Sampled1D" ]
         },
         {
           "enumerant" : "2D",
-          "value" : 1,
-          "capabilities" : [ "Shader", "Kernel", "ImageMSArray" ]
+          "value" : 1
         },
         {
           "enumerant" : "3D",
@@ -11046,17 +11045,17 @@
         {
           "enumerant" : "Cube",
           "value" : 3,
-          "capabilities" : [ "Shader", "ImageCubeArray" ]
+          "capabilities" : [ "Shader" ]
         },
         {
           "enumerant" : "Rect",
           "value" : 4,
-          "capabilities" : [ "SampledRect", "ImageRect" ]
+          "capabilities" : [ "SampledRect" ]
         },
         {
           "enumerant" : "Buffer",
           "value" : 5,
-          "capabilities" : [ "SampledBuffer", "ImageBuffer" ]
+          "capabilities" : [ "SampledBuffer" ]
         },
         {
           "enumerant" : "SubpassData",


### PR DESCRIPTION
A lot of these capabilities implied another of the enabling capabilities so didn't really serve their intended purpose. Remove them to simplify this section of the grammar.

This affects one table in the spec and a corresponding spec change will clarify that this makes no change to the meaning or scope of these capabilities.