### PR TITLE
Add generator magic number for nuvk's SPIR-V emitter

### DIFF
--- a/include/spirv/spir-v.xml
+++ b/include/spirv/spir-v.xml
@@ -95,7 +95,8 @@
         <id value="42"  vendor="Rendong Liang" tool="spq" comment="Contact Rendong Liang, admin@penguinliong.moe, https://github.com/PENGUINLIONG/spq-rs"/>
         <id value="43"  vendor="LLVM" tool="LLVM SPIR-V Backend" comment="Contact Michal Paszkowski, michal.paszkowski@intel.com, https://github.com/llvm/llvm-project/tree/main/llvm/lib/Target/SPIRV"/>
         <id value="44"  vendor="Robert Konrad" tool="Kongruent" comment="Contact Robert Konrad, https://github.com/Kode/Kongruent"/>
-        <unused start="45" end="0xFFFF" comment="Tool ID range reservable for future use by vendors"/>
+        <id value="45"  vendor="Kitsunebi Games" tool="Nuvk SPIR-V Emitter and DLSL compiler" comment="Contact Luna Nielsen, luna@foxgirls.gay, https://github.com/Inochi2D/nuvk"/>
+        <unused start="46" end="0xFFFF" comment="Tool ID range reservable for future use by vendors"/>
     </ids>
 
     <!-- SECTION: SPIR-V Opcodes and Enumerants -->


### PR DESCRIPTION
Nuvk is the graphics API layer for Inochi2D, it includes a SPIR-V modification subsystem that can generate SPIR-V bytecode, and will additionally be used as the base for the DLSL shader compiler.

DLSL is a shader language based on a subset of the D programming language that I'm developing.

Source code may be found here: https://github.com/Inochi2D/nuvk/tree/main/source/spirv