### PR TITLE
Enforce grammar naming conventions for aliases

### DIFF
--- a/include/spirv/unified1/spirv.core.grammar.json
+++ b/include/spirv/unified1/spirv.core.grammar.json
@@ -5924,7 +5924,7 @@
       "version" : "None"
     },
     {
-      "opname" : "OpReportIntersectionNV",
+      "opname" : "OpReportIntersectionKHR",
       "class"  : "Reserved",
       "opcode" : 5334,
       "operands" : [
@@ -5938,7 +5938,7 @@
       "version" : "None"
     },
     {
-      "opname" : "OpReportIntersectionKHR",
+      "opname" : "OpReportIntersectionNV",
       "class"  : "Reserved",
       "opcode" : 5334,
       "operands" : [
@@ -6055,7 +6055,7 @@
       "version" : "None"
     },
     {
-      "opname" : "OpTypeAccelerationStructureNV",
+      "opname" : "OpTypeAccelerationStructureKHR",
       "class"  : "Type-Declaration",
       "opcode" : 5341,
       "operands" : [
@@ -6066,7 +6066,7 @@
       "version" : "None"
     },
     {
-      "opname" : "OpTypeAccelerationStructureKHR",
+      "opname" : "OpTypeAccelerationStructureNV",
       "class"  : "Type-Declaration",
       "opcode" : 5341,
       "operands" : [
@@ -10873,20 +10873,14 @@
           "version" : "None"
         },
         {
-          "enumerant" : "RayGenerationNV",
-          "value" : 5313,
-          "capabilities" : [ "RayTracingNV" , "RayTracingKHR" ],
-          "version" : "None"
-        },
-        {
           "enumerant" : "RayGenerationKHR",
           "value" : 5313,
           "capabilities" : [ "RayTracingNV" , "RayTracingKHR" ],
           "version" : "None"
         },
         {
-          "enumerant" : "IntersectionNV",
-          "value" : 5314,
+          "enumerant" : "RayGenerationNV",
+          "value" : 5313,
           "capabilities" : [ "RayTracingNV" , "RayTracingKHR" ],
           "version" : "None"
         },
@@ -10897,8 +10891,8 @@
           "version" : "None"
         },
         {
-          "enumerant" : "AnyHitNV",
-          "value" : 5315,
+          "enumerant" : "IntersectionNV",
+          "value" : 5314,
           "capabilities" : [ "RayTracingNV" , "RayTracingKHR" ],
           "version" : "None"
         },
@@ -10909,8 +10903,8 @@
           "version" : "None"
         },
         {
-          "enumerant" : "ClosestHitNV",
-          "value" : 5316,
+          "enumerant" : "AnyHitNV",
+          "value" : 5315,
           "capabilities" : [ "RayTracingNV" , "RayTracingKHR" ],
           "version" : "None"
         },
@@ -10921,8 +10915,8 @@
           "version" : "None"
         },
         {
-          "enumerant" : "MissNV",
-          "value" : 5317,
+          "enumerant" : "ClosestHitNV",
+          "value" : 5316,
           "capabilities" : [ "RayTracingNV" , "RayTracingKHR" ],
           "version" : "None"
         },
@@ -10933,13 +10927,19 @@
           "version" : "None"
         },
         {
-          "enumerant" : "CallableNV",
-          "value" : 5318,
+          "enumerant" : "MissNV",
+          "value" : 5317,
           "capabilities" : [ "RayTracingNV" , "RayTracingKHR" ],
           "version" : "None"
         },
         {
           "enumerant" : "CallableKHR",
+          "value" : 5318,
+          "capabilities" : [ "RayTracingNV" , "RayTracingKHR" ],
+          "version" : "None"
+        },
+        {
+          "enumerant" : "CallableNV",
           "value" : 5318,
           "capabilities" : [ "RayTracingNV" , "RayTracingKHR" ],
           "version" : "None"
@@ -11497,13 +11497,6 @@
           "version" : "None"
         },
         {
-          "enumerant" : "OutputLinesNV",
-          "value" : 5269,
-          "capabilities" : [ "MeshShadingNV", "MeshShadingEXT" ],
-          "extensions" : [ "SPV_NV_mesh_shader", "SPV_EXT_mesh_shader" ],
-          "version" : "None"
-        },
-        {
           "enumerant" : "OutputLinesEXT",
           "value" : 5269,
           "capabilities" : [ "MeshShadingNV", "MeshShadingEXT" ],
@@ -11511,7 +11504,14 @@
           "version" : "None"
         },
         {
-          "enumerant" : "OutputPrimitivesNV",
+          "enumerant" : "OutputLinesNV",
+          "value" : 5269,
+          "capabilities" : [ "MeshShadingNV", "MeshShadingEXT" ],
+          "extensions" : [ "SPV_NV_mesh_shader", "SPV_EXT_mesh_shader" ],
+          "version" : "None"
+        },
+        {
+          "enumerant" : "OutputPrimitivesEXT",
           "value" : 5270,
           "capabilities" : [ "MeshShadingNV", "MeshShadingEXT" ],
           "parameters" : [
@@ -11521,7 +11521,7 @@
           "version" : "None"
         },
         {
-          "enumerant" : "OutputPrimitivesEXT",
+          "enumerant" : "OutputPrimitivesNV",
           "value" : 5270,
           "capabilities" : [ "MeshShadingNV", "MeshShadingEXT" ],
           "parameters" : [
@@ -11545,14 +11545,14 @@
           "version" : "None"
         },
         {
-          "enumerant" : "OutputTrianglesNV",
+          "enumerant" : "OutputTrianglesEXT",
           "value" : 5298,
           "capabilities" : [ "MeshShadingNV", "MeshShadingEXT" ],
           "extensions" : [ "SPV_NV_mesh_shader", "SPV_EXT_mesh_shader" ],
           "version" : "None"
         },
         {
-          "enumerant" : "OutputTrianglesEXT",
+          "enumerant" : "OutputTrianglesNV",
           "value" : 5298,
           "capabilities" : [ "MeshShadingNV", "MeshShadingEXT" ],
           "extensions" : [ "SPV_NV_mesh_shader", "SPV_EXT_mesh_shader" ],
@@ -11865,13 +11865,6 @@
           "version" : "None"
         },
         {
-          "enumerant" : "CallableDataNV",
-          "value" : 5328,
-          "extensions" : [ "SPV_NV_ray_tracing" , "SPV_KHR_ray_tracing" ],
-          "capabilities" : [ "RayTracingNV" , "RayTracingKHR" ],
-          "version" : "None"
-        },
-        {
           "enumerant" : "CallableDataKHR",
           "value" : 5328,
           "extensions" : [ "SPV_NV_ray_tracing" , "SPV_KHR_ray_tracing" ],
@@ -11879,8 +11872,8 @@
           "version" : "None"
         },
         {
-          "enumerant" : "IncomingCallableDataNV",
-          "value" : 5329,
+          "enumerant" : "CallableDataNV",
+          "value" : 5328,
           "extensions" : [ "SPV_NV_ray_tracing" , "SPV_KHR_ray_tracing" ],
           "capabilities" : [ "RayTracingNV" , "RayTracingKHR" ],
           "version" : "None"
@@ -11893,8 +11886,8 @@
           "version" : "None"
         },
         {
-          "enumerant" : "RayPayloadNV",
-          "value" : 5338,
+          "enumerant" : "IncomingCallableDataNV",
+          "value" : 5329,
           "extensions" : [ "SPV_NV_ray_tracing" , "SPV_KHR_ray_tracing" ],
           "capabilities" : [ "RayTracingNV" , "RayTracingKHR" ],
           "version" : "None"
@@ -11907,8 +11900,8 @@
           "version" : "None"
         },
         {
-          "enumerant" : "HitAttributeNV",
-          "value" : 5339,
+          "enumerant" : "RayPayloadNV",
+          "value" : 5338,
           "extensions" : [ "SPV_NV_ray_tracing" , "SPV_KHR_ray_tracing" ],
           "capabilities" : [ "RayTracingNV" , "RayTracingKHR" ],
           "version" : "None"
@@ -11921,8 +11914,8 @@
           "version" : "None"
         },
         {
-          "enumerant" : "IncomingRayPayloadNV",
-          "value" : 5342,
+          "enumerant" : "HitAttributeNV",
+          "value" : 5339,
           "extensions" : [ "SPV_NV_ray_tracing" , "SPV_KHR_ray_tracing" ],
           "capabilities" : [ "RayTracingNV" , "RayTracingKHR" ],
           "version" : "None"
@@ -11935,14 +11928,21 @@
           "version" : "None"
         },
         {
-          "enumerant" : "ShaderRecordBufferNV",
-          "value" : 5343,
+          "enumerant" : "IncomingRayPayloadNV",
+          "value" : 5342,
           "extensions" : [ "SPV_NV_ray_tracing" , "SPV_KHR_ray_tracing" ],
           "capabilities" : [ "RayTracingNV" , "RayTracingKHR" ],
           "version" : "None"
         },
         {
           "enumerant" : "ShaderRecordBufferKHR",
+          "value" : 5343,
+          "extensions" : [ "SPV_NV_ray_tracing" , "SPV_KHR_ray_tracing" ],
+          "capabilities" : [ "RayTracingNV" , "RayTracingKHR" ],
+          "version" : "None"
+        },
+        {
+          "enumerant" : "ShaderRecordBufferNV",
           "value" : 5343,
           "extensions" : [ "SPV_NV_ray_tracing" , "SPV_KHR_ray_tracing" ],
           "capabilities" : [ "RayTracingNV" , "RayTracingKHR" ],
@@ -13299,14 +13299,14 @@
           ]
         },
         {
-          "enumerant" : "PerPrimitiveNV",
+          "enumerant" : "PerPrimitiveEXT",
           "value" : 5271,
           "capabilities" : [ "MeshShadingNV", "MeshShadingEXT" ],
           "extensions" : [ "SPV_NV_mesh_shader", "SPV_EXT_mesh_shader" ],
           "version" : "None"
         },
         {
-          "enumerant" : "PerPrimitiveEXT",
+          "enumerant" : "PerPrimitiveNV",
           "value" : 5271,
           "capabilities" : [ "MeshShadingNV", "MeshShadingEXT" ],
           "extensions" : [ "SPV_NV_mesh_shader", "SPV_EXT_mesh_shader" ],
@@ -14606,13 +14606,6 @@
           "version" : "None"
         },
         {
-          "enumerant" : "LaunchIdNV",
-          "value" : 5319,
-          "capabilities" : [ "RayTracingNV" , "RayTracingKHR" ],
-          "extensions" : [ "SPV_NV_ray_tracing" , "SPV_KHR_ray_tracing" ],
-          "version" : "None"
-        },
-        {
           "enumerant" : "LaunchIdKHR",
           "value" : 5319,
           "capabilities" : [ "RayTracingNV" , "RayTracingKHR" ],
@@ -14620,8 +14613,8 @@
           "version" : "None"
         },
         {
-          "enumerant" : "LaunchSizeNV",
-          "value" : 5320,
+          "enumerant" : "LaunchIdNV",
+          "value" : 5319,
           "capabilities" : [ "RayTracingNV" , "RayTracingKHR" ],
           "extensions" : [ "SPV_NV_ray_tracing" , "SPV_KHR_ray_tracing" ],
           "version" : "None"
@@ -14634,8 +14627,8 @@
           "version" : "None"
         },
         {
-          "enumerant" : "WorldRayOriginNV",
-          "value" : 5321,
+          "enumerant" : "LaunchSizeNV",
+          "value" : 5320,
           "capabilities" : [ "RayTracingNV" , "RayTracingKHR" ],
           "extensions" : [ "SPV_NV_ray_tracing" , "SPV_KHR_ray_tracing" ],
           "version" : "None"
@@ -14648,8 +14641,8 @@
           "version" : "None"
         },
         {
-          "enumerant" : "WorldRayDirectionNV",
-          "value" : 5322,
+          "enumerant" : "WorldRayOriginNV",
+          "value" : 5321,
           "capabilities" : [ "RayTracingNV" , "RayTracingKHR" ],
           "extensions" : [ "SPV_NV_ray_tracing" , "SPV_KHR_ray_tracing" ],
           "version" : "None"
@@ -14662,8 +14655,8 @@
           "version" : "None"
         },
         {
-          "enumerant" : "ObjectRayOriginNV",
-          "value" : 5323,
+          "enumerant" : "WorldRayDirectionNV",
+          "value" : 5322,
           "capabilities" : [ "RayTracingNV" , "RayTracingKHR" ],
           "extensions" : [ "SPV_NV_ray_tracing" , "SPV_KHR_ray_tracing" ],
           "version" : "None"
@@ -14676,8 +14669,8 @@
           "version" : "None"
         },
         {
-          "enumerant" : "ObjectRayDirectionNV",
-          "value" : 5324,
+          "enumerant" : "ObjectRayOriginNV",
+          "value" : 5323,
           "capabilities" : [ "RayTracingNV" , "RayTracingKHR" ],
           "extensions" : [ "SPV_NV_ray_tracing" , "SPV_KHR_ray_tracing" ],
           "version" : "None"
@@ -14690,8 +14683,8 @@
           "version" : "None"
         },
         {
-          "enumerant" : "RayTminNV",
-          "value" : 5325,
+          "enumerant" : "ObjectRayDirectionNV",
+          "value" : 5324,
           "capabilities" : [ "RayTracingNV" , "RayTracingKHR" ],
           "extensions" : [ "SPV_NV_ray_tracing" , "SPV_KHR_ray_tracing" ],
           "version" : "None"
@@ -14704,8 +14697,8 @@
           "version" : "None"
         },
         {
-          "enumerant" : "RayTmaxNV",
-          "value" : 5326,
+          "enumerant" : "RayTminNV",
+          "value" : 5325,
           "capabilities" : [ "RayTracingNV" , "RayTracingKHR" ],
           "extensions" : [ "SPV_NV_ray_tracing" , "SPV_KHR_ray_tracing" ],
           "version" : "None"
@@ -14718,8 +14711,8 @@
           "version" : "None"
         },
         {
-          "enumerant" : "InstanceCustomIndexNV",
-          "value" : 5327,
+          "enumerant" : "RayTmaxNV",
+          "value" : 5326,
           "capabilities" : [ "RayTracingNV" , "RayTracingKHR" ],
           "extensions" : [ "SPV_NV_ray_tracing" , "SPV_KHR_ray_tracing" ],
           "version" : "None"
@@ -14732,8 +14725,8 @@
           "version" : "None"
         },
         {
-          "enumerant" : "ObjectToWorldNV",
-          "value" : 5330,
+          "enumerant" : "InstanceCustomIndexNV",
+          "value" : 5327,
           "capabilities" : [ "RayTracingNV" , "RayTracingKHR" ],
           "extensions" : [ "SPV_NV_ray_tracing" , "SPV_KHR_ray_tracing" ],
           "version" : "None"
@@ -14746,14 +14739,21 @@
           "version" : "None"
         },
         {
-          "enumerant" : "WorldToObjectNV",
-          "value" : 5331,
+          "enumerant" : "ObjectToWorldNV",
+          "value" : 5330,
           "capabilities" : [ "RayTracingNV" , "RayTracingKHR" ],
           "extensions" : [ "SPV_NV_ray_tracing" , "SPV_KHR_ray_tracing" ],
           "version" : "None"
         },
         {
           "enumerant" : "WorldToObjectKHR",
+          "value" : 5331,
+          "capabilities" : [ "RayTracingNV" , "RayTracingKHR" ],
+          "extensions" : [ "SPV_NV_ray_tracing" , "SPV_KHR_ray_tracing" ],
+          "version" : "None"
+        },
+        {
+          "enumerant" : "WorldToObjectNV",
           "value" : 5331,
           "capabilities" : [ "RayTracingNV" , "RayTracingKHR" ],
           "extensions" : [ "SPV_NV_ray_tracing" , "SPV_KHR_ray_tracing" ],
@@ -14767,14 +14767,14 @@
           "version" : "None"
         },
         {
-          "enumerant" : "HitKindNV",
+          "enumerant" : "HitKindKHR",
           "value" : 5333,
           "capabilities" : [ "RayTracingNV" , "RayTracingKHR" ],
           "extensions" : [ "SPV_NV_ray_tracing" , "SPV_KHR_ray_tracing" ],
           "version" : "None"
         },
         {
-          "enumerant" : "HitKindKHR",
+          "enumerant" : "HitKindNV",
           "value" : 5333,
           "capabilities" : [ "RayTracingNV" , "RayTracingKHR" ],
           "extensions" : [ "SPV_NV_ray_tracing" , "SPV_KHR_ray_tracing" ],
@@ -14806,14 +14806,14 @@
           "version" : "None"
         },
         {
-          "enumerant" : "IncomingRayFlagsNV",
+          "enumerant" : "IncomingRayFlagsKHR",
           "value" : 5351,
           "capabilities" : [ "RayTracingNV" , "RayTracingKHR" ],
           "extensions" : [ "SPV_NV_ray_tracing" , "SPV_KHR_ray_tracing" ],
           "version" : "None"
         },
         {
-          "enumerant" : "IncomingRayFlagsKHR",
+          "enumerant" : "IncomingRayFlagsNV",
           "value" : 5351,
           "capabilities" : [ "RayTracingNV" , "RayTracingKHR" ],
           "extensions" : [ "SPV_NV_ray_tracing" , "SPV_KHR_ray_tracing" ],

--- a/include/spirv/unified1/spirv.h
+++ b/include/spirv/unified1/spirv.h
@@ -2613,14 +2613,14 @@ inline void SpvHasResultAndType(SpvOp opcode, bool *hasResult, bool *hasResultTy
     case SpvOpWritePackedPrimitiveIndices4x8NV: *hasResult = false; *hasResultType = false; break;
     case SpvOpFetchMicroTriangleVertexPositionNV: *hasResult = true; *hasResultType = true; break;
     case SpvOpFetchMicroTriangleVertexBarycentricNV: *hasResult = true; *hasResultType = true; break;
-    case SpvOpReportIntersectionNV: *hasResult = true; *hasResultType = true; break;
+    case SpvOpReportIntersectionKHR: *hasResult = true; *hasResultType = true; break;
     case SpvOpIgnoreIntersectionNV: *hasResult = false; *hasResultType = false; break;
     case SpvOpTerminateRayNV: *hasResult = false; *hasResultType = false; break;
     case SpvOpTraceNV: *hasResult = false; *hasResultType = false; break;
     case SpvOpTraceMotionNV: *hasResult = false; *hasResultType = false; break;
     case SpvOpTraceRayMotionNV: *hasResult = false; *hasResultType = false; break;
     case SpvOpRayQueryGetIntersectionTriangleVertexPositionsKHR: *hasResult = true; *hasResultType = true; break;
-    case SpvOpTypeAccelerationStructureNV: *hasResult = true; *hasResultType = false; break;
+    case SpvOpTypeAccelerationStructureKHR: *hasResult = true; *hasResultType = false; break;
     case SpvOpExecuteCallableNV: *hasResult = false; *hasResultType = false; break;
     case SpvOpTypeCooperativeMatrixNV: *hasResult = true; *hasResultType = false; break;
     case SpvOpCooperativeMatrixLoadNV: *hasResult = true; *hasResultType = true; break;

--- a/include/spirv/unified1/spirv.hpp
+++ b/include/spirv/unified1/spirv.hpp
@@ -2609,14 +2609,14 @@ inline void HasResultAndType(Op opcode, bool *hasResult, bool *hasResultType) {
     case OpWritePackedPrimitiveIndices4x8NV: *hasResult = false; *hasResultType = false; break;
     case OpFetchMicroTriangleVertexPositionNV: *hasResult = true; *hasResultType = true; break;
     case OpFetchMicroTriangleVertexBarycentricNV: *hasResult = true; *hasResultType = true; break;
-    case OpReportIntersectionNV: *hasResult = true; *hasResultType = true; break;
+    case OpReportIntersectionKHR: *hasResult = true; *hasResultType = true; break;
     case OpIgnoreIntersectionNV: *hasResult = false; *hasResultType = false; break;
     case OpTerminateRayNV: *hasResult = false; *hasResultType = false; break;
     case OpTraceNV: *hasResult = false; *hasResultType = false; break;
     case OpTraceMotionNV: *hasResult = false; *hasResultType = false; break;
     case OpTraceRayMotionNV: *hasResult = false; *hasResultType = false; break;
     case OpRayQueryGetIntersectionTriangleVertexPositionsKHR: *hasResult = true; *hasResultType = true; break;
-    case OpTypeAccelerationStructureNV: *hasResult = true; *hasResultType = false; break;
+    case OpTypeAccelerationStructureKHR: *hasResult = true; *hasResultType = false; break;
     case OpExecuteCallableNV: *hasResult = false; *hasResultType = false; break;
     case OpTypeCooperativeMatrixNV: *hasResult = true; *hasResultType = false; break;
     case OpCooperativeMatrixLoadNV: *hasResult = true; *hasResultType = true; break;

--- a/include/spirv/unified1/spirv.hpp11
+++ b/include/spirv/unified1/spirv.hpp11
@@ -2609,14 +2609,14 @@ inline void HasResultAndType(Op opcode, bool *hasResult, bool *hasResultType) {
     case Op::OpWritePackedPrimitiveIndices4x8NV: *hasResult = false; *hasResultType = false; break;
     case Op::OpFetchMicroTriangleVertexPositionNV: *hasResult = true; *hasResultType = true; break;
     case Op::OpFetchMicroTriangleVertexBarycentricNV: *hasResult = true; *hasResultType = true; break;
-    case Op::OpReportIntersectionNV: *hasResult = true; *hasResultType = true; break;
+    case Op::OpReportIntersectionKHR: *hasResult = true; *hasResultType = true; break;
     case Op::OpIgnoreIntersectionNV: *hasResult = false; *hasResultType = false; break;
     case Op::OpTerminateRayNV: *hasResult = false; *hasResultType = false; break;
     case Op::OpTraceNV: *hasResult = false; *hasResultType = false; break;
     case Op::OpTraceMotionNV: *hasResult = false; *hasResultType = false; break;
     case Op::OpTraceRayMotionNV: *hasResult = false; *hasResultType = false; break;
     case Op::OpRayQueryGetIntersectionTriangleVertexPositionsKHR: *hasResult = true; *hasResultType = true; break;
-    case Op::OpTypeAccelerationStructureNV: *hasResult = true; *hasResultType = false; break;
+    case Op::OpTypeAccelerationStructureKHR: *hasResult = true; *hasResultType = false; break;
     case Op::OpExecuteCallableNV: *hasResult = false; *hasResultType = false; break;
     case Op::OpTypeCooperativeMatrixNV: *hasResult = true; *hasResultType = false; break;
     case Op::OpCooperativeMatrixLoadNV: *hasResult = true; *hasResultType = true; break;

--- a/tools/buildHeaders/jsonToSpirv.cpp
+++ b/tools/buildHeaders/jsonToSpirv.cpp
@@ -482,7 +482,8 @@ unsigned int NumberStringToBit(const std::string& str)
 bool SuffixComparison(const std::string& prev, bool prevCore,
                       const std::string& cur, bool curCore)
 {
-  if (prev == cur) return true;
+  // Duplicate entry
+  if (prev == cur) return false;
 
   if (prevCore) return true;
   if (curCore) return false;

--- a/tools/buildHeaders/jsonToSpirv.cpp
+++ b/tools/buildHeaders/jsonToSpirv.cpp
@@ -471,6 +471,36 @@ unsigned int NumberStringToBit(const std::string& str)
     return bit;
 }
 
+// Given two pairs (name and in core) compares if the order is correct for naming
+// conventions. The conventions are:
+// * Core
+// * KHR
+// * EXT
+// * Vendor (no preference between vendors)
+//
+// Returns true if the order is valid.
+bool SuffixComparison(const std::string& prev, bool prevCore,
+                      const std::string& cur, bool curCore)
+{
+  if (prev == cur) return true;
+
+  if (prevCore) return true;
+  if (curCore) return false;
+
+  // Both are suffixed names.
+  const bool prevKHR = prev.substr(prev.size() - 3) == "KHR";
+  const bool prevEXT = prev.substr(prev.size() - 3) == "EXT";
+  const bool curKHR = cur.substr(cur.size() - 3) == "KHR";
+  const bool curEXT = cur.substr(cur.size() - 3) == "EXT";
+
+  if (prevKHR) return true;
+  if (curKHR) return false;
+  if (prevEXT) return true;
+  if (curEXT) return false;
+
+  return true;
+}
+
 void jsonToSpirv(const std::string& jsonPath, bool buildingHeaders)
 {
     // only do this once.
@@ -547,6 +577,8 @@ void jsonToSpirv(const std::string& jsonPath, bool buildingHeaders)
     // process the instructions
     const Json::Value insts = root["instructions"];
     unsigned maxOpcode = 0;
+    std::string maxName = "";
+    bool maxCore = false;
     bool firstOpcode = true;
     for (const auto& inst : insts) {
         const auto printingClass = inst["class"].asString();
@@ -565,8 +597,11 @@ void jsonToSpirv(const std::string& jsonPath, bool buildingHeaders)
         }
         const auto opcode = inst["opcode"].asUInt();
         const std::string name = inst["opname"].asString();
+        std::string version = inst["version"].asString();
         if (firstOpcode) {
           maxOpcode = opcode;
+          maxName = name;
+          maxCore = version != "None";
           firstOpcode = false;
         } else {
           if (maxOpcode > opcode) {
@@ -574,12 +609,20 @@ void jsonToSpirv(const std::string& jsonPath, bool buildingHeaders)
                       << " is out of order. It follows the instruction with opcode " << maxOpcode
                       << std::endl;
             std::exit(1);
+          } else if (maxOpcode == opcode &&
+                     !SuffixComparison(maxName, maxCore, name,
+                                       version != "None")) {
+            std::cerr << "Error: " << name
+                      << " is out of order. It follows alias " << maxName
+                      << std::endl;
+            std::exit(1);
           } else {
             maxOpcode = opcode;
+            maxName = name;
+            maxCore = version != "None";
           }
         }
         EnumCaps caps = getCaps(inst);
-        std::string version = inst["version"].asString();
         std::string lastVersion = inst["lastVersion"].asString();
         Extensions exts = getExts(inst);
         OperandParameters operands;
@@ -625,28 +668,41 @@ void jsonToSpirv(const std::string& jsonPath, bool buildingHeaders)
         };
 
         unsigned maxValue = 0;
+        std::string maxName = "";
+        bool maxCore = false;
         bool firstValue = true;
         for (const auto& enumerant : source["enumerants"]) {
             unsigned value;
             bool skip_zero_in_bitfield;
             std::tie(value, skip_zero_in_bitfield) = getValue(enumerant);
+            std::string name = enumerant["enumerant"].asString();
+            std::string version = enumerant["version"].asString();
             if (skip_zero_in_bitfield)
                 continue;
             if (firstValue) {
               maxValue = value;
+              maxName = name;
+              maxCore = version != "None";
               firstValue = false;
             } else {
               if (maxValue > value) {
-                std::cerr << "Error: " << source["kind"] << " enumerant " << enumerant["enumerant"]
+                std::cerr << "Error: " << source["kind"] << " enumerant " << name
                           << " is out of order. It has value " <<  value
                           << " but follows the enumerant with value " << maxValue << std::endl;
                 std::exit(1);
+              } else if (maxValue == value &&
+                         !SuffixComparison(maxName, maxCore, name,
+                                           version != "None")) {
+                std::cerr << "Error: " << source["kind"] << " enumerant " << name
+                          << " is out of order. It follows alias " << maxName << std::endl;
+                std::exit(1);
               } else {
                 maxValue = value;
+                maxName = name;
+                maxCore = version != "None";
               }
             }
             EnumCaps caps(getCaps(enumerant));
-            std::string version = enumerant["version"].asString();
             std::string lastVersion = enumerant["lastVersion"].asString();
             Extensions exts(getExts(enumerant));
             OperandParameters params;


### PR DESCRIPTION
Fixes #429

* Enforce Core -> KHR -> EXT -> Vendor conventions for aliased names
* Update grammar to satisfy these conventions and regenerate headers

