### PR TITLE
Add UnormInt2_101010EXT ImageChannelDataType

### DIFF
--- a/include/spirv/unified1/spirv.bf
+++ b/include/spirv/unified1/spirv.bf
@@ -385,6 +385,7 @@ namespace Spv
             UnormInt101010_2 = 16,
             UnsignedIntRaw10EXT = 19,
             UnsignedIntRaw12EXT = 20,
+            UnormInt2_101010EXT = 21,
             Max = 0x7fffffff,
         }
 

--- a/include/spirv/unified1/spirv.core.grammar.json
+++ b/include/spirv/unified1/spirv.core.grammar.json
@@ -12693,6 +12693,11 @@
           "enumerant" : "UnsignedIntRaw12EXT",
           "value" : 20,
           "version": "1.0"
+        },
+        {
+          "enumerant" : "UnormInt2_101010EXT",
+          "value" : 21,
+          "version": "1.0"
         }
       ]
     },

--- a/include/spirv/unified1/spirv.cs
+++ b/include/spirv/unified1/spirv.cs
@@ -384,6 +384,7 @@ namespace Spv
             UnormInt101010_2 = 16,
             UnsignedIntRaw10EXT = 19,
             UnsignedIntRaw12EXT = 20,
+            UnormInt2_101010EXT = 21,
             Max = 0x7fffffff,
         }
 

--- a/include/spirv/unified1/spirv.h
+++ b/include/spirv/unified1/spirv.h
@@ -381,6 +381,7 @@ typedef enum SpvImageChannelDataType_ {
     SpvImageChannelDataTypeUnormInt101010_2 = 16,
     SpvImageChannelDataTypeUnsignedIntRaw10EXT = 19,
     SpvImageChannelDataTypeUnsignedIntRaw12EXT = 20,
+    SpvImageChannelDataTypeUnormInt2_101010EXT = 21,
     SpvImageChannelDataTypeMax = 0x7fffffff,
 } SpvImageChannelDataType;
 
@@ -3243,6 +3244,7 @@ inline const char* SpvImageChannelDataTypeToString(SpvImageChannelDataType value
     case SpvImageChannelDataTypeUnormInt101010_2: return "UnormInt101010_2";
     case SpvImageChannelDataTypeUnsignedIntRaw10EXT: return "UnsignedIntRaw10EXT";
     case SpvImageChannelDataTypeUnsignedIntRaw12EXT: return "UnsignedIntRaw12EXT";
+    case SpvImageChannelDataTypeUnormInt2_101010EXT: return "UnormInt2_101010EXT";
     default: return "Unknown";
     }
 }

--- a/include/spirv/unified1/spirv.hpp
+++ b/include/spirv/unified1/spirv.hpp
@@ -377,6 +377,7 @@ enum ImageChannelDataType {
     ImageChannelDataTypeUnormInt101010_2 = 16,
     ImageChannelDataTypeUnsignedIntRaw10EXT = 19,
     ImageChannelDataTypeUnsignedIntRaw12EXT = 20,
+    ImageChannelDataTypeUnormInt2_101010EXT = 21,
     ImageChannelDataTypeMax = 0x7fffffff,
 };
 
@@ -3239,6 +3240,7 @@ inline const char* ImageChannelDataTypeToString(ImageChannelDataType value) {
     case ImageChannelDataTypeUnormInt101010_2: return "UnormInt101010_2";
     case ImageChannelDataTypeUnsignedIntRaw10EXT: return "UnsignedIntRaw10EXT";
     case ImageChannelDataTypeUnsignedIntRaw12EXT: return "UnsignedIntRaw12EXT";
+    case ImageChannelDataTypeUnormInt2_101010EXT: return "UnormInt2_101010EXT";
     default: return "Unknown";
     }
 }

--- a/include/spirv/unified1/spirv.hpp11
+++ b/include/spirv/unified1/spirv.hpp11
@@ -377,6 +377,7 @@ enum class ImageChannelDataType : unsigned {
     UnormInt101010_2 = 16,
     UnsignedIntRaw10EXT = 19,
     UnsignedIntRaw12EXT = 20,
+    UnormInt2_101010EXT = 21,
     Max = 0x7fffffff,
 };
 
@@ -3239,6 +3240,7 @@ inline const char* ImageChannelDataTypeToString(ImageChannelDataType value) {
     case ImageChannelDataTypeUnormInt101010_2: return "UnormInt101010_2";
     case ImageChannelDataTypeUnsignedIntRaw10EXT: return "UnsignedIntRaw10EXT";
     case ImageChannelDataTypeUnsignedIntRaw12EXT: return "UnsignedIntRaw12EXT";
+    case ImageChannelDataTypeUnormInt2_101010EXT: return "UnormInt2_101010EXT";
     default: return "Unknown";
     }
 }

--- a/include/spirv/unified1/spirv.json
+++ b/include/spirv/unified1/spirv.json
@@ -416,7 +416,8 @@
                     "UnormInt24": 15,
                     "UnormInt101010_2": 16,
                     "UnsignedIntRaw10EXT": 19,
-                    "UnsignedIntRaw12EXT": 20
+                    "UnsignedIntRaw12EXT": 20,
+                    "UnormInt2_101010EXT": 21
                 }
             },
             {

--- a/include/spirv/unified1/spirv.lua
+++ b/include/spirv/unified1/spirv.lua
@@ -368,6 +368,7 @@ spv = {
         UnormInt101010_2 = 16,
         UnsignedIntRaw10EXT = 19,
         UnsignedIntRaw12EXT = 20,
+        UnormInt2_101010EXT = 21,
         Max = 0x7fffffff,
     },
 

--- a/include/spirv/unified1/spirv.py
+++ b/include/spirv/unified1/spirv.py
@@ -357,6 +357,7 @@ spv = {
         'UnormInt101010_2' : 16,
         'UnsignedIntRaw10EXT' : 19,
         'UnsignedIntRaw12EXT' : 20,
+        'UnormInt2_101010EXT' : 21,
     },
 
     'ImageOperandsShift' : {

--- a/include/spirv/unified1/spv.d
+++ b/include/spirv/unified1/spv.d
@@ -387,6 +387,7 @@ enum ImageChannelDataType : uint
     UnormInt101010_2 = 16,
     UnsignedIntRaw10EXT = 19,
     UnsignedIntRaw12EXT = 20,
+    UnormInt2_101010EXT = 21,
     Max = 0x7fffffff,
 }
 


### PR DESCRIPTION
Used by the following OpenCL extension: https://github.com/KhronosGroup/OpenCL-Docs/pull/1223


Change-Id: I2bffc986855a4c2960b5e0f851e52474754144a1