### PR TITLE
Shift Codeplay opcode range to preserve alignment of opcodes and non-opcodes

### DIFF
--- a/include/spirv/spir-v.xml
+++ b/include/spirv/spir-v.xml
@@ -140,14 +140,15 @@
     <ids type="opcode" start="6144" end="6271" vendor="Intel" comment="Contact michael.kinsner@intel.com"/>
     <ids type="opcode" start="6272" end="6399" vendor="Huawei" comment="Contact wanghuilong2@xunweitech.com"/>
     <ids type="opcode" start="6400" end="6463" vendor="Intel" comment="Contact ben.ashbaugh@intel.com"/>
-    <ids type="opcode" start="6464" end="6527" vendor="Codeplay" comment="Contact duncan.brawley@codeplay.com"/>
+    <ids type="opcode" start="6464" end="6527" vendor="N/A" comment="Blank range to keep alignment with non-opcodes"/>
+    <ids type="opcode" start="6528" end="6591" vendor="Codeplay" comment="Contact duncan.brawley@codeplay.com"/>
     <!-- Opcode enumerants to reserve for future use. To get a block, allocate
          multiples of 64 starting at the lowest available point in this
          block and add a corresponding <ids> tag immediately above. Make
          sure to fill in the vendor attribute, and preferably add a contact
          person/address in a comment attribute. -->
     <!-- Example new block: <ids type="opcode" start="XXXX" end="XXXX+64n-1" vendor="Add vendor" comment="Contact TBD"/> -->
-    <ids type="opcode" start="6528" end="65535" comment="Opcode range reservable for future use by vendors"/>
+    <ids type="opcode" start="6592" end="65535" comment="Opcode range reservable for future use by vendors"/>
     <!-- End reservations of opcodes -->
 
 


### PR DESCRIPTION
We wish to preserve our opcode and non-opcode alignment but without reserving a space we probably won't use. Don't want to put nothing otherwise it would be very difficult to spot. But another style might be better. Perhaps a comment instead.