### PR TITLE
VkspReflection non-sematic: add dispatchId in configuration

### DIFF
--- a/include/spirv/unified1/NonSemanticVkspReflection.h
+++ b/include/spirv/unified1/NonSemanticVkspReflection.h
@@ -33,7 +33,7 @@ extern "C" {
 #endif
 
 enum {
-    NonSemanticVkspReflectionRevision = 1,
+    NonSemanticVkspReflectionRevision = 2,
     NonSemanticVkspReflectionRevision_BitWidthPadding = 0x7fffffff
 };
 

--- a/include/spirv/unified1/extinst.nonsemantic.vkspreflection.grammar.json
+++ b/include/spirv/unified1/extinst.nonsemantic.vkspreflection.grammar.json
@@ -1,5 +1,5 @@
 {
-  "revision" : 1,
+  "revision" : 2,
   "instructions" : [
     {
       "opname" : "Configuration",
@@ -12,7 +12,8 @@
         {"kind" : "LiteralString", "name" : "EntryPoint" },
         {"kind" : "LiteralInteger", "name" : "groupCountX" },
         {"kind" : "LiteralInteger", "name" : "groupCountY" },
-        {"kind" : "LiteralInteger", "name" : "groupCountZ" }
+        {"kind" : "LiteralInteger", "name" : "groupCountZ" },
+        {"kind" : "LiteralInteger", "name" : "dispatchId" }
       ]
     },
     {


### PR DESCRIPTION
This is needed to add new features intercepting buffers content in vksp.