### PR TITLE
Fix SPV_KHR_workgroup_memory_explicit_layout implicit declare capabilities

### DIFF
--- a/include/spirv/unified1/spirv.core.grammar.json
+++ b/include/spirv/unified1/spirv.core.grammar.json
@@ -15213,7 +15213,7 @@
         {
           "enumerant" : "WorkgroupMemoryExplicitLayout16BitAccessKHR",
           "value" : 4430,
-          "capabilities" : [ "Shader" ],
+          "capabilities" : [ "WorkgroupMemoryExplicitLayoutKHR" ],
           "extensions" : [ "SPV_KHR_workgroup_memory_explicit_layout" ],
           "version" : "None"
         },


### PR DESCRIPTION
https://htmlpreview.github.io/?https://github.com/KhronosGroup/SPIRV-Registry/blob/master/extensions/KHR/SPV_KHR_workgroup_memory_explicit_layout.html

shows

![image](https://github.com/KhronosGroup/SPIRV-Headers/assets/115671160/892907f4-3c3f-4203-8714-5ff80d8bccfc)

but seems there is a mistake in the grammar