### PR TITLE
update copyright dates to 2024

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Google LLC
+# Copyright (c) 2020-2024 Google LLC
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and/or associated documentation files (the "Materials"),

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2023 The Khronos Group Inc.
+# Copyright (c) 2015-2024 The Khronos Group Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and/or associated documentation files (the

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2015-2018 The Khronos Group Inc.
+Copyright (c) 2015-2024 The Khronos Group Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and/or associated documentation files (the

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ python3 bin/makeExtinstHeaders.py
 ## License
 <a name="license"></a>
 ```
-Copyright (c) 2015-2018 The Khronos Group Inc.
+Copyright (c) 2015-2024 The Khronos Group Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and/or associated documentation files (the

--- a/include/spirv/spir-v.xml
+++ b/include/spirv/spir-v.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <registry>
     <!--
-    Copyright (c) 2015 The Khronos Group Inc.
+    Copyright (c) 2015-2024 The Khronos Group Inc.
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and/or associated documentation files (the

--- a/include/spirv/unified1/AMD_gcn_shader.h
+++ b/include/spirv/unified1/AMD_gcn_shader.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Khronos Group Inc.
+// Copyright (c) 2020-2024 The Khronos Group Inc.
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and/or associated documentation files (the

--- a/include/spirv/unified1/AMD_shader_ballot.h
+++ b/include/spirv/unified1/AMD_shader_ballot.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Khronos Group Inc.
+// Copyright (c) 2020-2024 The Khronos Group Inc.
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and/or associated documentation files (the

--- a/include/spirv/unified1/AMD_shader_explicit_vertex_parameter.h
+++ b/include/spirv/unified1/AMD_shader_explicit_vertex_parameter.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Khronos Group Inc.
+// Copyright (c) 2020-2024 The Khronos Group Inc.
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and/or associated documentation files (the

--- a/include/spirv/unified1/AMD_shader_trinary_minmax.h
+++ b/include/spirv/unified1/AMD_shader_trinary_minmax.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Khronos Group Inc.
+// Copyright (c) 2020-2024 The Khronos Group Inc.
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and/or associated documentation files (the

--- a/include/spirv/unified1/DebugInfo.h
+++ b/include/spirv/unified1/DebugInfo.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 The Khronos Group Inc.
+// Copyright (c) 2017-2024 The Khronos Group Inc.
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and/or associated documentation files (the "Materials"),

--- a/include/spirv/unified1/GLSL.std.450.h
+++ b/include/spirv/unified1/GLSL.std.450.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2014-2016 The Khronos Group Inc.
+** Copyright (c) 2014-2024 The Khronos Group Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a copy
 ** of this software and/or associated documentation files (the "Materials"),

--- a/include/spirv/unified1/NonSemanticClspvReflection.h
+++ b/include/spirv/unified1/NonSemanticClspvReflection.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Khronos Group Inc.
+// Copyright (c) 2020-2024 The Khronos Group Inc.
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and/or associated documentation files (the

--- a/include/spirv/unified1/NonSemanticDebugBreak.h
+++ b/include/spirv/unified1/NonSemanticDebugBreak.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Khronos Group Inc.
+// Copyright (c) 2020-2024 The Khronos Group Inc.
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and/or associated documentation files (the

--- a/include/spirv/unified1/NonSemanticDebugPrintf.h
+++ b/include/spirv/unified1/NonSemanticDebugPrintf.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Khronos Group Inc.
+// Copyright (c) 2020-2024 The Khronos Group Inc.
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and/or associated documentation files (the

--- a/include/spirv/unified1/NonSemanticShaderDebugInfo100.h
+++ b/include/spirv/unified1/NonSemanticShaderDebugInfo100.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Khronos Group Inc.
+// Copyright (c) 2018-2024 The Khronos Group Inc.
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and/or associated documentation files (the "Materials"),

--- a/include/spirv/unified1/NonSemanticVkspReflection.h
+++ b/include/spirv/unified1/NonSemanticVkspReflection.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Khronos Group Inc.
+// Copyright (c) 2020-2024 The Khronos Group Inc.
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and/or associated documentation files (the

--- a/include/spirv/unified1/OpenCL.std.h
+++ b/include/spirv/unified1/OpenCL.std.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2015-2019 The Khronos Group Inc.
+** Copyright (c) 2015-2024 The Khronos Group Inc.
 **
 ** Permission is hereby granted, free of charge, to any person obtaining a copy
 ** of this software and/or associated documentation files (the "Materials"),

--- a/include/spirv/unified1/OpenCLDebugInfo100.h
+++ b/include/spirv/unified1/OpenCLDebugInfo100.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Khronos Group Inc.
+// Copyright (c) 2018-2024 The Khronos Group Inc.
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and/or associated documentation files (the "Materials"),

--- a/include/spirv/unified1/extinst.debuginfo.grammar.json
+++ b/include/spirv/unified1/extinst.debuginfo.grammar.json
@@ -1,6 +1,6 @@
 {
   "copyright" : [
-    "Copyright (c) 2017 The Khronos Group Inc.",
+    "Copyright (c) 2017-2024 The Khronos Group Inc.",
     "",
     "Permission is hereby granted, free of charge, to any person obtaining a copy",
     "of this software and/or associated documentation files (the \"Materials\"),",

--- a/include/spirv/unified1/extinst.glsl.std.450.grammar.json
+++ b/include/spirv/unified1/extinst.glsl.std.450.grammar.json
@@ -1,6 +1,6 @@
 {
   "copyright" : [
-    "Copyright (c) 2014-2016 The Khronos Group Inc.",
+    "Copyright (c) 2014-2024 The Khronos Group Inc.",
     "",
     "Permission is hereby granted, free of charge, to any person obtaining a copy",
     "of this software and/or associated documentation files (the \"Materials\"),",

--- a/include/spirv/unified1/extinst.nonsemantic.shader.debuginfo.100.grammar.json
+++ b/include/spirv/unified1/extinst.nonsemantic.shader.debuginfo.100.grammar.json
@@ -1,6 +1,6 @@
 {
   "copyright" : [
-    "Copyright (c) 2018 The Khronos Group Inc.",
+    "Copyright (c) 2018-2024 The Khronos Group Inc.",
     "",
     "Permission is hereby granted, free of charge, to any person obtaining a copy",
     "of this software and/or associated documentation files (the \"Materials\"),",

--- a/include/spirv/unified1/extinst.opencl.debuginfo.100.grammar.json
+++ b/include/spirv/unified1/extinst.opencl.debuginfo.100.grammar.json
@@ -1,6 +1,6 @@
 {
   "copyright" : [
-    "Copyright (c) 2018 The Khronos Group Inc.",
+    "Copyright (c) 2018-2024 The Khronos Group Inc.",
     "",
     "Permission is hereby granted, free of charge, to any person obtaining a copy",
     "of this software and/or associated documentation files (the \"Materials\"),",

--- a/include/spirv/unified1/extinst.opencl.std.100.grammar.json
+++ b/include/spirv/unified1/extinst.opencl.std.100.grammar.json
@@ -1,6 +1,6 @@
 {
   "copyright" : [
-    "Copyright (c) 2014-2016 The Khronos Group Inc.",
+    "Copyright (c) 2014-2024 The Khronos Group Inc.",
     "",
     "Permission is hereby granted, free of charge, to any person obtaining a copy",
     "of this software and/or associated documentation files (the \"Materials\"),",

--- a/include/spirv/unified1/spirv.bf
+++ b/include/spirv/unified1/spirv.bf
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2020 The Khronos Group Inc.
+// Copyright (c) 2014-2024 The Khronos Group Inc.
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and/or associated documentation files (the "Materials"),

--- a/include/spirv/unified1/spirv.core.grammar.json
+++ b/include/spirv/unified1/spirv.core.grammar.json
@@ -1,6 +1,6 @@
 {
   "copyright" : [
-    "Copyright (c) 2014-2020 The Khronos Group Inc.",
+    "Copyright (c) 2014-2024 The Khronos Group Inc.",
     "",
     "Permission is hereby granted, free of charge, to any person obtaining a copy",
     "of this software and/or associated documentation files (the \"Materials\"),",

--- a/include/spirv/unified1/spirv.cs
+++ b/include/spirv/unified1/spirv.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2020 The Khronos Group Inc.
+// Copyright (c) 2014-2024 The Khronos Group Inc.
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and/or associated documentation files (the "Materials"),

--- a/include/spirv/unified1/spirv.h
+++ b/include/spirv/unified1/spirv.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (c) 2014-2020 The Khronos Group Inc.
+** Copyright (c) 2014-2024 The Khronos Group Inc.
 ** 
 ** Permission is hereby granted, free of charge, to any person obtaining a copy
 ** of this software and/or associated documentation files (the "Materials"),

--- a/include/spirv/unified1/spirv.hpp
+++ b/include/spirv/unified1/spirv.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2020 The Khronos Group Inc.
+// Copyright (c) 2014-2024 The Khronos Group Inc.
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and/or associated documentation files (the "Materials"),

--- a/include/spirv/unified1/spirv.hpp11
+++ b/include/spirv/unified1/spirv.hpp11
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2020 The Khronos Group Inc.
+// Copyright (c) 2014-2024 The Khronos Group Inc.
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and/or associated documentation files (the "Materials"),

--- a/include/spirv/unified1/spirv.json
+++ b/include/spirv/unified1/spirv.json
@@ -6,7 +6,7 @@
             "Comment":
             [
                 [
-                    "Copyright (c) 2014-2020 The Khronos Group Inc.",
+                    "Copyright (c) 2014-2024 The Khronos Group Inc.",
                     "",
                     "Permission is hereby granted, free of charge, to any person obtaining a copy",
                     "of this software and/or associated documentation files (the \"Materials\"),",

--- a/include/spirv/unified1/spirv.lua
+++ b/include/spirv/unified1/spirv.lua
@@ -1,4 +1,4 @@
--- Copyright (c) 2014-2020 The Khronos Group Inc.
+-- Copyright (c) 2014-2024 The Khronos Group Inc.
 -- 
 -- Permission is hereby granted, free of charge, to any person obtaining a copy
 -- of this software and/or associated documentation files (the "Materials"),

--- a/include/spirv/unified1/spirv.py
+++ b/include/spirv/unified1/spirv.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2020 The Khronos Group Inc.
+# Copyright (c) 2014-2024 The Khronos Group Inc.
 # 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and/or associated documentation files (the "Materials"),

--- a/include/spirv/unified1/spv.d
+++ b/include/spirv/unified1/spv.d
@@ -1,5 +1,5 @@
 /+
- + Copyright (c) 2014-2020 The Khronos Group Inc.
+ + Copyright (c) 2014-2024 The Khronos Group Inc.
  + 
  + Permission is hereby granted, free of charge, to any person obtaining a copy
  + of this software and/or associated documentation files (the "Materials"),

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2023 The Khronos Group Inc.
+# Copyright (c) 2015-2024 The Khronos Group Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and/or associated documentation files (the

--- a/tests/example.cpp
+++ b/tests/example.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 The Khronos Group Inc.
+// Copyright (c) 2016-2024 The Khronos Group Inc.
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and/or associated documentation files (the

--- a/tools/buildHeaders/bin/generate_language_headers.py
+++ b/tools/buildHeaders/bin/generate_language_headers.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2017-2020 Google LLC
+# Copyright (c) 2017-2024 Google LLC
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and/or associated documentation files (the
@@ -32,7 +32,7 @@ import json
 import os.path
 import re
 
-DEFAULT_COPYRIGHT="""Copyright (c) 2020 The Khronos Group Inc.
+DEFAULT_COPYRIGHT="""Copyright (c) 2020-2024 The Khronos Group Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and/or associated documentation files (the

--- a/tools/buildHeaders/header.cpp
+++ b/tools/buildHeaders/header.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2020 The Khronos Group Inc.
+// Copyright (c) 2014-2024 The Khronos Group Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and/or associated documentation files (the "Materials"),
@@ -169,7 +169,7 @@ namespace {
     }
 
     const std::string TPrinter::DocCopyright =
-        "Copyright (c) 2014-2020 The Khronos Group Inc.\n"
+        "Copyright (c) 2014-2024 The Khronos Group Inc.\n"
         "\n"
         "Permission is hereby granted, free of charge, to any person obtaining a copy\n"
         "of this software and/or associated documentation files (the \"Materials\"),\n"

--- a/tools/buildHeaders/header.h
+++ b/tools/buildHeaders/header.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2019 The Khronos Group Inc.
+// Copyright (c) 2014-2024 The Khronos Group Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and/or associated documentation files (the "Materials"),

--- a/tools/buildHeaders/jsonToSpirv.cpp
+++ b/tools/buildHeaders/jsonToSpirv.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2020 The Khronos Group Inc.
+// Copyright (c) 2014-2024 The Khronos Group Inc.
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and/or associated documentation files (the "Materials"),

--- a/tools/buildHeaders/jsonToSpirv.h
+++ b/tools/buildHeaders/jsonToSpirv.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2020 The Khronos Group Inc.
+// Copyright (c) 2014-2024 The Khronos Group Inc.
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and/or associated documentation files (the "Materials"),

--- a/tools/buildHeaders/main.cpp
+++ b/tools/buildHeaders/main.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2019 The Khronos Group Inc.
+// Copyright (c) 2014-2024 The Khronos Group Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and/or associated documentation files (the "Materials"),


### PR DESCRIPTION
fixes #402 

Updates most copyright dates to 2024, for "active" files.  This includes:

* The README, LICENSE, and top-level build files in the root directory.
* The XML file in include/spirv.
* All files in include/spirv/unified1.
* All test files in tests.
* All header generation files in tools/buildHeaders.

Of note, the files that were not updated include:

* Any of the older headers in include/spirv/1.0, include/spirv/1.1, and include/spirv/1.2.
* Any of the jsoncpp files.