### PR TITLE
remove additional version "1.0" from SecondaryViewportRelativeNV

### DIFF
--- a/include/spirv/unified1/spirv.core.grammar.json
+++ b/include/spirv/unified1/spirv.core.grammar.json
@@ -13009,8 +13009,7 @@
           "version" : "None",
           "parameters" : [
             { "kind" : "LiteralInteger", "name" : "'Offset'" }
-          ],
-          "version": "1.0"
+          ]
         },
         {
           "enumerant" : "PerPrimitiveNV",


### PR DESCRIPTION
SecondaryViewportRelativeNV already has a version field "None" and some JSON parsers don't like two fields with the same key. I belive @dneto0 accidentally added the additional field with this commit: https://github.com/rAzoR8/SPIRV-Headers/commit/d790ced752b5bfc06b6988baadef6eb2d16bdf96

I'm not sure if the version "None" should have been replaced with "1.0" instead. In that case this PR can be ignored.

Best,
Fabian