### PR TITLE
Add a Source Language for Zig

### DIFF
--- a/include/spirv/unified1/spirv.bf
+++ b/include/spirv/unified1/spirv.bf
@@ -70,6 +70,7 @@ namespace Spv
             NZSL = 9,
             WGSL = 10,
             Slang = 11,
+            Zig = 12,
         }
 
         [AllowDuplicates, CRepr] public enum ExecutionModel

--- a/include/spirv/unified1/spirv.core.grammar.json
+++ b/include/spirv/unified1/spirv.core.grammar.json
@@ -10624,6 +10624,11 @@
           "enumerant" : "Slang",
           "value" : 11,
           "version" : "1.0"
+        },
+        {
+          "enumerant" : "Zig",
+          "value" : 12,
+          "version" : "1.0"
         }
       ]
     },

--- a/include/spirv/unified1/spirv.cs
+++ b/include/spirv/unified1/spirv.cs
@@ -69,6 +69,7 @@ namespace Spv
             NZSL = 9,
             WGSL = 10,
             Slang = 11,
+            Zig = 12,
         }
 
         public enum ExecutionModel

--- a/include/spirv/unified1/spirv.h
+++ b/include/spirv/unified1/spirv.h
@@ -77,6 +77,7 @@ typedef enum SpvSourceLanguage_ {
     SpvSourceLanguageNZSL = 9,
     SpvSourceLanguageWGSL = 10,
     SpvSourceLanguageSlang = 11,
+    SpvSourceLanguageZig = 12,
     SpvSourceLanguageMax = 0x7fffffff,
 } SpvSourceLanguage;
 

--- a/include/spirv/unified1/spirv.hpp
+++ b/include/spirv/unified1/spirv.hpp
@@ -73,6 +73,7 @@ enum SourceLanguage {
     SourceLanguageNZSL = 9,
     SourceLanguageWGSL = 10,
     SourceLanguageSlang = 11,
+    SourceLanguageZig = 12,
     SourceLanguageMax = 0x7fffffff,
 };
 

--- a/include/spirv/unified1/spirv.hpp11
+++ b/include/spirv/unified1/spirv.hpp11
@@ -73,6 +73,7 @@ enum class SourceLanguage : unsigned {
     NZSL = 9,
     WGSL = 10,
     Slang = 11,
+    Zig = 12,
     Max = 0x7fffffff,
 };
 

--- a/include/spirv/unified1/spirv.json
+++ b/include/spirv/unified1/spirv.json
@@ -79,7 +79,8 @@
                     "HERO_C": 8,
                     "NZSL": 9,
                     "WGSL": 10,
-                    "Slang": 11
+                    "Slang": 11,
+                    "Zig": 12
                 }
             },
             {

--- a/include/spirv/unified1/spirv.lua
+++ b/include/spirv/unified1/spirv.lua
@@ -64,6 +64,7 @@ spv = {
         NZSL = 9,
         WGSL = 10,
         Slang = 11,
+        Zig = 12,
     },
 
     ExecutionModel = {

--- a/include/spirv/unified1/spirv.py
+++ b/include/spirv/unified1/spirv.py
@@ -64,6 +64,7 @@ spv = {
         'NZSL' : 9,
         'WGSL' : 10,
         'Slang' : 11,
+        'Zig' : 12,
     },
 
     'ExecutionModel' : {

--- a/include/spirv/unified1/spv.d
+++ b/include/spirv/unified1/spv.d
@@ -72,6 +72,7 @@ enum SourceLanguage : uint
     NZSL = 9,
     WGSL = 10,
     Slang = 11,
+    Zig = 12,
 }
 
 enum ExecutionModel : uint


### PR DESCRIPTION
Adds source language identifiers for [Zig](https://ziglang.org/) (github: [ziglang/zig](https://github.com/ziglang/zig)). The self-hosted Zig compiler has a work-in-progress SPIR-V backend.