### PR TITLE
Revert "Merge pull request #367 from dneto0/coop-matrix-enums-deps"

### DIFF
--- a/include/spirv/unified1/spirv.core.grammar.json
+++ b/include/spirv/unified1/spirv.core.grammar.json
@@ -15390,37 +15390,31 @@
         {
           "enumerant" : "NoneKHR",
           "value" : "0x0000",
-          "extensions" : [ "SPV_KHR_cooperative_matrix" ],
           "version" : "None"
         },
         {
           "enumerant" : "MatrixASignedComponentsKHR",
           "value" : "0x0001",
-          "extensions" : [ "SPV_KHR_cooperative_matrix" ],
           "version" : "None"
         },
         {
           "enumerant" : "MatrixBSignedComponentsKHR",
           "value" : "0x0002",
-          "extensions" : [ "SPV_KHR_cooperative_matrix" ],
           "version" : "None"
         },
         {
           "enumerant" : "MatrixCSignedComponentsKHR",
           "value" : "0x0004",
-          "extensions" : [ "SPV_KHR_cooperative_matrix" ],
           "version" : "None"
         },
         {
           "enumerant" : "MatrixResultSignedComponentsKHR",
           "value" : "0x0008",
-          "extensions" : [ "SPV_KHR_cooperative_matrix" ],
           "version" : "None"
         },
         {
           "enumerant" : "SaturatingAccumulationKHR",
           "value" : "0x0010",
-          "extensions" : [ "SPV_KHR_cooperative_matrix" ],
           "version" : "None"
         }
       ]
@@ -15432,13 +15426,11 @@
         {
           "enumerant" : "RowMajorKHR",
           "value" : 0,
-          "extensions" : [ "SPV_KHR_cooperative_matrix" ],
           "version" : "None"
         },
         {
           "enumerant" : "ColumnMajorKHR",
           "value" : 1,
-          "extensions" : [ "SPV_KHR_cooperative_matrix" ],
           "version" : "None"
         }
       ]
@@ -15450,19 +15442,16 @@
         {
           "enumerant" : "MatrixAKHR",
           "value" : 0,
-          "extensions" : [ "SPV_KHR_cooperative_matrix" ],
           "version" : "None"
         },
         {
           "enumerant" : "MatrixBKHR",
           "value" : 1,
-          "extensions" : [ "SPV_KHR_cooperative_matrix" ],
           "version" : "None"
         },
         {
           "enumerant" : "MatrixAccumulatorKHR",
           "value" : 2,
-          "extensions" : [ "SPV_KHR_cooperative_matrix" ],
           "version" : "None"
         }
       ]


### PR DESCRIPTION
This reverts commit 124a9665e464ef98b8b718d572d5f329311061eb, reversing changes made to f14a663c84e8da4776bd615ac19450aa4d03cd71.

This returns the contents back to when we merged https://github.com/KhronosGroup/SPIRV-Headers/pull/361 

This is made possible because SPIRV-Tools has been fixed.  See https://github.com/KhronosGroup/SPIRV-Tools/pull/5370