### PR TITLE
Add LiteralFloat to operand_kinds

### DIFF
--- a/include/spirv/unified1/spirv.core.grammar.json
+++ b/include/spirv/unified1/spirv.core.grammar.json
@@ -16483,6 +16483,11 @@
     },
     {
       "category" : "Literal",
+      "kind" : "LiteralFloat",
+      "doc" : "A float consuming one word"
+    },
+    {
+      "category" : "Literal",
       "kind" : "LiteralContextDependentNumber",
       "doc" : "A literal number whose size and format are determined by a previous operand in the enclosing instruction"
     },


### PR DESCRIPTION
LiteralFloat was introduced with FPMaxErrorDecorationINTEL, but no entry in operand_kinds corresponds to it. Some codegen tooling might depend on operand_kinds -> category mapping.

This PR adds it with the following "doc" string: "A float consuming one word"
Maybe better wording is necessary.

```
{
      "category" : "Literal",
      "kind" : "LiteralFloat",
      "doc" : "A float consuming one word"
}
```

Best,
Fabian