### PR TITLE
Add NonSemantic.AuxData

### DIFF
--- a/include/spirv/unified1/NonSemanticAuxData.h
+++ b/include/spirv/unified1/NonSemanticAuxData.h
@@ -1,0 +1,51 @@
+// Copyright (c) 2020 The Khronos Group Inc.
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and/or associated documentation files (the
+// "Materials"), to deal in the Materials without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Materials, and to
+// permit persons to whom the Materials are furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Materials.
+// 
+// MODIFICATIONS TO THIS FILE MAY MEAN IT NO LONGER ACCURATELY REFLECTS
+// KHRONOS STANDARDS. THE UNMODIFIED, NORMATIVE VERSIONS OF KHRONOS
+// SPECIFICATIONS AND HEADER INFORMATION ARE LOCATED AT
+//    https://www.khronos.org/registry/
+// 
+// THE MATERIALS ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
+// 
+
+#ifndef SPIRV_UNIFIED1_NonSemanticAuxData_H_
+#define SPIRV_UNIFIED1_NonSemanticAuxData_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum {
+    NonSemanticAuxDataRevision = 1,
+    NonSemanticAuxDataRevision_BitWidthPadding = 0x7fffffff
+};
+
+enum NonSemanticAuxDataInstructions {
+    NonSemanticAuxDataFunctionMetadata = 0,
+    NonSemanticAuxDataFunctionAttribute = 1,
+    NonSemanticAuxDataInstructionsMax = 0x7fffffff
+};
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // SPIRV_UNIFIED1_NonSemanticAuxData_H_

--- a/include/spirv/unified1/extinst.nonsemantic.auxdata.grammar.json
+++ b/include/spirv/unified1/extinst.nonsemantic.auxdata.grammar.json
@@ -1,0 +1,21 @@
+{
+  "revision" : 1,
+  "instructions" : [
+      {
+	  "opname" : "FunctionMetadata",
+	  "opcode" : 0,
+	  "operands" : [
+	      { "kind" : "IdRef", "name" : "Function" },
+              { "kind" : "IdRef", "quantifier" : "*", "name" : "'Operand 1', +\n'Operand 2', +\n..." }
+	  ]
+      },
+      {
+	  "opname" : "FunctionAttribute",
+	  "opcode" : 1,
+	  "operands" : [
+	      { "kind" : "IdRef", "name" : "Function" },
+              { "kind" : "IdRef", "quantifier" : "*", "name" : "'Operand 1', +\n'Operand 2', +\n..." }
+	  ]
+      }
+  ]
+}

--- a/tools/buildHeaders/bin/makeExtinstHeaders.py
+++ b/tools/buildHeaders/bin/makeExtinstHeaders.py
@@ -27,3 +27,4 @@ mk_extinst('AMD_shader_trinary_minmax', 'extinst.spv-amd-shader-trinary-minmax.g
 mk_extinst('NonSemanticDebugPrintf', 'extinst.nonsemantic.debugprintf.grammar.json')
 mk_extinst('NonSemanticClspvReflection', 'extinst.nonsemantic.clspvreflection.grammar.json')
 mk_extinst('NonSemanticDebugBreak', 'extinst.nonsemantic.debugbreak.grammar.json')
+mk_extinst('NonSemanticAuxData', 'extinst.nonsemantic.auxdata.grammar.json')


### PR DESCRIPTION
This non-semantic EIS is used to specify preserving otherwise unhandled function metadata and attributes.