### PR TITLE
Fix OpAsmTargetINTEL operand

### DIFF
--- a/include/spirv/unified1/spirv.core.grammar.json
+++ b/include/spirv/unified1/spirv.core.grammar.json
@@ -6986,7 +6986,6 @@
       "class"  : "@exclude",
       "opcode" : 5609,
       "operands" : [
-        { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
         { "kind" : "LiteralString", "name" : "'Asm target'" }
       ],

--- a/include/spirv/unified1/spirv.h
+++ b/include/spirv/unified1/spirv.h
@@ -2795,7 +2795,7 @@ inline void SpvHasResultAndType(SpvOp opcode, bool *hasResult, bool *hasResultTy
     case SpvOpUMul32x16INTEL: *hasResult = true; *hasResultType = true; break;
     case SpvOpConstantFunctionPointerINTEL: *hasResult = true; *hasResultType = true; break;
     case SpvOpFunctionPointerCallINTEL: *hasResult = true; *hasResultType = true; break;
-    case SpvOpAsmTargetINTEL: *hasResult = true; *hasResultType = true; break;
+    case SpvOpAsmTargetINTEL: *hasResult = true; *hasResultType = false; break;
     case SpvOpAsmINTEL: *hasResult = true; *hasResultType = true; break;
     case SpvOpAsmCallINTEL: *hasResult = true; *hasResultType = true; break;
     case SpvOpAtomicFMinEXT: *hasResult = true; *hasResultType = true; break;

--- a/include/spirv/unified1/spirv.hpp
+++ b/include/spirv/unified1/spirv.hpp
@@ -2791,7 +2791,7 @@ inline void HasResultAndType(Op opcode, bool *hasResult, bool *hasResultType) {
     case OpUMul32x16INTEL: *hasResult = true; *hasResultType = true; break;
     case OpConstantFunctionPointerINTEL: *hasResult = true; *hasResultType = true; break;
     case OpFunctionPointerCallINTEL: *hasResult = true; *hasResultType = true; break;
-    case OpAsmTargetINTEL: *hasResult = true; *hasResultType = true; break;
+    case OpAsmTargetINTEL: *hasResult = true; *hasResultType = false; break;
     case OpAsmINTEL: *hasResult = true; *hasResultType = true; break;
     case OpAsmCallINTEL: *hasResult = true; *hasResultType = true; break;
     case OpAtomicFMinEXT: *hasResult = true; *hasResultType = true; break;

--- a/include/spirv/unified1/spirv.hpp11
+++ b/include/spirv/unified1/spirv.hpp11
@@ -2791,7 +2791,7 @@ inline void HasResultAndType(Op opcode, bool *hasResult, bool *hasResultType) {
     case Op::OpUMul32x16INTEL: *hasResult = true; *hasResultType = true; break;
     case Op::OpConstantFunctionPointerINTEL: *hasResult = true; *hasResultType = true; break;
     case Op::OpFunctionPointerCallINTEL: *hasResult = true; *hasResultType = true; break;
-    case Op::OpAsmTargetINTEL: *hasResult = true; *hasResultType = true; break;
+    case Op::OpAsmTargetINTEL: *hasResult = true; *hasResultType = false; break;
     case Op::OpAsmINTEL: *hasResult = true; *hasResultType = true; break;
     case Op::OpAsmCallINTEL: *hasResult = true; *hasResultType = true; break;
     case Op::OpAtomicFMinEXT: *hasResult = true; *hasResultType = true; break;


### PR DESCRIPTION
The `OpAsmTargetINTEL` instruction had an extra Result Type operand which is not specified in the extension https://github.com/intel/llvm/blob/sycl/sycl/doc/design/spirv-extensions/SPV_INTEL_inline_assembly.asciidoc. This causes errors in tools relying on the headers.

Small example of the failure:
```c
// foo.c
void foo (const float * restrict a, const float * restrict b, float * restrict c) {
    __asm__ ("nop");
}
```

Compile to `.spt` via `llc`:
```bash
clang -S -emit-llvm -O3 foo.c -o foo.ll
llc -O3 -mtriple=spirv64-unknown-unknown --spirv-ext=+SPV_INTEL_inline_assembly foo.ll -o foo.spt
```

The output contains something like `%12 = OpAsmTargetINTEL "spirv64-unknown-unknown"`, without any result type. Then, running `spirv-as foo.spt -o foo.spv` fails because return type is expected.

Tagging @mmerecki who worked on the extension.