### PR TITLE
Enable Dependabot to keep CI up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Closes #396 

Here is a configuration file for dependabot.

I decided to configure it group updates on a single PR in order to avoid multiple PRs. Although, since it is major version updates, single PRs would probably since it major versions are not releases too often.