### PR TITLE
Remove extension from OpDecorateId

### DIFF
--- a/include/spirv/unified1/spirv.core.grammar.json
+++ b/include/spirv/unified1/spirv.core.grammar.json
@@ -3863,7 +3863,6 @@
         { "kind" : "IdRef", "name" : "'Target'" },
         { "kind" : "Decoration" }
       ],
-      "extensions" : [ "SPV_GOOGLE_hlsl_functionality1" ],
       "version" : "1.2"
     },
     {


### PR DESCRIPTION
OpDecorateId was introduced by SPIR-V 1.2 not by SPV_GOOGLE_hlsl_functionality1