### PR TITLE
Add provisional key to grammar

### DIFF
--- a/include/spirv/unified1/spirv.core.grammar.json
+++ b/include/spirv/unified1/spirv.core.grammar.json
@@ -5373,6 +5373,7 @@
         { "kind" : "IdRef", "name": "'Node Index'" }
       ],
       "capabilities" : [ "ShaderEnqueueAMDX" ],
+      "provisional" : true,
       "version" : "None"
     },
     {
@@ -5383,6 +5384,7 @@
         { "kind" : "IdRef", "name": "'Payload Array'" }
       ],
       "capabilities" : [ "ShaderEnqueueAMDX" ],
+      "provisional" : true,
       "version" : "None"
     },
     {
@@ -5394,6 +5396,7 @@
         { "kind" : "IdRef", "name": "'Payload Type'" }
       ],
       "capabilities" : [ "ShaderEnqueueAMDX" ],
+      "provisional" : true,
       "version" : "None"
     },
     {
@@ -5406,6 +5409,7 @@
         { "kind" : "IdRef", "name": "'Payload'" }
       ],
       "capabilities" : [ "ShaderEnqueueAMDX" ],
+      "provisional" : true,
       "version" : "None"
     },
     {
@@ -5418,6 +5422,7 @@
         { "kind" : "IdRef", "name": "'Payload Array'" }
       ],
       "capabilities" : [ "ShaderEnqueueAMDX" ],
+      "provisional" : true,
       "version" : "None"
     },
     {
@@ -5431,6 +5436,7 @@
         { "kind" : "IdRef", "name": "'Node Index'" }
       ],
       "capabilities" : [ "ShaderEnqueueAMDX" ],
+      "provisional" : true,
       "version": "None"
     },
     {
@@ -5442,6 +5448,7 @@
         { "kind" : "LiteralString", "name": "'Literal String'" }
       ],
       "capabilities" : [ "ShaderEnqueueAMDX" ],
+      "provisional" : true,
       "version": "None"
     },
     {
@@ -5453,6 +5460,7 @@
         { "kind" : "LiteralString", "name": "'Literal String'" }
       ],
       "capabilities" : [ "ShaderEnqueueAMDX" ],
+      "provisional" : true,
       "version": "None"
     },
     {
@@ -11610,6 +11618,7 @@
           "enumerant" : "CoalescingAMDX",
           "value" : 5069,
           "capabilities" : [ "ShaderEnqueueAMDX" ],
+          "provisional" : true,
           "version" : "None"
         },
         {
@@ -11619,6 +11628,7 @@
           "parameters" : [
             { "kind" : "IdRef", "name" : "'Is Entry'" }
           ],
+          "provisional" : true,
           "version" : "None"
         },
         {
@@ -11628,6 +11638,7 @@
           "parameters" : [
             { "kind" : "IdRef", "name" : "'Number of recursions'" }
           ],
+          "provisional" : true,
           "version" : "None"
         },
         {
@@ -11639,6 +11650,7 @@
             { "kind" : "IdRef", "name" : "'y size'" },
             { "kind" : "IdRef", "name" : "'z size'" }
           ],
+          "provisional" : true,
           "version" : "None"
         },
         {
@@ -11648,6 +11660,7 @@
           "parameters" : [
             { "kind" : "IdRef", "name" : "'Shader Index'" }
           ],
+          "provisional" : true,
           "version" : "None"
         },
         {
@@ -11659,6 +11672,7 @@
             { "kind" : "IdRef", "name" : "'y size'" },
             { "kind" : "IdRef", "name" : "'z size'" }
           ],
+          "provisional" : true,
           "version" : "None"
         },
         {
@@ -11723,6 +11737,7 @@
             { "kind" : "IdRef", "name" : "'Node Name'" },
             { "kind" : "IdRef", "name" : "'Shader Index'" }
           ],
+          "provisional" : true,
           "version" : "None"
         },
         {
@@ -12066,6 +12081,7 @@
           "enumerant" : "NodePayloadAMDX",
           "value" : 5068,
           "capabilities" : [ "ShaderEnqueueAMDX" ],
+          "provisional" : true,
           "version" : "None"
         },
         {
@@ -13409,6 +13425,7 @@
           "parameters" : [
             { "kind" : "IdRef", "name" : "'Payload Type'" }
           ],
+          "provisional" : true,
           "version" : "None"
         },
         {
@@ -13418,12 +13435,14 @@
           "parameters" : [
             { "kind" : "IdRef", "name" : "'Max number of payloads'" }
           ],
+          "provisional" : true,
           "version" : "None"
         },
         {
           "enumerant" : "TrackFinishWritingAMDX",
           "value" : 5078,
           "capabilities" : [ "ShaderEnqueueAMDX" ],
+          "provisional" : true,
           "version" : "None"
         },
         {
@@ -13433,6 +13452,7 @@
           "parameters" : [
             { "kind" : "IdRef", "name" : "'Node Name'" }
           ],
+          "provisional" : true,
           "version" : "None"
         },
         {
@@ -13442,12 +13462,14 @@
           "parameters" : [
             { "kind" : "IdRef", "name" : "'Base Index'" }
           ],
+          "provisional" : true,
           "version" : "None"
         },
         {
           "enumerant" : "PayloadNodeSparseArrayAMDX",
           "value" : 5099,
           "capabilities" : [ "ShaderEnqueueAMDX" ],
+          "provisional" : true,
           "version" : "None"
         },
         {
@@ -13457,12 +13479,14 @@
           "parameters" : [
             { "kind" : "IdRef", "name" : "'Array Size'" }
           ],
+          "provisional" : true,
           "version" : "None"
         },
         {
           "enumerant" : "PayloadDispatchIndirectAMDX",
           "value" : 5105,
           "capabilities" : [ "ShaderEnqueueAMDX" ],
+          "provisional" : true,
           "version" : "None"
         },
         {
@@ -14544,12 +14568,14 @@
           "enumerant" : "RemainingRecursionLevelsAMDX",
           "value" : 5021,
           "capabilities" : [ "ShaderEnqueueAMDX" ],
+          "provisional" : true,
           "version" : "None"
         },
         {
           "enumerant" : "ShaderIndexAMDX",
           "value" : 5073,
           "capabilities" : [ "ShaderEnqueueAMDX" ],
+          "provisional" : true,
           "version" : "None"
         },
         {
@@ -15733,6 +15759,7 @@
           "value" : 5067,
           "capabilities" : [ "Shader" ],
           "extensions" : [ "SPV_AMDX_shader_enqueue" ],
+          "provisional" : true,
           "version" : "None"
         },
         {

--- a/include/spirv/unified1/spirv.core.grammar.json
+++ b/include/spirv/unified1/spirv.core.grammar.json
@@ -4450,6 +4450,7 @@
       "capabilities" : [
         "UntypedPointersKHR"
       ],
+      "provisional" : true,
       "version" : "None",
       "operands" : [
         { "kind" : "IdResult" },
@@ -4461,6 +4462,7 @@
       "class" : "Memory",
       "opcode" : 4418,
       "capabilities" : [ "UntypedPointersKHR" ],
+      "provisional" : true,
       "version" : "None",
       "operands" : [
         { "kind" : "IdResultType" },
@@ -4475,6 +4477,7 @@
       "class" : "Memory",
       "opcode" : 4419,
       "capabilities" : [ "UntypedPointersKHR" ],
+      "provisional" : true,
       "version" : "None",
       "operands" : [
         { "kind" : "IdResultType" },
@@ -4489,6 +4492,7 @@
       "class" : "Memory",
       "opcode" : 4420,
       "capabilities" : [ "UntypedPointersKHR" ],
+      "provisional" : true,
       "version" : "None",
       "operands" : [
         { "kind" : "IdResultType" },
@@ -4529,6 +4533,7 @@
       "class"  : "Memory",
       "opcode" : 4423,
       "capabilities" : [ "UntypedPointersKHR" ],
+      "provisional" : true,
       "version" : "None",
       "operands" : [
         { "kind" : "IdResultType" },
@@ -4544,6 +4549,7 @@
       "class"  : "Memory",
       "opcode" : 4424,
       "capabilities" : [ "UntypedPointersKHR" ],
+      "provisional" : true,
       "version" : "None",
       "operands" : [
         { "kind" : "IdResultType" },
@@ -4559,6 +4565,7 @@
       "class"  : "Memory",
       "opcode" : 4425,
       "capabilities" : [ "UntypedPointersKHR" ],
+      "provisional" : true,
       "version" : "None",
       "operands" : [
         { "kind" : "IdResultType" },
@@ -4573,6 +4580,7 @@
       "class"  : "Memory",
       "opcode" : 4426,
       "capabilities" : [ "UntypedPointersKHR" ],
+      "provisional" : true,
       "version" : "None",
       "operands" : [
         { "kind" : "IdRef",                            "name" : "'Pointer Type'" },
@@ -15666,6 +15674,7 @@
           "enumerant" : "UntypedPointersKHR",
           "value" : 4473,
           "extensions" : [ "SPV_KHR_untyped_pointers" ],
+          "provisional" : true,
           "version" : "None"
         },
         {


### PR DESCRIPTION
closes https://github.com/KhronosGroup/SPIRV-Headers/issues/460

The idea is like `VK_ENABLE_BETA_EXTENSIONS` the consumer of the headers can now consume the SPIR-V if they desire ( by adding something like `add_compile_definitions(SPV_ENABLE_BETA_EXTENSIONS)` to their build)

Open to suggestions on other ways to go about this