### PR TITLE
Enforce best practices for guarding enums

### DIFF
--- a/tools/buildHeaders/jsonToSpirv.h
+++ b/tools/buildHeaders/jsonToSpirv.h
@@ -28,6 +28,7 @@
 
 #include <algorithm>
 #include <string>
+#include <iostream>
 #include <vector>
 #include <assert.h>
 
@@ -187,6 +188,7 @@ public:
 
     iterator begin() { return values.begin(); }
     iterator end() { return values.end(); }
+    EValue& back() { return values.back(); }
 
 private:
     ContainerType values;
@@ -219,6 +221,10 @@ public:
     Extensions extensions;
     OperandParameters operands;
     const char* desc;
+
+    // Returns true if this enum is valid, in isolation.
+    // Otherwise emits a diagnostic to std::cerr and returns false.
+    bool IsValid(const std::string& context) const;
 };
 
 using EnumValues = EnumValuesContainer<EnumValue>;

--- a/tools/buildHeaders/jsonToSpirv.h
+++ b/tools/buildHeaders/jsonToSpirv.h
@@ -224,7 +224,7 @@ public:
 
     // Returns true if this enum is valid, in isolation.
     // Otherwise emits a diagnostic to std::cerr and returns false.
-    bool IsValid(const std::string& context) const;
+    bool IsValid(OperandClass oc, const std::string& context) const;
 };
 
 using EnumValues = EnumValuesContainer<EnumValue>;


### PR DESCRIPTION
Enforce best practices for guarding enums
    
    An enum introduced by an extension (that is not in a core SPIR-V
    version) is either:
    - a capability, or
    - not a capability, but guarded by a capability and not guarded by an extension.
    
    Allow cases that have already landed, with an allow-list.
    
Fixes: #278

Builds on #369