### PR TITLE
It seems d790ced752b5bfc06b6988baadef6eb2d16bdf96 add tabs.

### DIFF
--- a/include/spirv/unified1/spirv.core.grammar.json
+++ b/include/spirv/unified1/spirv.core.grammar.json
@@ -9922,32 +9922,32 @@
         {
           "enumerant" : "None",
           "value" : "0x0000",
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "NotNaN",
           "value" : "0x0001",
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "NotInf",
           "value" : "0x0002",
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "NSZ",
           "value" : "0x0004",
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "AllowRecip",
           "value" : "0x0008",
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "Fast",
           "value" : "0x0010",
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "AllowContractFastINTEL",
@@ -9970,17 +9970,17 @@
         {
           "enumerant" : "None",
           "value" : "0x0000",
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "Flatten",
           "value" : "0x0001",
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "DontFlatten",
           "value" : "0x0002",
-	  "version" : "1.0"
+          "version" : "1.0"
         }
       ]
     },
@@ -9991,17 +9991,17 @@
         {
           "enumerant" : "None",
           "value" : "0x0000",
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "Unroll",
           "value" : "0x0001",
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "DontUnroll",
           "value" : "0x0002",
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "DependencyInfinite",
@@ -10152,27 +10152,27 @@
         {
           "enumerant" : "None",
           "value" : "0x0000",
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "Inline",
           "value" : "0x0001",
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "DontInline",
           "value" : "0x0002",
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "Pure",
           "value" : "0x0004",
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "Const",
           "value" : "0x0008",
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "OptNoneINTEL",
@@ -10189,32 +10189,32 @@
         {
           "enumerant" : "Relaxed",
           "value" : "0x0000",
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "None",
           "value" : "0x0000",
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "Acquire",
           "value" : "0x0002",
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "Release",
           "value" : "0x0004",
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "AcquireRelease",
           "value" : "0x0008",
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "SequentiallyConsistent",
           "value" : "0x0010",
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "UniformMemory",
@@ -10225,17 +10225,17 @@
         {
           "enumerant" : "SubgroupMemory",
           "value" : "0x0080",
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "WorkgroupMemory",
           "value" : "0x0100",
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "CrossWorkgroupMemory",
           "value" : "0x0200",
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "AtomicCounterMemory",
@@ -10246,7 +10246,7 @@
         {
           "enumerant" : "ImageMemory",
           "value" : "0x0800",
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "OutputMemory",
@@ -10303,12 +10303,12 @@
         {
           "enumerant" : "None",
           "value" : "0x0000",
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "Volatile",
           "value" : "0x0001",
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "Aligned",
@@ -10316,12 +10316,12 @@
           "parameters" : [
             { "kind" : "LiteralInteger" }
           ],
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "Nontemporal",
           "value" : "0x0004",
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "MakePointerAvailable",
@@ -10403,7 +10403,7 @@
         {
           "enumerant" : "None",
           "value" : "0x0000",
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "CmdExecTime",
@@ -10528,62 +10528,62 @@
         {
           "enumerant" : "Unknown",
           "value" : 0,
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "ESSL",
           "value" : 1,
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "GLSL",
           "value" : 2,
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "OpenCL_C",
           "value" : 3,
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "OpenCL_CPP",
           "value" : 4,
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "HLSL",
           "value" : 5,
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "CPP_for_OpenCL",
           "value" : 6,
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "SYCL",
           "value" : 7,
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "HERO_C",
           "value" : 8,
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "NZSL",
           "value" : 9,
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "WGSL",
           "value" : 10,
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "Slang",
           "value" : 11,
-	  "version" : "1.0"
+          "version" : "1.0"
         }
       ]
     },
@@ -10738,7 +10738,7 @@
         {
           "enumerant" : "Logical",
           "value" : 0,
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "Physical32",
@@ -11490,12 +11490,12 @@
         {
           "enumerant" : "UniformConstant",
           "value" : 0,
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "Input",
           "value" : 1,
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "Uniform",
@@ -11512,12 +11512,12 @@
         {
           "enumerant" : "Workgroup",
           "value" : 4,
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "CrossWorkgroup",
           "value" : 5,
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "Private",
@@ -11528,7 +11528,7 @@
         {
           "enumerant" : "Function",
           "value" : 7,
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "Generic",
@@ -11551,7 +11551,7 @@
         {
           "enumerant" : "Image",
           "value" : 11,
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "StorageBuffer",
@@ -11732,12 +11732,12 @@
         {
           "enumerant" : "2D",
           "value" : 1,
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "3D",
           "value" : 2,
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "Cube",
@@ -11825,7 +11825,7 @@
         {
           "enumerant" : "Unknown",
           "value" : 0,
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "Rgba32f",
@@ -12061,7 +12061,7 @@
           "capabilities" : [ "StorageImageExtendedFormats" ],
           "version": "1.0"
         },
-	{
+        {
           "enumerant" : "R64ui",
           "value" : 40,
           "capabilities" : [ "Int64ImageEXT" ],
@@ -12328,22 +12328,22 @@
         {
           "enumerant" : "RTE",
           "value" : 0,
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "RTZ",
           "value" : 1,
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "RTP",
           "value" : 2,
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "RTN",
           "value" : 3,
-	  "version" : "1.0"
+          "version" : "1.0"
         }
       ]
     },
@@ -12362,7 +12362,7 @@
           "value" : 1,
           "capabilities" : [ "FunctionFloatControlINTEL" ],
           "version" : "None"
-	}
+        }
       ]
     },
     {
@@ -12733,17 +12733,17 @@
         {
           "enumerant" : "Restrict",
           "value" : 19,
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "Aliased",
           "value" : 20,
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "Volatile",
           "value" : 21,
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "Constant",
@@ -13857,32 +13857,32 @@
         {
           "enumerant" : "NumWorkgroups",
           "value" : 24,
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "WorkgroupSize",
           "value" : 25,
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "WorkgroupId",
           "value" : 26,
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "LocalInvocationId",
           "value" : 27,
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "GlobalInvocationId",
           "value" : 28,
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "LocalInvocationIndex",
           "value" : 29,
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "WorkDim",
@@ -14626,27 +14626,27 @@
         {
           "enumerant" : "CrossDevice",
           "value" : 0,
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "Device",
           "value" : 1,
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "Workgroup",
           "value" : 2,
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "Subgroup",
           "value" : 3,
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "Invocation",
           "value" : 4,
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "QueueFamily",
@@ -14750,7 +14750,7 @@
         {
           "enumerant" : "Matrix",
           "value" : 0,
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "Shader",
@@ -14773,17 +14773,17 @@
         {
           "enumerant" : "Addresses",
           "value" : 4,
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "Linkage",
           "value" : 5,
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "Kernel",
           "value" : 6,
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "Vector16",
@@ -14800,17 +14800,17 @@
         {
           "enumerant" : "Float16",
           "value" : 9,
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "Float64",
           "value" : 10,
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "Int64",
           "value" : 11,
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "Int64Atomics",
@@ -14869,7 +14869,7 @@
         {
           "enumerant" : "Int16",
           "value" : 22,
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "TessellationPointSize",
@@ -14964,7 +14964,7 @@
         {
           "enumerant" : "Int8",
           "value" : 39,
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "InputAttachment",
@@ -14987,7 +14987,7 @@
         {
           "enumerant" : "Sampled1D",
           "value" : 43,
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "Image1D",
@@ -15004,7 +15004,7 @@
         {
           "enumerant" : "SampledBuffer",
           "value" : 46,
-	  "version" : "1.0"
+          "version" : "1.0"
         },
         {
           "enumerant" : "ImageBuffer",


### PR DESCRIPTION
It seems d790ced752b5bfc06b6988baadef6eb2d16bdf96 or something related add tabs to all the version "1.0" lines.

Tabs and spaces mixed on the same line. It should all be spaces.