### PR TITLE
Allow OpMatrixTimesScalar for cooperative matrix type

### DIFF
--- a/include/spirv/unified1/spirv.core.grammar.json
+++ b/include/spirv/unified1/spirv.core.grammar.json
@@ -1547,7 +1547,10 @@
         { "kind" : "IdRef",        "name" : "'Matrix'" },
         { "kind" : "IdRef",        "name" : "'Scalar'" }
       ],
-      "capabilities" : [ "Matrix" ]
+      "capabilities": [
+        "Matrix",
+        "CooperativeMatrixKHR"
+      ]
     },
     {
       "opname" : "OpVectorTimesMatrix",


### PR DESCRIPTION
This change fixes `spirv-val` validation error, when we use `OpMatrixTimesScalar` with the `TypeCooperativeMatrixKHR`, allowing to use one of the expected capabilities instead of only `Matrix` one:

```
Opcode MatrixTimesScalar requires one of these capabilities: Matrix
```

Extension spec: https://github.com/KhronosGroup/SPIRV-Registry/blob/main/extensions/KHR/SPV_KHR_cooperative_matrix.asciidoc