### PR TITLE
Add definitions for SVP_EXT_image_raw10_raw12

### DIFF
--- a/include/spirv/unified1/spirv.bf
+++ b/include/spirv/unified1/spirv.bf
@@ -354,6 +354,8 @@ namespace Spv
             Float = 14,
             UnormInt24 = 15,
             UnormInt101010_2 = 16,
+            UnsignedIntRaw10EXT = 19,
+            UnsignedIntRaw12EXT = 20,
         }
 
         [AllowDuplicates, CRepr] public enum ImageOperandsShift

--- a/include/spirv/unified1/spirv.core.grammar.json
+++ b/include/spirv/unified1/spirv.core.grammar.json
@@ -11610,6 +11610,16 @@
           "enumerant" : "UnormInt101010_2",
           "value" : 16,
           "capabilities" : [ "Kernel" ]
+        },
+        {
+          "enumerant" : "UnsignedIntRaw10EXT",
+          "value" : 19,
+          "capabilities" : [ "Kernel" ]
+        },
+        {
+          "enumerant" : "UnsignedIntRaw12EXT",
+          "value" : 20,
+          "capabilities" : [ "Kernel" ]
         }
       ]
     },

--- a/include/spirv/unified1/spirv.cs
+++ b/include/spirv/unified1/spirv.cs
@@ -353,6 +353,8 @@ namespace Spv
             Float = 14,
             UnormInt24 = 15,
             UnormInt101010_2 = 16,
+            UnsignedIntRaw10EXT = 19,
+            UnsignedIntRaw12EXT = 20,
         }
 
         public enum ImageOperandsShift

--- a/include/spirv/unified1/spirv.h
+++ b/include/spirv/unified1/spirv.h
@@ -361,6 +361,8 @@ typedef enum SpvImageChannelDataType_ {
     SpvImageChannelDataTypeFloat = 14,
     SpvImageChannelDataTypeUnormInt24 = 15,
     SpvImageChannelDataTypeUnormInt101010_2 = 16,
+    SpvImageChannelDataTypeUnsignedIntRaw10EXT = 19,
+    SpvImageChannelDataTypeUnsignedIntRaw12EXT = 20,
     SpvImageChannelDataTypeMax = 0x7fffffff,
 } SpvImageChannelDataType;
 

--- a/include/spirv/unified1/spirv.hpp
+++ b/include/spirv/unified1/spirv.hpp
@@ -357,6 +357,8 @@ enum ImageChannelDataType {
     ImageChannelDataTypeFloat = 14,
     ImageChannelDataTypeUnormInt24 = 15,
     ImageChannelDataTypeUnormInt101010_2 = 16,
+    ImageChannelDataTypeUnsignedIntRaw10EXT = 19,
+    ImageChannelDataTypeUnsignedIntRaw12EXT = 20,
     ImageChannelDataTypeMax = 0x7fffffff,
 };
 

--- a/include/spirv/unified1/spirv.hpp11
+++ b/include/spirv/unified1/spirv.hpp11
@@ -357,6 +357,8 @@ enum class ImageChannelDataType : unsigned {
     Float = 14,
     UnormInt24 = 15,
     UnormInt101010_2 = 16,
+    UnsignedIntRaw10EXT = 19,
+    UnsignedIntRaw12EXT = 20,
     Max = 0x7fffffff,
 };
 

--- a/include/spirv/unified1/spirv.json
+++ b/include/spirv/unified1/spirv.json
@@ -396,7 +396,9 @@
                     "HalfFloat": 13,
                     "Float": 14,
                     "UnormInt24": 15,
-                    "UnormInt101010_2": 16
+                    "UnormInt101010_2": 16,
+                    "UnsignedIntRaw10EXT": 19,
+                    "UnsignedIntRaw12EXT": 20
                 }
             },
             {

--- a/include/spirv/unified1/spirv.lua
+++ b/include/spirv/unified1/spirv.lua
@@ -337,6 +337,8 @@ spv = {
         Float = 14,
         UnormInt24 = 15,
         UnormInt101010_2 = 16,
+        UnsignedIntRaw10EXT = 19,
+        UnsignedIntRaw12EXT = 20,
     },
 
     ImageOperandsShift = {

--- a/include/spirv/unified1/spirv.py
+++ b/include/spirv/unified1/spirv.py
@@ -337,6 +337,8 @@ spv = {
         'Float' : 14,
         'UnormInt24' : 15,
         'UnormInt101010_2' : 16,
+        'UnsignedIntRaw10EXT' : 19,
+        'UnsignedIntRaw12EXT' : 20,
     },
 
     'ImageOperandsShift' : {

--- a/include/spirv/unified1/spv.d
+++ b/include/spirv/unified1/spv.d
@@ -356,6 +356,8 @@ enum ImageChannelDataType : uint
     Float = 14,
     UnormInt24 = 15,
     UnormInt101010_2 = 16,
+    UnsignedIntRaw10EXT = 19,
+    UnsignedIntRaw12EXT = 20,
 }
 
 enum ImageOperandsShift : uint


### PR DESCRIPTION
Spec: https://github.com/KhronosGroup/SPIRV-Registry/pull/206

Used by the following OpenCL extension: https://github.com/KhronosGroup/OpenCL-Docs/pull/919