### PR TITLE
Upstream tokens for SPV_INTEL_masked_gather_scatter

### DIFF
--- a/include/spirv/unified1/spirv.bf
+++ b/include/spirv/unified1/spirv.bf
@@ -1210,6 +1210,7 @@ namespace Spv
             FPGALatencyControlINTEL = 6171,
             FPGAArgumentInterfacesINTEL = 6174,
             GroupUniformArithmeticKHR = 6400,
+            MaskedGatherScatterINTEL = 6427,
             CacheControlsINTEL = 6441,
         }
 
@@ -2106,6 +2107,8 @@ namespace Spv
             OpGroupLogicalAndKHR = 6406,
             OpGroupLogicalOrKHR = 6407,
             OpGroupLogicalXorKHR = 6408,
+            OpMaskedGatherINTEL = 6428,
+            OpMaskedScatterINTEL = 6429,
         }
     }
 }

--- a/include/spirv/unified1/spirv.core.grammar.json
+++ b/include/spirv/unified1/spirv.core.grammar.json
@@ -9746,6 +9746,34 @@
       ],
       "capabilities" : [ "GroupUniformArithmeticKHR" ],
       "version" : "None"
+    },
+    {
+      "opname" : "OpMaskedGatherINTEL",
+      "class"  : "Memory",
+      "opcode" : 6428,
+      "operands" : [
+        { "kind" : "IdResultType" },
+        { "kind" : "IdResult" },
+        { "kind" : "IdRef",           "name" : "'PtrVector'" },
+        { "kind" : "LiteralInteger",  "name" : "'Alignment'" },
+        { "kind" : "IdRef",           "name" : "'Mask'" },
+        { "kind" : "IdRef",           "name" : "'FillEmpty'" }
+      ],
+      "capabilities" : [ "MaskedGatherScatterINTEL" ],
+      "version" : "None"
+    },
+    {
+      "opname" : "OpMaskedScatterINTEL",
+      "class"  : "Memory",
+      "opcode" : 6429,
+      "operands" : [
+        { "kind" : "IdRef",           "name" : "'InputVector'" },
+        { "kind" : "IdRef",           "name" : "'PtrVector'" },
+        { "kind" : "LiteralInteger",  "name" : "'Alignment'" },
+        { "kind" : "IdRef",           "name" : "'Mask'" }
+      ],
+      "capabilities" : [ "MaskedGatherScatterINTEL" ],
+      "version" : "None"
     }
   ],
   "operand_kinds" : [
@@ -16301,6 +16329,12 @@
           "value" : 6400,
           "extensions" : [ "SPV_KHR_uniform_group_instructions"],
           "version" : "None"
+        },
+        {
+          "enumerant" : "MaskedGatherScatterINTEL",
+	  "value" : 6427,
+	  "extensions" : [ "SPV_INTEL_masked_gather_scatter"],
+	  "version" : "None"
         },
         {
           "enumerant" : "CacheControlsINTEL",

--- a/include/spirv/unified1/spirv.cs
+++ b/include/spirv/unified1/spirv.cs
@@ -1209,6 +1209,7 @@ namespace Spv
             FPGALatencyControlINTEL = 6171,
             FPGAArgumentInterfacesINTEL = 6174,
             GroupUniformArithmeticKHR = 6400,
+            MaskedGatherScatterINTEL = 6427,
             CacheControlsINTEL = 6441,
         }
 
@@ -2105,6 +2106,8 @@ namespace Spv
             OpGroupLogicalAndKHR = 6406,
             OpGroupLogicalOrKHR = 6407,
             OpGroupLogicalXorKHR = 6408,
+            OpMaskedGatherINTEL = 6428,
+            OpMaskedScatterINTEL = 6429,
         }
     }
 }

--- a/include/spirv/unified1/spirv.h
+++ b/include/spirv/unified1/spirv.h
@@ -1209,6 +1209,7 @@ typedef enum SpvCapability_ {
     SpvCapabilityFPGALatencyControlINTEL = 6171,
     SpvCapabilityFPGAArgumentInterfacesINTEL = 6174,
     SpvCapabilityGroupUniformArithmeticKHR = 6400,
+    SpvCapabilityMaskedGatherScatterINTEL = 6427,
     SpvCapabilityCacheControlsINTEL = 6441,
     SpvCapabilityMax = 0x7fffffff,
 } SpvCapability;
@@ -2102,6 +2103,8 @@ typedef enum SpvOp_ {
     SpvOpGroupLogicalAndKHR = 6406,
     SpvOpGroupLogicalOrKHR = 6407,
     SpvOpGroupLogicalXorKHR = 6408,
+    SpvOpMaskedGatherINTEL = 6428,
+    SpvOpMaskedScatterINTEL = 6429,
     SpvOpMax = 0x7fffffff,
 } SpvOp;
 
@@ -2825,6 +2828,8 @@ inline void SpvHasResultAndType(SpvOp opcode, bool *hasResult, bool *hasResultTy
     case SpvOpGroupLogicalAndKHR: *hasResult = true; *hasResultType = true; break;
     case SpvOpGroupLogicalOrKHR: *hasResult = true; *hasResultType = true; break;
     case SpvOpGroupLogicalXorKHR: *hasResult = true; *hasResultType = true; break;
+    case SpvOpMaskedGatherINTEL: *hasResult = true; *hasResultType = true; break;
+    case SpvOpMaskedScatterINTEL: *hasResult = false; *hasResultType = false; break;
     }
 }
 #endif /* SPV_ENABLE_UTILITY_CODE */

--- a/include/spirv/unified1/spirv.hpp
+++ b/include/spirv/unified1/spirv.hpp
@@ -1205,6 +1205,7 @@ enum Capability {
     CapabilityFPGALatencyControlINTEL = 6171,
     CapabilityFPGAArgumentInterfacesINTEL = 6174,
     CapabilityGroupUniformArithmeticKHR = 6400,
+    CapabilityMaskedGatherScatterINTEL = 6427,
     CapabilityCacheControlsINTEL = 6441,
     CapabilityMax = 0x7fffffff,
 };
@@ -2098,6 +2099,8 @@ enum Op {
     OpGroupLogicalAndKHR = 6406,
     OpGroupLogicalOrKHR = 6407,
     OpGroupLogicalXorKHR = 6408,
+    OpMaskedGatherINTEL = 6428,
+    OpMaskedScatterINTEL = 6429,
     OpMax = 0x7fffffff,
 };
 
@@ -2821,6 +2824,8 @@ inline void HasResultAndType(Op opcode, bool *hasResult, bool *hasResultType) {
     case OpGroupLogicalAndKHR: *hasResult = true; *hasResultType = true; break;
     case OpGroupLogicalOrKHR: *hasResult = true; *hasResultType = true; break;
     case OpGroupLogicalXorKHR: *hasResult = true; *hasResultType = true; break;
+    case OpMaskedGatherINTEL: *hasResult = true; *hasResultType = true; break;
+    case OpMaskedScatterINTEL: *hasResult = false; *hasResultType = false; break;
     }
 }
 #endif /* SPV_ENABLE_UTILITY_CODE */

--- a/include/spirv/unified1/spirv.hpp11
+++ b/include/spirv/unified1/spirv.hpp11
@@ -1205,6 +1205,7 @@ enum class Capability : unsigned {
     FPGALatencyControlINTEL = 6171,
     FPGAArgumentInterfacesINTEL = 6174,
     GroupUniformArithmeticKHR = 6400,
+    MaskedGatherScatterINTEL = 6427,
     CacheControlsINTEL = 6441,
     Max = 0x7fffffff,
 };
@@ -2098,6 +2099,8 @@ enum class Op : unsigned {
     OpGroupLogicalAndKHR = 6406,
     OpGroupLogicalOrKHR = 6407,
     OpGroupLogicalXorKHR = 6408,
+    OpMaskedGatherINTEL = 6428,
+    OpMaskedScatterINTEL = 6429,
     Max = 0x7fffffff,
 };
 
@@ -2821,6 +2824,8 @@ inline void HasResultAndType(Op opcode, bool *hasResult, bool *hasResultType) {
     case Op::OpGroupLogicalAndKHR: *hasResult = true; *hasResultType = true; break;
     case Op::OpGroupLogicalOrKHR: *hasResult = true; *hasResultType = true; break;
     case Op::OpGroupLogicalXorKHR: *hasResult = true; *hasResultType = true; break;
+    case Op::OpMaskedGatherINTEL: *hasResult = true; *hasResultType = true; break;
+    case Op::OpMaskedScatterINTEL: *hasResult = false; *hasResultType = false; break;
     }
 }
 #endif /* SPV_ENABLE_UTILITY_CODE */

--- a/include/spirv/unified1/spirv.json
+++ b/include/spirv/unified1/spirv.json
@@ -1185,6 +1185,7 @@
                     "FPGALatencyControlINTEL": 6171,
                     "FPGAArgumentInterfacesINTEL": 6174,
                     "GroupUniformArithmeticKHR": 6400,
+                    "MaskedGatherScatterINTEL": 6427,
                     "CacheControlsINTEL": 6441
                 }
             },
@@ -2099,7 +2100,9 @@
                     "OpGroupBitwiseXorKHR": 6405,
                     "OpGroupLogicalAndKHR": 6406,
                     "OpGroupLogicalOrKHR": 6407,
-                    "OpGroupLogicalXorKHR": 6408
+                    "OpGroupLogicalXorKHR": 6408,
+                    "OpMaskedGatherINTEL": 6428,
+                    "OpMaskedScatterINTEL": 6429
                 }
             }
         ]

--- a/include/spirv/unified1/spirv.lua
+++ b/include/spirv/unified1/spirv.lua
@@ -1167,6 +1167,7 @@ spv = {
         FPGALatencyControlINTEL = 6171,
         FPGAArgumentInterfacesINTEL = 6174,
         GroupUniformArithmeticKHR = 6400,
+        MaskedGatherScatterINTEL = 6427,
         CacheControlsINTEL = 6441,
     },
 
@@ -2042,6 +2043,8 @@ spv = {
         OpGroupLogicalAndKHR = 6406,
         OpGroupLogicalOrKHR = 6407,
         OpGroupLogicalXorKHR = 6408,
+        OpMaskedGatherINTEL = 6428,
+        OpMaskedScatterINTEL = 6429,
     },
 
 }

--- a/include/spirv/unified1/spirv.py
+++ b/include/spirv/unified1/spirv.py
@@ -1167,6 +1167,7 @@ spv = {
         'FPGALatencyControlINTEL' : 6171,
         'FPGAArgumentInterfacesINTEL' : 6174,
         'GroupUniformArithmeticKHR' : 6400,
+        'MaskedGatherScatterINTEL' : 6427,
         'CacheControlsINTEL' : 6441,
     },
 
@@ -2042,6 +2043,8 @@ spv = {
         'OpGroupLogicalAndKHR' : 6406,
         'OpGroupLogicalOrKHR' : 6407,
         'OpGroupLogicalXorKHR' : 6408,
+        'OpMaskedGatherINTEL' : 6428,
+        'OpMaskedScatterINTEL' : 6429,
     },
 
 }

--- a/include/spirv/unified1/spv.d
+++ b/include/spirv/unified1/spv.d
@@ -1212,6 +1212,7 @@ enum Capability : uint
     FPGALatencyControlINTEL = 6171,
     FPGAArgumentInterfacesINTEL = 6174,
     GroupUniformArithmeticKHR = 6400,
+    MaskedGatherScatterINTEL = 6427,
     CacheControlsINTEL = 6441,
 }
 
@@ -2108,6 +2109,8 @@ enum Op : uint
     OpGroupLogicalAndKHR = 6406,
     OpGroupLogicalOrKHR = 6407,
     OpGroupLogicalXorKHR = 6408,
+    OpMaskedGatherINTEL = 6428,
+    OpMaskedScatterINTEL = 6429,
 }
 
 


### PR DESCRIPTION
This extension allows TypeVector to have a physical pointer type Component Type and introduces gather/scatter instructions. It will be useful for explicitly vectorized kernels.

SPIR-V validator adjustments will be done later.

The spec: https://github.com/KhronosGroup/SPIRV-Registry/pull/223