### PR TITLE
Add Type-Declaration for extended types

### DIFF
--- a/include/spirv/unified1/spirv.core.grammar.json
+++ b/include/spirv/unified1/spirv.core.grammar.json
@@ -4856,7 +4856,7 @@
     },
     {
         "opname" : "OpTypeRayQueryKHR",
-        "class" : "Reserved",
+        "class" : "Type-Declaration",
         "opcode" : 4472,
         "operands" : [
             { "kind" : "IdResult" }
@@ -5693,7 +5693,7 @@
     },
     {
       "opname" : "OpTypeHitObjectNV",
-      "class"  : "Reserved",
+      "class"  : "Type-Declaration",
       "opcode" : 5281,
       "operands" : [
         { "kind" : "IdResult" }
@@ -5932,7 +5932,7 @@
     },
     {
       "opname" : "OpTypeAccelerationStructureNV",
-      "class"  : "Reserved",
+      "class"  : "Type-Declaration",
       "opcode" : 5341,
       "operands" : [
         { "kind" : "IdResult" }
@@ -5943,7 +5943,7 @@
     },
     {
       "opname" : "OpTypeAccelerationStructureKHR",
-      "class"  : "Reserved",
+      "class"  : "Type-Declaration",
       "opcode" : 5341,
       "operands" : [
         { "kind" : "IdResult" }
@@ -5967,7 +5967,7 @@
     },
     {
       "opname" : "OpTypeCooperativeMatrixNV",
-      "class"  : "Reserved",
+      "class"  : "Type-Declaration",
       "opcode" : 5358,
       "operands" : [
         { "kind" : "IdResult" },


### PR DESCRIPTION
Was trying to use the `Type-Declaration` class to get the `OpType*` out of the grammar json but realized the Ray Tracing types still are in `Reserved` 