### PR TITLE
cmake: Allow external control of test and install options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,12 +35,14 @@ add_library(SPIRV-Headers INTERFACE)
 add_library(SPIRV-Headers::SPIRV-Headers ALIAS SPIRV-Headers)
 target_include_directories(SPIRV-Headers INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
 
-if (PROJECT_IS_TOP_LEVEL)
-    option(BUILD_TESTS "Build the tests")
-    if (BUILD_TESTS)
-        add_subdirectory(tests)
-    endif()
+option(SPIRV_HEADERS_ENABLE_TESTS "Test SPIRV-Headers" ${PROJECT_IS_TOP_LEVEL})
+option(SPIRV_HEADERS_ENABLE_INSTALL "Install SPIRV-Headers" ${PROJECT_IS_TOP_LEVEL})
 
+if(SPIRV_HEADERS_ENABLE_TESTS)
+    add_subdirectory(tests)
+endif()
+
+if(SPIRV_HEADERS_ENABLE_INSTALL)
     include(GNUInstallDirs)
     include(CMakePackageConfigHelpers)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,13 +24,13 @@
 # TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 # MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
 
-add_library(simple_test STATIC)
+add_library(spirv_headers_simple_test STATIC)
 
-target_sources(simple_test PRIVATE
+target_sources(spirv_headers_simple_test PRIVATE
     example.cpp
 )
 
-target_link_libraries(simple_test PRIVATE
+target_link_libraries(spirv_headers_simple_test PRIVATE
     SPIRV-Headers::SPIRV-Headers
 )
 


### PR DESCRIPTION
Test and install by default when the project is top level.

In any case, they can be controlled via CMake variables SPIRV_HEADERS_ENABLE_TEST and SPIRV_HEADERS_ENABLE_INSTALL

Rename the simple test target to spirv_headers_simple_test