### PR TITLE
reserve one scope bit for an Intel extension

### DIFF
--- a/include/spirv/spir-v.xml
+++ b/include/spirv/spir-v.xml
@@ -293,8 +293,8 @@
     <ids type="ImageOperand" start="17" end="30" comment="Unreserved bits reservable for use by vendors"/>
     <ids type="ImageOperand" start="31" end="31" vendor="Khronos" comment="Reserved ImageOperand bit, not available to vendors"/>
 
-    <!-- SECTION: SPIR-V Scope Bit Reservations -->
-    <!-- Reserve ranges of bits in the "Scope"" bitfield.
+    <!-- SECTION: SPIR-V Scope Reservations -->
+    <!-- Reserve "Scope" values.
 
          Each vendor determines the use of values in their own ranges.
          Vendors are not required to disclose those uses.  If the use of a
@@ -307,9 +307,8 @@
          - All values in a range should be used before allocating a new range.
          -->
 
-    <!-- Reserved Scope bits -->
-    <ids type="Scope" start="0" end="15" vendor="Khronos" comment="Reserved Scope bits, not available to vendors - see the SPIR-V Specification"/>
+    <!-- Reserved Scope values -->
+    <ids type="Scope" start="0" end="15" vendor="Khronos" comment="Reserved Scope values, not available to vendors - see the SPIR-V Specification"/>
     <ids type="Scope" start="16" end="16" vendor="Intel" comment="Contact ben.ashbaugh@intel.com"/>
-    <ids type="Scope" start="17" end="31" comment="Unreserved bits reservable for use by vendors"/>
 
 </registry>

--- a/include/spirv/spir-v.xml
+++ b/include/spirv/spir-v.xml
@@ -293,4 +293,23 @@
     <ids type="ImageOperand" start="17" end="30" comment="Unreserved bits reservable for use by vendors"/>
     <ids type="ImageOperand" start="31" end="31" vendor="Khronos" comment="Reserved ImageOperand bit, not available to vendors"/>
 
+    <!-- SECTION: SPIR-V Scope Bit Reservations -->
+    <!-- Reserve ranges of bits in the "Scope"" bitfield.
+
+         Each vendor determines the use of values in their own ranges.
+         Vendors are not required to disclose those uses.  If the use of a
+         value is included in an extension that is adopted by a Khronos
+         extension or specification, then that value's use may be permanently
+         fixed as if originally reserved in a Khronos range.
+
+         The SPIR Working Group strongly recommends:
+         - Each value is used for only one purpose.
+         - All values in a range should be used before allocating a new range.
+         -->
+
+    <!-- Reserved Scope bits -->
+    <ids type="Scope" start="0" end="15" vendor="Khronos" comment="Reserved Scope bits, not available to vendors - see the SPIR-V Specification"/>
+    <ids type="Scope" start="16" end="16" vendor="Intel" comment="Contact ben.ashbaugh@intel.com"/>
+    <ids type="Scope" start="17" end="31" comment="Unreserved bits reservable for use by vendors"/>
+
 </registry>


### PR DESCRIPTION
Please reserve one "scope" bit for an Intel extension.

This appears to be the first time a non-Khronos extension has needed a scope bit, so this is a new section in the SPIR-V XML file.  I tried to follow existing conventions for other bit reservations, but please let me know if I missed something.

Please pay careful attention to:

1. I've kept the low 16 bits reserved for Khronos use, similar to the other bit reservations.  Do we still want to do this?
2. I did NOT keep the highest bit 31 reserved, since it's not clear how this would work for the scope bits like it would for things like the loop control bitfield or the memory operands bitfield.  Is this correct?