### PR TITLE
build: Remove version support from packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@
 # TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 # MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
 cmake_minimum_required(VERSION 3.14)
-project(SPIRV-Headers LANGUAGES CXX VERSION 1.5.5)
+project(SPIRV-Headers LANGUAGES CXX)
 
 if (CMAKE_VERSION VERSION_LESS "3.21")
     # https://cmake.org/cmake/help/latest/variable/PROJECT_IS_TOP_LEVEL.html
@@ -42,18 +42,10 @@ if (PROJECT_IS_TOP_LEVEL)
     endif()
 
     include(GNUInstallDirs)
-    include(CMakePackageConfigHelpers)
 
     install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/spirv DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-
-    set(cmake_install_dir "${CMAKE_INSTALL_DATADIR}/cmake/SPIRV-Headers")
-    set(version_config "${CMAKE_CURRENT_BINARY_DIR}/generated/SPIRV-HeadersConfigVersion.cmake")
-
-    write_basic_package_version_file("${version_config}" COMPATIBILITY SameMajorVersion ARCH_INDEPENDENT)
-    install(FILES "${version_config}" DESTINATION "${cmake_install_dir}")
-
     install(TARGETS SPIRV-Headers EXPORT "SPIRV-HeadersConfig" INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-    install(EXPORT "SPIRV-HeadersConfig" NAMESPACE "SPIRV-Headers::" DESTINATION "${cmake_install_dir}")
+    install(EXPORT "SPIRV-HeadersConfig" NAMESPACE "SPIRV-Headers::" DESTINATION "${CMAKE_INSTALL_DATADIR}/cmake/SPIRV-Headers")
 
     if (IS_ABSOLUTE ${CMAKE_INSTALL_INCLUDEDIR})
         set(SPIRV_HEADERS_PKGCONFIG_INCLUDE_DIR ${CMAKE_INSTALL_INCLUDEDIR})

--- a/cmake/SPIRV-Headers.pc.in
+++ b/cmake/SPIRV-Headers.pc.in
@@ -2,7 +2,7 @@ includedir=@SPIRV_HEADERS_PKGCONFIG_INCLUDE_DIR@
 
 Name: SPIRV-Headers
 Description: Header files from the SPIR-V registry
-Version: @CMAKE_PROJECT_VERSION@
+Version:
 Requires:
 Libs:
 Cflags: -I${includedir}

--- a/tests/find_package/CMakeLists.txt
+++ b/tests/find_package/CMakeLists.txt
@@ -16,8 +16,3 @@ target_link_libraries(find_package_example PRIVATE
     SPIRV-Headers::SPIRV-Headers
 )
 
-if (NOT DEFINED SPIRV-Headers_VERSION)
-    message(FATAL_ERROR "SPIRV-Headers_VERSION not provided!")
-endif()
-
-message(STATUS "SPIRV-Headers_VERSION = ${SPIRV-Headers_VERSION}")

--- a/tests/pkg_config/CMakeLists.txt
+++ b/tests/pkg_config/CMakeLists.txt
@@ -16,8 +16,3 @@ target_link_libraries(pkgconfig_example PRIVATE
     PkgConfig::SPIRV_HEADERS
 )
 
-if (NOT DEFINED SPIRV_HEADERS_VERSION)
-    message(FATAL_ERROR "SPIRV_HEADERS_VERSION not defined!")
-endif()
-
-message(STATUS "PkgConfig::SPIRV_HEADERS version = ${SPIRV_HEADERS_VERSION}")


### PR DESCRIPTION
Removes version information from the both the CMake/pkg-config files.