### PR TITLE
ClspvReflection non-sematic: add NormalizedSamplerMaskPushConstant

### DIFF
--- a/include/spirv/unified1/NonSemanticClspvReflection.h
+++ b/include/spirv/unified1/NonSemanticClspvReflection.h
@@ -33,7 +33,7 @@ extern "C" {
 #endif
 
 enum {
-    NonSemanticClspvReflectionRevision = 5,
+    NonSemanticClspvReflectionRevision = 6,
     NonSemanticClspvReflectionRevision_BitWidthPadding = 0x7fffffff
 };
 
@@ -78,6 +78,7 @@ enum NonSemanticClspvReflectionInstructions {
     NonSemanticClspvReflectionPrintfInfo = 38,
     NonSemanticClspvReflectionPrintfBufferStorageBuffer = 39,
     NonSemanticClspvReflectionPrintfBufferPointerPushConstant = 40,
+    NonSemanticClspvReflectionNormalizedSamplerMaskPushConstant = 41,
     NonSemanticClspvReflectionInstructionsMax = 0x7fffffff
 };
 

--- a/include/spirv/unified1/extinst.nonsemantic.clspvreflection.grammar.json
+++ b/include/spirv/unified1/extinst.nonsemantic.clspvreflection.grammar.json
@@ -1,5 +1,5 @@
 {
-  "revision" : 5,
+  "revision" : 6,
   "instructions" : [
     {
       "opname" : "Kernel",
@@ -394,6 +394,16 @@
       { "kind" : "IdRef", "name" : "Offset" },
       { "kind" : "IdRef", "name" : "Size"},
       { "kind" : "IdRef", "name" : "BufferSize"}
+      ]
+    },
+    {
+    "opname" : "NormalizedSamplerMaskPushConstant",
+    "opcode" : 41,
+    "operands" : [
+      { "kind" : "IdRef", "name" : "Kernel" },
+      { "kind" : "IdRef", "name" : "Ordinal" },
+      { "kind" : "IdRef", "name" : "Offset" },
+      { "kind" : "IdRef", "name" : "Size" }
       ]
     }
   ],


### PR DESCRIPTION
This is needed to implement 3D Image read using unnormalised sampler.

Ref google/clspv#1202