### PR TITLE
VkspReflection non-sematic: add fields to DescriptorSetBuffer

### DIFF
--- a/include/spirv/unified1/NonSemanticVkspReflection.h
+++ b/include/spirv/unified1/NonSemanticVkspReflection.h
@@ -33,7 +33,7 @@ extern "C" {
 #endif
 
 enum {
-    NonSemanticVkspReflectionRevision = 2,
+    NonSemanticVkspReflectionRevision = 3,
     NonSemanticVkspReflectionRevision_BitWidthPadding = 0x7fffffff
 };
 

--- a/include/spirv/unified1/extinst.nonsemantic.vkspreflection.grammar.json
+++ b/include/spirv/unified1/extinst.nonsemantic.vkspreflection.grammar.json
@@ -1,5 +1,5 @@
 {
-  "revision" : 2,
+  "revision" : 3,
   "instructions" : [
     {
       "opname" : "Configuration",
@@ -65,7 +65,9 @@
         { "kind" : "LiteralInteger", "name" : "offset" },
         { "kind" : "LiteralInteger", "name" : "memorySize" },
         { "kind" : "LiteralInteger", "name" : "memoryType" },
-        { "kind" : "LiteralInteger", "name" : "bindOffset" }
+        { "kind" : "LiteralInteger", "name" : "bindOffset" },
+        { "kind" : "LiteralInteger", "name" : "viewFlags" },
+        { "kind" : "LiteralInteger", "name" : "viewFormat" }
       ]
     },
     {


### PR DESCRIPTION
This is needed to add support for texel buffer to vksp.