### PR TITLE
Use modern asciidoc markup in JSON annotations, instead of compat-mode

### DIFF
--- a/include/spirv/unified1/extinst.debuginfo.grammar.json
+++ b/include/spirv/unified1/extinst.debuginfo.grammar.json
@@ -35,253 +35,253 @@
       "opname" : "DebugCompilationUnit",
       "opcode" : 1,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Source'" },
-        { "kind" : "LiteralInteger", "name" : "'Version'" },
-        { "kind" : "LiteralInteger", "name" : "'DWARF Version'" }
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "LiteralInteger", "name" : "Version" },
+        { "kind" : "LiteralInteger", "name" : "DWARF Version" }
       ]
     },
     {
       "opname" : "DebugTypeBasic",
       "opcode" : 2,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Name'" },
-        { "kind" : "IdRef", "name" : "'Size'" },
-        { "kind" : "DebugBaseTypeAttributeEncoding", "name" : "'Encoding'" }
+        { "kind" : "IdRef", "name" : "Name" },
+        { "kind" : "IdRef", "name" : "Size" },
+        { "kind" : "DebugBaseTypeAttributeEncoding", "name" : "Encoding" }
       ]
     },
     {
       "opname" : "DebugTypePointer",
       "opcode" : 3,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Base Type'" },
-        { "kind" : "StorageClass", "name" : "'Storage Class'" },
-        { "kind" : "DebugInfoFlags", "name" : "'Literal Flags'" }
+        { "kind" : "IdRef", "name" : "Base Type" },
+        { "kind" : "StorageClass", "name" : "Storage Class" },
+        { "kind" : "DebugInfoFlags", "name" : "Literal Flags" }
       ]
     },
     {
       "opname" : "DebugTypeQualifier",
       "opcode" : 4,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Base Type'" },
-        { "kind" : "DebugTypeQualifier", "name" : "'Type Qualifier'" }
+        { "kind" : "IdRef", "name" : "Base Type" },
+        { "kind" : "DebugTypeQualifier", "name" : "Type Qualifier" }
       ]
     },
     {
       "opname" : "DebugTypeArray",
       "opcode" : 5,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Base Type'" },
-        { "kind" : "IdRef", "name" : "'Component Counts'", "quantifier" : "*" }
+        { "kind" : "IdRef", "name" : "Base Type" },
+        { "kind" : "IdRef", "name" : "Component Counts", "quantifier" : "*" }
       ]
     },
     {
       "opname" : "DebugTypeVector",
       "opcode" : 6,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Base Type'" },
-        { "kind" : "LiteralInteger", "name" : "'Component Count'" }
+        { "kind" : "IdRef", "name" : "Base Type" },
+        { "kind" : "LiteralInteger", "name" : "Component Count" }
       ]
     },
     {
       "opname" : "DebugTypedef",
       "opcode" : 7,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Name'" },
-        { "kind" : "IdRef", "name" : "'Base Type'" },
-        { "kind" : "IdRef", "name" : "'Source'" },
-        { "kind" : "LiteralInteger", "name" : "'Line'" },
-        { "kind" : "LiteralInteger", "name" : "'Column'" },
-        { "kind" : "IdRef", "name" : "'Parent'" }
+        { "kind" : "IdRef", "name" : "Name" },
+        { "kind" : "IdRef", "name" : "Base Type" },
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "LiteralInteger", "name" : "Line" },
+        { "kind" : "LiteralInteger", "name" : "Column" },
+        { "kind" : "IdRef", "name" : "Parent" }
       ]
     },
     {
       "opname" : "DebugTypeFunction",
       "opcode" : 8,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Return Type'" },
-        { "kind" : "IdRef", "name" : "'Paramter Types'", "quantifier" : "*" }
+        { "kind" : "IdRef", "name" : "Return Type" },
+        { "kind" : "IdRef", "name" : "Paramter Types", "quantifier" : "*" }
       ]
     },
     {
       "opname" : "DebugTypeEnum",
       "opcode" : 9,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Name'" },
-        { "kind" : "IdRef", "name" : "'Underlying Type'" },
-        { "kind" : "IdRef", "name" : "'Source'" },
-        { "kind" : "LiteralInteger", "name" : "'Line'" },
-        { "kind" : "LiteralInteger", "name" : "'Column'" },
-        { "kind" : "IdRef", "name" : "'Parent'" },
-        { "kind" : "IdRef", "name" : "'Size'" },
-        { "kind" : "DebugInfoFlags", "name" : "'Flags'" },
-        { "kind" : "PairIdRefIdRef", "name" : "'Value, Name, Value, Name, ...'", "quantifier" : "*" }
+        { "kind" : "IdRef", "name" : "Name" },
+        { "kind" : "IdRef", "name" : "Underlying Type" },
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "LiteralInteger", "name" : "Line" },
+        { "kind" : "LiteralInteger", "name" : "Column" },
+        { "kind" : "IdRef", "name" : "Parent" },
+        { "kind" : "IdRef", "name" : "Size" },
+        { "kind" : "DebugInfoFlags", "name" : "Flags" },
+        { "kind" : "PairIdRefIdRef", "name" : "Value, Name, Value, Name, ...", "quantifier" : "*" }
       ]
     },
     {
       "opname" : "DebugTypeComposite",
       "opcode" : 10,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Name'" },
-        { "kind" : "DebugCompositeType", "name" : "'Tag'" },
-        { "kind" : "IdRef", "name" : "'Source'" },
-        { "kind" : "LiteralInteger", "name" : "'Line'" },
-        { "kind" : "LiteralInteger", "name" : "'Column'" },
-        { "kind" : "IdRef", "name" : "'Parent'" },
-        { "kind" : "IdRef", "name" : "'Size'" },
-        { "kind" : "DebugInfoFlags", "name" : "'Flags'" },
-        { "kind" : "IdRef", "name" : "'Members'", "quantifier" : "*" }
+        { "kind" : "IdRef", "name" : "Name" },
+        { "kind" : "DebugCompositeType", "name" : "Tag" },
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "LiteralInteger", "name" : "Line" },
+        { "kind" : "LiteralInteger", "name" : "Column" },
+        { "kind" : "IdRef", "name" : "Parent" },
+        { "kind" : "IdRef", "name" : "Size" },
+        { "kind" : "DebugInfoFlags", "name" : "Flags" },
+        { "kind" : "IdRef", "name" : "Members", "quantifier" : "*" }
       ]
     },
     {
       "opname" : "DebugTypeMember",
       "opcode" : 11,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Name'" },
-        { "kind" : "IdRef", "name" : "'Type'" },
-        { "kind" : "IdRef", "name" : "'Source'" },
-        { "kind" : "LiteralInteger", "name" : "'Line'" },
-        { "kind" : "LiteralInteger", "name" : "'Column'" },
-        { "kind" : "IdRef", "name" : "'Parent'" },
-        { "kind" : "IdRef", "name" : "'Offset'" },
-        { "kind" : "IdRef", "name" : "'Size'" },
-        { "kind" : "DebugInfoFlags", "name" : "'Flags'" },
-        { "kind" : "IdRef", "name" : "'Value'", "quantifier" : "?" }
+        { "kind" : "IdRef", "name" : "Name" },
+        { "kind" : "IdRef", "name" : "Type" },
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "LiteralInteger", "name" : "Line" },
+        { "kind" : "LiteralInteger", "name" : "Column" },
+        { "kind" : "IdRef", "name" : "Parent" },
+        { "kind" : "IdRef", "name" : "Offset" },
+        { "kind" : "IdRef", "name" : "Size" },
+        { "kind" : "DebugInfoFlags", "name" : "Flags" },
+        { "kind" : "IdRef", "name" : "Value", "quantifier" : "?" }
       ]
     },
     {
       "opname" : "DebugTypeInheritance",
       "opcode" : 12,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Child'" },
-        { "kind" : "IdRef", "name" : "'Parent'" },
-        { "kind" : "IdRef", "name" : "'Offset'" },
-        { "kind" : "IdRef", "name" : "'Size'" },
-        { "kind" : "DebugInfoFlags", "name" : "'Flags'" }
+        { "kind" : "IdRef", "name" : "Child" },
+        { "kind" : "IdRef", "name" : "Parent" },
+        { "kind" : "IdRef", "name" : "Offset" },
+        { "kind" : "IdRef", "name" : "Size" },
+        { "kind" : "DebugInfoFlags", "name" : "Flags" }
       ]
     },
     {
       "opname" : "DebugTypePtrToMember",
       "opcode" : 13,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Member Type'" },
-        { "kind" : "IdRef", "name" : "'Parent'" }
+        { "kind" : "IdRef", "name" : "Member Type" },
+        { "kind" : "IdRef", "name" : "Parent" }
       ]
     },
     {
       "opname" : "DebugTypeTemplate",
       "opcode" : 14,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Target'" },
-        { "kind" : "IdRef", "name" : "'Parameters'", "quantifier" : "*" }
+        { "kind" : "IdRef", "name" : "Target" },
+        { "kind" : "IdRef", "name" : "Parameters", "quantifier" : "*" }
       ]
     },
     {
       "opname" : "DebugTypeTemplateParameter",
       "opcode" : 15,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Name'" },
-        { "kind" : "IdRef", "name" : "'Actual Type'" },
-        { "kind" : "IdRef", "name" : "'Value'" },
-        { "kind" : "IdRef", "name" : "'Source'" },
-        { "kind" : "LiteralInteger", "name" : "'Line'" },
-        { "kind" : "LiteralInteger", "name" : "'Column'" }
+        { "kind" : "IdRef", "name" : "Name" },
+        { "kind" : "IdRef", "name" : "Actual Type" },
+        { "kind" : "IdRef", "name" : "Value" },
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "LiteralInteger", "name" : "Line" },
+        { "kind" : "LiteralInteger", "name" : "Column" }
       ]
     },
     {
       "opname" : "DebugTypeTemplateTemplateParameter",
       "opcode" : 16,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Name'" },
-        { "kind" : "IdRef", "name" : "'Template Name'" },
-        { "kind" : "IdRef", "name" : "'Source'" },
-        { "kind" : "LiteralInteger", "name" : "'Line'" },
-        { "kind" : "LiteralInteger", "name" : "'Column'" }
+        { "kind" : "IdRef", "name" : "Name" },
+        { "kind" : "IdRef", "name" : "Template Name" },
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "LiteralInteger", "name" : "Line" },
+        { "kind" : "LiteralInteger", "name" : "Column" }
       ]
     },
     {
       "opname" : "DebugTypeTemplateParameterPack",
       "opcode" : 17,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Name'" },
-        { "kind" : "IdRef", "name" : "'Source'" },
-        { "kind" : "LiteralInteger", "name" : "'Line'" },
-        { "kind" : "LiteralInteger", "name" : "'Column'" },
-        { "kind" : "IdRef", "name" : "'Template Parameters'", "quantifier" : "*" }
+        { "kind" : "IdRef", "name" : "Name" },
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "LiteralInteger", "name" : "Line" },
+        { "kind" : "LiteralInteger", "name" : "Column" },
+        { "kind" : "IdRef", "name" : "Template Parameters", "quantifier" : "*" }
       ]
     },
     {
       "opname" : "DebugGlobalVariable",
       "opcode" : 18,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Name'" },
-        { "kind" : "IdRef", "name" : "'Type'" },
-        { "kind" : "IdRef", "name" : "'Source'" },
-        { "kind" : "LiteralInteger", "name" : "'Line'" },
-        { "kind" : "LiteralInteger", "name" : "'Column'" },
-        { "kind" : "IdRef", "name" : "'Parent'" },
-        { "kind" : "IdRef", "name" : "'Linkage Name'" },
-        { "kind" : "IdRef", "name" : "'Variable'" },
-        { "kind" : "DebugInfoFlags", "name" : "'Flags'" },
-        { "kind" : "IdRef", "name" : "'Static Member Declaration'", "quantifier" : "?" }
+        { "kind" : "IdRef", "name" : "Name" },
+        { "kind" : "IdRef", "name" : "Type" },
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "LiteralInteger", "name" : "Line" },
+        { "kind" : "LiteralInteger", "name" : "Column" },
+        { "kind" : "IdRef", "name" : "Parent" },
+        { "kind" : "IdRef", "name" : "Linkage Name" },
+        { "kind" : "IdRef", "name" : "Variable" },
+        { "kind" : "DebugInfoFlags", "name" : "Flags" },
+        { "kind" : "IdRef", "name" : "Static Member Declaration", "quantifier" : "?" }
       ]
     },
     {
       "opname" : "DebugFunctionDeclaration",
       "opcode" : 19,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Name'" },
-        { "kind" : "IdRef", "name" : "'Type'" },
-        { "kind" : "IdRef", "name" : "'Source'" },
-        { "kind" : "LiteralInteger", "name" : "'Line'" },
-        { "kind" : "LiteralInteger", "name" : "'Column'" },
-        { "kind" : "IdRef", "name" : "'Parent'" },
-        { "kind" : "IdRef", "name" : "'Linkage Name'" },
-        { "kind" : "DebugInfoFlags", "name" : "'Flags'" }
+        { "kind" : "IdRef", "name" : "Name" },
+        { "kind" : "IdRef", "name" : "Type" },
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "LiteralInteger", "name" : "Line" },
+        { "kind" : "LiteralInteger", "name" : "Column" },
+        { "kind" : "IdRef", "name" : "Parent" },
+        { "kind" : "IdRef", "name" : "Linkage Name" },
+        { "kind" : "DebugInfoFlags", "name" : "Flags" }
       ]
     },
     {
       "opname" : "DebugFunction",
       "opcode" : 20,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Name'" },
-        { "kind" : "IdRef", "name" : "'Type'" },
-        { "kind" : "IdRef", "name" : "'Source'" },
-        { "kind" : "LiteralInteger", "name" : "'Line'" },
-        { "kind" : "LiteralInteger", "name" : "'Column'" },
-        { "kind" : "IdRef", "name" : "'Parent'" },
-        { "kind" : "IdRef", "name" : "'Linkage Name'" },
-        { "kind" : "DebugInfoFlags", "name" : "'Flags'" },
-        { "kind" : "LiteralInteger", "name" : "'Scope Line'" },
-        { "kind" : "IdRef", "name" : "'Function'" },
-        { "kind" : "IdRef", "name" : "'Declaration'", "quantifier" : "?" }
+        { "kind" : "IdRef", "name" : "Name" },
+        { "kind" : "IdRef", "name" : "Type" },
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "LiteralInteger", "name" : "Line" },
+        { "kind" : "LiteralInteger", "name" : "Column" },
+        { "kind" : "IdRef", "name" : "Parent" },
+        { "kind" : "IdRef", "name" : "Linkage Name" },
+        { "kind" : "DebugInfoFlags", "name" : "Flags" },
+        { "kind" : "LiteralInteger", "name" : "Scope Line" },
+        { "kind" : "IdRef", "name" : "Function" },
+        { "kind" : "IdRef", "name" : "Declaration", "quantifier" : "?" }
       ]
     },
     {
       "opname" : "DebugLexicalBlock",
       "opcode" : 21,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Source'" },
-        { "kind" : "LiteralInteger", "name" : "'Line'" },
-        { "kind" : "LiteralInteger", "name" : "'Column'" },
-        { "kind" : "IdRef", "name" : "'Parent'" },
-        { "kind" : "IdRef", "name" : "'Name'", "quantifier" : "?" }
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "LiteralInteger", "name" : "Line" },
+        { "kind" : "LiteralInteger", "name" : "Column" },
+        { "kind" : "IdRef", "name" : "Parent" },
+        { "kind" : "IdRef", "name" : "Name", "quantifier" : "?" }
       ]
     },
     {
       "opname" : "DebugLexicalBlockDiscriminator",
       "opcode" : 22,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Scope'" },
-        { "kind" : "LiteralInteger", "name" : "'Discriminator'" },
-        { "kind" : "IdRef", "name" : "'Parent'" }
+        { "kind" : "IdRef", "name" : "Scope" },
+        { "kind" : "LiteralInteger", "name" : "Discriminator" },
+        { "kind" : "IdRef", "name" : "Parent" }
       ]
     },
     {
       "opname" : "DebugScope",
       "opcode" : 23,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Scope'" },
-        { "kind" : "IdRef", "name" : "'Inlined At'", "quantifier" : "?" }
+        { "kind" : "IdRef", "name" : "Scope" },
+        { "kind" : "IdRef", "name" : "Inlined At", "quantifier" : "?" }
       ]
     },
     {
@@ -292,82 +292,82 @@
       "opname" : "DebugInlinedAt",
       "opcode" : 25,
       "operands" : [
-        { "kind" : "LiteralInteger", "name" : "'Line'" },
-        { "kind" : "IdRef", "name" : "'Scope'" },
-        { "kind" : "IdRef", "name" : "'Inlined'", "quantifier" : "?" }
+        { "kind" : "LiteralInteger", "name" : "Line" },
+        { "kind" : "IdRef", "name" : "Scope" },
+        { "kind" : "IdRef", "name" : "Inlined", "quantifier" : "?" }
       ]
     },
     {
       "opname" : "DebugLocalVariable",
       "opcode" : 26,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Name'" },
-        { "kind" : "IdRef", "name" : "'Type'" },
-        { "kind" : "IdRef", "name" : "'Source'" },
-        { "kind" : "LiteralInteger", "name" : "'Line'" },
-        { "kind" : "LiteralInteger", "name" : "'Column'" },
-        { "kind" : "IdRef", "name" : "'Parent'" },
-        { "kind" : "LiteralInteger", "name" : "'Arg Number'", "quantifier" : "?" }
+        { "kind" : "IdRef", "name" : "Name" },
+        { "kind" : "IdRef", "name" : "Type" },
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "LiteralInteger", "name" : "Line" },
+        { "kind" : "LiteralInteger", "name" : "Column" },
+        { "kind" : "IdRef", "name" : "Parent" },
+        { "kind" : "LiteralInteger", "name" : "Arg Number", "quantifier" : "?" }
       ]
     },
     {
       "opname" : "DebugInlinedVariable",
       "opcode" : 27,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Variable'" },
-        { "kind" : "IdRef", "name" : "'Inlined'" }
+        { "kind" : "IdRef", "name" : "Variable" },
+        { "kind" : "IdRef", "name" : "Inlined" }
       ]
     },
     {
       "opname" : "DebugDeclare",
       "opcode" : 28,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Local Variable'" },
-        { "kind" : "IdRef", "name" : "'Variable'" },
-        { "kind" : "IdRef", "name" : "'Expression'" }
+        { "kind" : "IdRef", "name" : "Local Variable" },
+        { "kind" : "IdRef", "name" : "Variable" },
+        { "kind" : "IdRef", "name" : "Expression" }
       ]
     },
     {
       "opname" : "DebugValue",
       "opcode" : 29,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Value'" },
-        { "kind" : "IdRef", "name" : "'Expression'" },
-        { "kind" : "IdRef", "name" : "'Indexes'", "quantifier" : "*" }
+        { "kind" : "IdRef", "name" : "Value" },
+        { "kind" : "IdRef", "name" : "Expression" },
+        { "kind" : "IdRef", "name" : "Indexes", "quantifier" : "*" }
       ]
     },
     {
       "opname" : "DebugOperation",
       "opcode" : 30,
       "operands" : [
-        { "kind" : "DebugOperation", "name" : "'OpCode'" },
-        { "kind" : "LiteralInteger", "name" : "'Operands ...'", "quantifier" : "*" }
+        { "kind" : "DebugOperation", "name" : "OpCode" },
+        { "kind" : "LiteralInteger", "name" : "Operands ...", "quantifier" : "*" }
       ]
     },
     {
       "opname" : "DebugExpression",
       "opcode" : 31,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Operands ...'", "quantifier" : "*" }
+        { "kind" : "IdRef", "name" : "Operands ...", "quantifier" : "*" }
       ]
     },
     {
       "opname" : "DebugMacroDef",
       "opcode" : 32,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Source'" },
-        { "kind" : "LiteralInteger", "name" : "'Line'" },
-        { "kind" : "IdRef", "name" : "'Name'" },
-        { "kind" : "IdRef", "name" : "'Value'", "quantifier" : "?" }
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "LiteralInteger", "name" : "Line" },
+        { "kind" : "IdRef", "name" : "Name" },
+        { "kind" : "IdRef", "name" : "Value", "quantifier" : "?" }
       ]
     },
     {
       "opname" : "DebugMacroUndef",
       "opcode" : 33,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Source'" },
-        { "kind" : "LiteralInteger", "name" : "'Line'" },
-        { "kind" : "IdRef", "name" : "'Macro'" }
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "LiteralInteger", "name" : "Line" },
+        { "kind" : "IdRef", "name" : "Macro" }
       ]
     }
   ],

--- a/include/spirv/unified1/extinst.glsl.std.450.grammar.json
+++ b/include/spirv/unified1/extinst.glsl.std.450.grammar.json
@@ -31,439 +31,439 @@
       "opname" : "Round",
       "opcode" : 1,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "RoundEven",
       "opcode" : 2,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "Trunc",
       "opcode" : 3,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "FAbs",
       "opcode" : 4,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "SAbs",
       "opcode" : 5,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "FSign",
       "opcode" : 6,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "SSign",
       "opcode" : 7,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "Floor",
       "opcode" : 8,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "Ceil",
       "opcode" : 9,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "Fract",
       "opcode" : 10,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "Radians",
       "opcode" : 11,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'degrees'" }
+        { "kind" : "IdRef", "name" : "degrees" }
       ]
     },
     {
       "opname" : "Degrees",
       "opcode" : 12,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'radians'" }
+        { "kind" : "IdRef", "name" : "radians" }
       ]
     },
     {
       "opname" : "Sin",
       "opcode" : 13,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "Cos",
       "opcode" : 14,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "Tan",
       "opcode" : 15,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "Asin",
       "opcode" : 16,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "Acos",
       "opcode" : 17,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "Atan",
       "opcode" : 18,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'y_over_x'" }
+        { "kind" : "IdRef", "name" : "y_over_x" }
       ]
     },
     {
       "opname" : "Sinh",
       "opcode" : 19,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "Cosh",
       "opcode" : 20,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "Tanh",
       "opcode" : 21,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "Asinh",
       "opcode" : 22,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "Acosh",
       "opcode" : 23,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "Atanh",
       "opcode" : 24,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "Atan2",
       "opcode" : 25,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'y'" },
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "y" },
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "Pow",
       "opcode" : 26,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" }
       ]
     },
     {
       "opname" : "Exp",
       "opcode" : 27,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "Log",
       "opcode" : 28,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "Exp2",
       "opcode" : 29,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "Log2",
       "opcode" : 30,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "Sqrt",
       "opcode" : 31,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "InverseSqrt",
       "opcode" : 32,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "Determinant",
       "opcode" : 33,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "MatrixInverse",
       "opcode" : 34,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "Modf",
       "opcode" : 35,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'i'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "i" }
       ]
     },
     {
       "opname" : "ModfStruct",
       "opcode" : 36,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "FMin",
       "opcode" : 37,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" }
       ]
     },
     {
       "opname" : "UMin",
       "opcode" : 38,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" }
       ]
     },
     {
       "opname" : "SMin",
       "opcode" : 39,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" }
       ]
     },
     {
       "opname" : "FMax",
       "opcode" : 40,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" }
       ]
     },
     {
       "opname" : "UMax",
       "opcode" : 41,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" }
       ]
     },
     {
       "opname" : "SMax",
       "opcode" : 42,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" }
       ]
     },
     {
       "opname" : "FClamp",
       "opcode" : 43,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'minVal'" },
-        { "kind" : "IdRef", "name" : "'maxVal'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "minVal" },
+        { "kind" : "IdRef", "name" : "maxVal" }
       ]
     },
     {
       "opname" : "UClamp",
       "opcode" : 44,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'minVal'" },
-        { "kind" : "IdRef", "name" : "'maxVal'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "minVal" },
+        { "kind" : "IdRef", "name" : "maxVal" }
       ]
     },
     {
       "opname" : "SClamp",
       "opcode" : 45,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'minVal'" },
-        { "kind" : "IdRef", "name" : "'maxVal'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "minVal" },
+        { "kind" : "IdRef", "name" : "maxVal" }
       ]
     },
     {
       "opname" : "FMix",
       "opcode" : 46,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" },
-        { "kind" : "IdRef", "name" : "'a'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" },
+        { "kind" : "IdRef", "name" : "a" }
       ]
     },
     {
       "opname" : "IMix",
       "opcode" : 47,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" },
-        { "kind" : "IdRef", "name" : "'a'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" },
+        { "kind" : "IdRef", "name" : "a" }
       ]
     },
     {
       "opname" : "Step",
       "opcode" : 48,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'edge'" },
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "edge" },
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "SmoothStep",
       "opcode" : 49,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'edge0'" },
-        { "kind" : "IdRef", "name" : "'edge1'" },
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "edge0" },
+        { "kind" : "IdRef", "name" : "edge1" },
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "Fma",
       "opcode" : 50,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'a'" },
-        { "kind" : "IdRef", "name" : "'b'" },
-        { "kind" : "IdRef", "name" : "'c'" }
+        { "kind" : "IdRef", "name" : "a" },
+        { "kind" : "IdRef", "name" : "b" },
+        { "kind" : "IdRef", "name" : "c" }
       ]
     },
     {
       "opname" : "Frexp",
       "opcode" : 51,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'exp'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "exp" }
       ]
     },
     {
       "opname" : "FrexpStruct",
       "opcode" : 52,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "Ldexp",
       "opcode" : 53,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'exp'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "exp" }
       ]
     },
     {
       "opname" : "PackSnorm4x8",
       "opcode" : 54,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'v'" }
+        { "kind" : "IdRef", "name" : "v" }
       ]
     },
     {
       "opname" : "PackUnorm4x8",
       "opcode" : 55,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'v'" }
+        { "kind" : "IdRef", "name" : "v" }
       ]
     },
     {
       "opname" : "PackSnorm2x16",
       "opcode" : 56,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'v'" }
+        { "kind" : "IdRef", "name" : "v" }
       ]
     },
     {
       "opname" : "PackUnorm2x16",
       "opcode" : 57,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'v'" }
+        { "kind" : "IdRef", "name" : "v" }
       ]
     },
     {
       "opname" : "PackHalf2x16",
       "opcode" : 58,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'v'" }
+        { "kind" : "IdRef", "name" : "v" }
       ]
     },
     {
       "opname" : "PackDouble2x32",
       "opcode" : 59,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'v'" }
+        { "kind" : "IdRef", "name" : "v" }
       ],
       "capabilities" : [ "Float64" ]
     },
@@ -471,42 +471,42 @@
       "opname" : "UnpackSnorm2x16",
       "opcode" : 60,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'p'" }
+        { "kind" : "IdRef", "name" : "p" }
       ]
     },
     {
       "opname" : "UnpackUnorm2x16",
       "opcode" : 61,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'p'" }
+        { "kind" : "IdRef", "name" : "p" }
       ]
     },
     {
       "opname" : "UnpackHalf2x16",
       "opcode" : 62,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'v'" }
+        { "kind" : "IdRef", "name" : "v" }
       ]
     },
     {
       "opname" : "UnpackSnorm4x8",
       "opcode" : 63,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'p'" }
+        { "kind" : "IdRef", "name" : "p" }
       ]
     },
     {
       "opname" : "UnpackUnorm4x8",
       "opcode" : 64,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'p'" }
+        { "kind" : "IdRef", "name" : "p" }
       ]
     },
     {
       "opname" : "UnpackDouble2x32",
       "opcode" : 65,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'v'" }
+        { "kind" : "IdRef", "name" : "v" }
       ],
       "capabilities" : [ "Float64" ]
     },
@@ -514,84 +514,84 @@
       "opname" : "Length",
       "opcode" : 66,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "Distance",
       "opcode" : 67,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'p0'" },
-        { "kind" : "IdRef", "name" : "'p1'" }
+        { "kind" : "IdRef", "name" : "p0" },
+        { "kind" : "IdRef", "name" : "p1" }
       ]
     },
     {
       "opname" : "Cross",
       "opcode" : 68,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" }
       ]
     },
     {
       "opname" : "Normalize",
       "opcode" : 69,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "FaceForward",
       "opcode" : 70,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'N'" },
-        { "kind" : "IdRef", "name" : "'I'" },
-        { "kind" : "IdRef", "name" : "'Nref'" }
+        { "kind" : "IdRef", "name" : "N" },
+        { "kind" : "IdRef", "name" : "I" },
+        { "kind" : "IdRef", "name" : "Nref" }
       ]
     },
     {
       "opname" : "Reflect",
       "opcode" : 71,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'I'" },
-        { "kind" : "IdRef", "name" : "'N'" }
+        { "kind" : "IdRef", "name" : "I" },
+        { "kind" : "IdRef", "name" : "N" }
       ]
     },
     {
       "opname" : "Refract",
       "opcode" : 72,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'I'" },
-        { "kind" : "IdRef", "name" : "'N'" },
-        { "kind" : "IdRef", "name" : "'eta'" }
+        { "kind" : "IdRef", "name" : "I" },
+        { "kind" : "IdRef", "name" : "N" },
+        { "kind" : "IdRef", "name" : "eta" }
       ]
     },
     {
       "opname" : "FindILsb",
       "opcode" : 73,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Value'" }
+        { "kind" : "IdRef", "name" : "Value" }
       ]
     },
     {
       "opname" : "FindSMsb",
       "opcode" : 74,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Value'" }
+        { "kind" : "IdRef", "name" : "Value" }
       ]
     },
     {
       "opname" : "FindUMsb",
       "opcode" : 75,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Value'" }
+        { "kind" : "IdRef", "name" : "Value" }
       ]
     },
     {
       "opname" : "InterpolateAtCentroid",
       "opcode" : 76,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'interpolant'" }
+        { "kind" : "IdRef", "name" : "interpolant" }
       ],
       "capabilities" : [ "InterpolationFunction" ]
     },
@@ -599,8 +599,8 @@
       "opname" : "InterpolateAtSample",
       "opcode" : 77,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'interpolant'" },
-        { "kind" : "IdRef", "name" : "'sample'" }
+        { "kind" : "IdRef", "name" : "interpolant" },
+        { "kind" : "IdRef", "name" : "sample" }
       ],
       "capabilities" : [ "InterpolationFunction" ]
     },
@@ -608,8 +608,8 @@
       "opname" : "InterpolateAtOffset",
       "opcode" : 78,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'interpolant'" },
-        { "kind" : "IdRef", "name" : "'offset'" }
+        { "kind" : "IdRef", "name" : "interpolant" },
+        { "kind" : "IdRef", "name" : "offset" }
       ],
       "capabilities" : [ "InterpolationFunction" ]
     },
@@ -617,25 +617,25 @@
       "opname" : "NMin",
       "opcode" : 79,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" }
       ]
     },
     {
       "opname" : "NMax",
       "opcode" : 80,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" }
       ]
     },
     {
       "opname" : "NClamp",
       "opcode" : 81,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'minVal'" },
-        { "kind" : "IdRef", "name" : "'maxVal'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "minVal" },
+        { "kind" : "IdRef", "name" : "maxVal" }
       ]
     }
   ]

--- a/include/spirv/unified1/extinst.nonsemantic.debugprintf.grammar.json
+++ b/include/spirv/unified1/extinst.nonsemantic.debugprintf.grammar.json
@@ -5,7 +5,7 @@
       "opname" : "DebugPrintf",
       "opcode" : 1,
       "operands" : [
-        { "kind" : "IdRef",        "name" : "'Format'" },
+        { "kind" : "IdRef",        "name" : "Format" },
         { "kind" : "IdRef",        "quantifier" : "*" }
       ]
     }

--- a/include/spirv/unified1/extinst.nonsemantic.shader.debuginfo.100.grammar.json
+++ b/include/spirv/unified1/extinst.nonsemantic.shader.debuginfo.100.grammar.json
@@ -35,254 +35,254 @@
       "opname" : "DebugCompilationUnit",
       "opcode" : 1,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Version'" },
-        { "kind" : "IdRef", "name" : "'DWARF Version'" },
-        { "kind" : "IdRef", "name" : "'Source'" },
-        { "kind" : "IdRef", "name" : "'Language'" }
+        { "kind" : "IdRef", "name" : "Version" },
+        { "kind" : "IdRef", "name" : "DWARF Version" },
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "IdRef", "name" : "Language" }
       ]
     },
     {
       "opname" : "DebugTypeBasic",
       "opcode" : 2,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Name'" },
-        { "kind" : "IdRef", "name" : "'Size'" },
-        { "kind" : "IdRef", "name" : "'Encoding'" },
-        { "kind" : "IdRef", "name" : "'Flags'" }
+        { "kind" : "IdRef", "name" : "Name" },
+        { "kind" : "IdRef", "name" : "Size" },
+        { "kind" : "IdRef", "name" : "Encoding" },
+        { "kind" : "IdRef", "name" : "Flags" }
       ]
     },
     {
       "opname" : "DebugTypePointer",
       "opcode" : 3,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Base Type'" },
-        { "kind" : "IdRef", "name" : "'Storage Class'" },
-        { "kind" : "IdRef", "name" : "'Flags'" }
+        { "kind" : "IdRef", "name" : "Base Type" },
+        { "kind" : "IdRef", "name" : "Storage Class" },
+        { "kind" : "IdRef", "name" : "Flags" }
       ]
     },
     {
       "opname" : "DebugTypeQualifier",
       "opcode" : 4,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Base Type'" },
-        { "kind" : "IdRef", "name" : "'Type Qualifier'" }
+        { "kind" : "IdRef", "name" : "Base Type" },
+        { "kind" : "IdRef", "name" : "Type Qualifier" }
       ]
     },
     {
       "opname" : "DebugTypeArray",
       "opcode" : 5,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Base Type'" },
-        { "kind" : "IdRef", "name" : "'Component Counts'", "quantifier" : "*" }
+        { "kind" : "IdRef", "name" : "Base Type" },
+        { "kind" : "IdRef", "name" : "Component Counts", "quantifier" : "*" }
       ]
     },
     {
       "opname" : "DebugTypeVector",
       "opcode" : 6,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Base Type'" },
-        { "kind" : "IdRef", "name" : "'Component Count'" }
+        { "kind" : "IdRef", "name" : "Base Type" },
+        { "kind" : "IdRef", "name" : "Component Count" }
       ]
     },
     {
       "opname" : "DebugTypedef",
       "opcode" : 7,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Name'" },
-        { "kind" : "IdRef", "name" : "'Base Type'" },
-        { "kind" : "IdRef", "name" : "'Source'" },
-        { "kind" : "IdRef", "name" : "'Line'" },
-        { "kind" : "IdRef", "name" : "'Column'" },
-        { "kind" : "IdRef", "name" : "'Parent'" }
+        { "kind" : "IdRef", "name" : "Name" },
+        { "kind" : "IdRef", "name" : "Base Type" },
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "IdRef", "name" : "Line" },
+        { "kind" : "IdRef", "name" : "Column" },
+        { "kind" : "IdRef", "name" : "Parent" }
       ]
     },
     {
       "opname" : "DebugTypeFunction",
       "opcode" : 8,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Flags'" },
-        { "kind" : "IdRef", "name" : "'Return Type'" },
-        { "kind" : "IdRef", "name" : "'Parameter Types'", "quantifier" : "*" }
+        { "kind" : "IdRef", "name" : "Flags" },
+        { "kind" : "IdRef", "name" : "Return Type" },
+        { "kind" : "IdRef", "name" : "Parameter Types", "quantifier" : "*" }
       ]
     },
     {
       "opname" : "DebugTypeEnum",
       "opcode" : 9,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Name'" },
-        { "kind" : "IdRef", "name" : "'Underlying Type'" },
-        { "kind" : "IdRef", "name" : "'Source'" },
-        { "kind" : "IdRef", "name" : "'Line'" },
-        { "kind" : "IdRef", "name" : "'Column'" },
-        { "kind" : "IdRef", "name" : "'Parent'" },
-        { "kind" : "IdRef", "name" : "'Size'" },
-        { "kind" : "IdRef", "name" : "'Flags'" },
-        { "kind" : "PairIdRefIdRef", "name" : "'Value, Name, Value, Name, ...'", "quantifier" : "*" }
+        { "kind" : "IdRef", "name" : "Name" },
+        { "kind" : "IdRef", "name" : "Underlying Type" },
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "IdRef", "name" : "Line" },
+        { "kind" : "IdRef", "name" : "Column" },
+        { "kind" : "IdRef", "name" : "Parent" },
+        { "kind" : "IdRef", "name" : "Size" },
+        { "kind" : "IdRef", "name" : "Flags" },
+        { "kind" : "PairIdRefIdRef", "name" : "Value, Name, Value, Name, ...", "quantifier" : "*" }
       ]
     },
     {
       "opname" : "DebugTypeComposite",
       "opcode" : 10,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Name'" },
-        { "kind" : "IdRef", "name" : "'Tag'" },
-        { "kind" : "IdRef", "name" : "'Source'" },
-        { "kind" : "IdRef", "name" : "'Line'" },
-        { "kind" : "IdRef", "name" : "'Column'" },
-        { "kind" : "IdRef", "name" : "'Parent'" },
-        { "kind" : "IdRef", "name" : "'Linkage Name'" },
-        { "kind" : "IdRef", "name" : "'Size'" },
-        { "kind" : "IdRef", "name" : "'Flags'" },
-        { "kind" : "IdRef", "name" : "'Members'", "quantifier" : "*" }
+        { "kind" : "IdRef", "name" : "Name" },
+        { "kind" : "IdRef", "name" : "Tag" },
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "IdRef", "name" : "Line" },
+        { "kind" : "IdRef", "name" : "Column" },
+        { "kind" : "IdRef", "name" : "Parent" },
+        { "kind" : "IdRef", "name" : "Linkage Name" },
+        { "kind" : "IdRef", "name" : "Size" },
+        { "kind" : "IdRef", "name" : "Flags" },
+        { "kind" : "IdRef", "name" : "Members", "quantifier" : "*" }
       ]
     },
     {
       "opname" : "DebugTypeMember",
       "opcode" : 11,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Name'" },
-        { "kind" : "IdRef", "name" : "'Type'" },
-        { "kind" : "IdRef", "name" : "'Source'" },
-        { "kind" : "IdRef", "name" : "'Line'" },
-        { "kind" : "IdRef", "name" : "'Column'" },
-        { "kind" : "IdRef", "name" : "'Offset'" },
-        { "kind" : "IdRef", "name" : "'Size'" },
-        { "kind" : "IdRef", "name" : "'Flags'" },
-        { "kind" : "IdRef", "name" : "'Value'", "quantifier" : "?" }
+        { "kind" : "IdRef", "name" : "Name" },
+        { "kind" : "IdRef", "name" : "Type" },
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "IdRef", "name" : "Line" },
+        { "kind" : "IdRef", "name" : "Column" },
+        { "kind" : "IdRef", "name" : "Offset" },
+        { "kind" : "IdRef", "name" : "Size" },
+        { "kind" : "IdRef", "name" : "Flags" },
+        { "kind" : "IdRef", "name" : "Value", "quantifier" : "?" }
       ]
     },
     {
       "opname" : "DebugTypeInheritance",
       "opcode" : 12,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Parent'" },
-        { "kind" : "IdRef", "name" : "'Offset'" },
-        { "kind" : "IdRef", "name" : "'Size'" },
-        { "kind" : "IdRef", "name" : "'Flags'" }
+        { "kind" : "IdRef", "name" : "Parent" },
+        { "kind" : "IdRef", "name" : "Offset" },
+        { "kind" : "IdRef", "name" : "Size" },
+        { "kind" : "IdRef", "name" : "Flags" }
       ]
     },
     {
       "opname" : "DebugTypePtrToMember",
       "opcode" : 13,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Member Type'" },
-        { "kind" : "IdRef", "name" : "'Parent'" }
+        { "kind" : "IdRef", "name" : "Member Type" },
+        { "kind" : "IdRef", "name" : "Parent" }
       ]
     },
     {
       "opname" : "DebugTypeTemplate",
       "opcode" : 14,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Target'" },
-        { "kind" : "IdRef", "name" : "'Parameters'", "quantifier" : "*" }
+        { "kind" : "IdRef", "name" : "Target" },
+        { "kind" : "IdRef", "name" : "Parameters", "quantifier" : "*" }
       ]
     },
     {
       "opname" : "DebugTypeTemplateParameter",
       "opcode" : 15,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Name'" },
-        { "kind" : "IdRef", "name" : "'Actual Type'" },
-        { "kind" : "IdRef", "name" : "'Value'" },
-        { "kind" : "IdRef", "name" : "'Source'" },
-        { "kind" : "IdRef", "name" : "'Line'" },
-        { "kind" : "IdRef", "name" : "'Column'" }
+        { "kind" : "IdRef", "name" : "Name" },
+        { "kind" : "IdRef", "name" : "Actual Type" },
+        { "kind" : "IdRef", "name" : "Value" },
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "IdRef", "name" : "Line" },
+        { "kind" : "IdRef", "name" : "Column" }
       ]
     },
     {
       "opname" : "DebugTypeTemplateTemplateParameter",
       "opcode" : 16,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Name'" },
-        { "kind" : "IdRef", "name" : "'Template Name'" },
-        { "kind" : "IdRef", "name" : "'Source'" },
-        { "kind" : "IdRef", "name" : "'Line'" },
-        { "kind" : "IdRef", "name" : "'Column'" }
+        { "kind" : "IdRef", "name" : "Name" },
+        { "kind" : "IdRef", "name" : "Template Name" },
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "IdRef", "name" : "Line" },
+        { "kind" : "IdRef", "name" : "Column" }
       ]
     },
     {
       "opname" : "DebugTypeTemplateParameterPack",
       "opcode" : 17,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Name'" },
-        { "kind" : "IdRef", "name" : "'Source'" },
-        { "kind" : "IdRef", "name" : "'Line'" },
-        { "kind" : "IdRef", "name" : "'Column'" },
-        { "kind" : "IdRef", "name" : "'Template Parameters'", "quantifier" : "*" }
+        { "kind" : "IdRef", "name" : "Name" },
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "IdRef", "name" : "Line" },
+        { "kind" : "IdRef", "name" : "Column" },
+        { "kind" : "IdRef", "name" : "Template Parameters", "quantifier" : "*" }
       ]
     },
     {
       "opname" : "DebugGlobalVariable",
       "opcode" : 18,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Name'" },
-        { "kind" : "IdRef", "name" : "'Type'" },
-        { "kind" : "IdRef", "name" : "'Source'" },
-        { "kind" : "IdRef", "name" : "'Line'" },
-        { "kind" : "IdRef", "name" : "'Column'" },
-        { "kind" : "IdRef", "name" : "'Parent'" },
-        { "kind" : "IdRef", "name" : "'Linkage Name'" },
-        { "kind" : "IdRef", "name" : "'Variable'" },
-        { "kind" : "IdRef", "name" : "'Flags'" },
-        { "kind" : "IdRef", "name" : "'Static Member Declaration'", "quantifier" : "?" }
+        { "kind" : "IdRef", "name" : "Name" },
+        { "kind" : "IdRef", "name" : "Type" },
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "IdRef", "name" : "Line" },
+        { "kind" : "IdRef", "name" : "Column" },
+        { "kind" : "IdRef", "name" : "Parent" },
+        { "kind" : "IdRef", "name" : "Linkage Name" },
+        { "kind" : "IdRef", "name" : "Variable" },
+        { "kind" : "IdRef", "name" : "Flags" },
+        { "kind" : "IdRef", "name" : "Static Member Declaration", "quantifier" : "?" }
       ]
     },
     {
       "opname" : "DebugFunctionDeclaration",
       "opcode" : 19,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Name'" },
-        { "kind" : "IdRef", "name" : "'Type'" },
-        { "kind" : "IdRef", "name" : "'Source'" },
-        { "kind" : "IdRef", "name" : "'Line'" },
-        { "kind" : "IdRef", "name" : "'Column'" },
-        { "kind" : "IdRef", "name" : "'Parent'" },
-        { "kind" : "IdRef", "name" : "'Linkage Name'" },
-        { "kind" : "IdRef", "name" : "'Flags'" }
+        { "kind" : "IdRef", "name" : "Name" },
+        { "kind" : "IdRef", "name" : "Type" },
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "IdRef", "name" : "Line" },
+        { "kind" : "IdRef", "name" : "Column" },
+        { "kind" : "IdRef", "name" : "Parent" },
+        { "kind" : "IdRef", "name" : "Linkage Name" },
+        { "kind" : "IdRef", "name" : "Flags" }
       ]
     },
     {
       "opname" : "DebugFunction",
       "opcode" : 20,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Name'" },
-        { "kind" : "IdRef", "name" : "'Type'" },
-        { "kind" : "IdRef", "name" : "'Source'" },
-        { "kind" : "IdRef", "name" : "'Line'" },
-        { "kind" : "IdRef", "name" : "'Column'" },
-        { "kind" : "IdRef", "name" : "'Parent'" },
-        { "kind" : "IdRef", "name" : "'Linkage Name'" },
-        { "kind" : "IdRef", "name" : "'Flags'" },
-        { "kind" : "IdRef", "name" : "'Scope Line'" },
-        { "kind" : "IdRef", "name" : "'Declaration'", "quantifier" : "?" }
+        { "kind" : "IdRef", "name" : "Name" },
+        { "kind" : "IdRef", "name" : "Type" },
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "IdRef", "name" : "Line" },
+        { "kind" : "IdRef", "name" : "Column" },
+        { "kind" : "IdRef", "name" : "Parent" },
+        { "kind" : "IdRef", "name" : "Linkage Name" },
+        { "kind" : "IdRef", "name" : "Flags" },
+        { "kind" : "IdRef", "name" : "Scope Line" },
+        { "kind" : "IdRef", "name" : "Declaration", "quantifier" : "?" }
       ]
     },
     {
       "opname" : "DebugLexicalBlock",
       "opcode" : 21,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Source'" },
-        { "kind" : "IdRef", "name" : "'Line'" },
-        { "kind" : "IdRef", "name" : "'Column'" },
-        { "kind" : "IdRef", "name" : "'Parent'" },
-        { "kind" : "IdRef", "name" : "'Name'", "quantifier" : "?" }
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "IdRef", "name" : "Line" },
+        { "kind" : "IdRef", "name" : "Column" },
+        { "kind" : "IdRef", "name" : "Parent" },
+        { "kind" : "IdRef", "name" : "Name", "quantifier" : "?" }
       ]
     },
     {
       "opname" : "DebugLexicalBlockDiscriminator",
       "opcode" : 22,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Source'" },
-        { "kind" : "IdRef", "name" : "'Discriminator'" },
-        { "kind" : "IdRef", "name" : "'Parent'" }
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "IdRef", "name" : "Discriminator" },
+        { "kind" : "IdRef", "name" : "Parent" }
       ]
     },
     {
       "opname" : "DebugScope",
       "opcode" : 23,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Scope'" },
-        { "kind" : "IdRef", "name" : "'Inlined At'", "quantifier" : "?" }
+        { "kind" : "IdRef", "name" : "Scope" },
+        { "kind" : "IdRef", "name" : "Inlined At", "quantifier" : "?" }
       ]
     },
     {
@@ -293,132 +293,132 @@
       "opname" : "DebugInlinedAt",
       "opcode" : 25,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Line'" },
-        { "kind" : "IdRef", "name" : "'Scope'" },
-        { "kind" : "IdRef", "name" : "'Inlined'", "quantifier" : "?" }
+        { "kind" : "IdRef", "name" : "Line" },
+        { "kind" : "IdRef", "name" : "Scope" },
+        { "kind" : "IdRef", "name" : "Inlined", "quantifier" : "?" }
       ]
     },
     {
       "opname" : "DebugLocalVariable",
       "opcode" : 26,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Name'" },
-        { "kind" : "IdRef", "name" : "'Type'" },
-        { "kind" : "IdRef", "name" : "'Source'" },
-        { "kind" : "IdRef", "name" : "'Line'" },
-        { "kind" : "IdRef", "name" : "'Column'" },
-        { "kind" : "IdRef", "name" : "'Parent'" },
-        { "kind" : "IdRef", "name" : "'Flags'" },
-        { "kind" : "IdRef", "name" : "'Arg Number'", "quantifier" : "?" }
+        { "kind" : "IdRef", "name" : "Name" },
+        { "kind" : "IdRef", "name" : "Type" },
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "IdRef", "name" : "Line" },
+        { "kind" : "IdRef", "name" : "Column" },
+        { "kind" : "IdRef", "name" : "Parent" },
+        { "kind" : "IdRef", "name" : "Flags" },
+        { "kind" : "IdRef", "name" : "Arg Number", "quantifier" : "?" }
       ]
     },
     {
       "opname" : "DebugInlinedVariable",
       "opcode" : 27,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Variable'" },
-        { "kind" : "IdRef", "name" : "'Inlined'" }
+        { "kind" : "IdRef", "name" : "Variable" },
+        { "kind" : "IdRef", "name" : "Inlined" }
       ]
     },
     {
       "opname" : "DebugDeclare",
       "opcode" : 28,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Local Variable'" },
-        { "kind" : "IdRef", "name" : "'Variable'" },
-        { "kind" : "IdRef", "name" : "'Expression'" },
-        { "kind" : "IdRef", "name" : "'Indexes'", "quantifier" : "*" }
+        { "kind" : "IdRef", "name" : "Local Variable" },
+        { "kind" : "IdRef", "name" : "Variable" },
+        { "kind" : "IdRef", "name" : "Expression" },
+        { "kind" : "IdRef", "name" : "Indexes", "quantifier" : "*" }
       ]
     },
     {
       "opname" : "DebugValue",
       "opcode" : 29,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Local Variable'" },
-        { "kind" : "IdRef", "name" : "'Value'" },
-        { "kind" : "IdRef", "name" : "'Expression'" },
-        { "kind" : "IdRef", "name" : "'Indexes'", "quantifier" : "*" }
+        { "kind" : "IdRef", "name" : "Local Variable" },
+        { "kind" : "IdRef", "name" : "Value" },
+        { "kind" : "IdRef", "name" : "Expression" },
+        { "kind" : "IdRef", "name" : "Indexes", "quantifier" : "*" }
       ]
     },
     {
       "opname" : "DebugOperation",
       "opcode" : 30,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'OpCode'" },
-        { "kind" : "IdRef", "name" : "'Operands ...'", "quantifier" : "*" }
+        { "kind" : "IdRef", "name" : "OpCode" },
+        { "kind" : "IdRef", "name" : "Operands ...", "quantifier" : "*" }
       ]
     },
     {
       "opname" : "DebugExpression",
       "opcode" : 31,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Operands ...'", "quantifier" : "*" }
+        { "kind" : "IdRef", "name" : "Operands ...", "quantifier" : "*" }
       ]
     },
     {
       "opname" : "DebugMacroDef",
       "opcode" : 32,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Source'" },
-        { "kind" : "IdRef", "name" : "'Line'" },
-        { "kind" : "IdRef", "name" : "'Name'" },
-        { "kind" : "IdRef", "name" : "'Value'", "quantifier" : "?" }
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "IdRef", "name" : "Line" },
+        { "kind" : "IdRef", "name" : "Name" },
+        { "kind" : "IdRef", "name" : "Value", "quantifier" : "?" }
       ]
     },
     {
       "opname" : "DebugMacroUndef",
       "opcode" : 33,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Source'" },
-        { "kind" : "IdRef", "name" : "'Line'" },
-        { "kind" : "IdRef", "name" : "'Macro'" }
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "IdRef", "name" : "Line" },
+        { "kind" : "IdRef", "name" : "Macro" }
       ]
     },
     {
       "opname" : "DebugImportedEntity",
       "opcode" : 34,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Name'" },
-        { "kind" : "IdRef", "name" : "'Tag'" },
-        { "kind" : "IdRef", "name" : "'Source'" },
-        { "kind" : "IdRef", "name" : "'Entity'" },
-        { "kind" : "IdRef", "name" : "'Line'" },
-        { "kind" : "IdRef", "name" : "'Column'" },
-        { "kind" : "IdRef", "name" : "'Parent'" }
+        { "kind" : "IdRef", "name" : "Name" },
+        { "kind" : "IdRef", "name" : "Tag" },
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "IdRef", "name" : "Entity" },
+        { "kind" : "IdRef", "name" : "Line" },
+        { "kind" : "IdRef", "name" : "Column" },
+        { "kind" : "IdRef", "name" : "Parent" }
       ]
     },
     {
       "opname" : "DebugSource",
       "opcode" : 35,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'File'" },
-        { "kind" : "IdRef", "name" : "'Text'", "quantifier" : "?" }
+        { "kind" : "IdRef", "name" : "File" },
+        { "kind" : "IdRef", "name" : "Text", "quantifier" : "?" }
       ]
     },
     {
       "opname" : "DebugFunctionDefinition",
       "opcode" : 101,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Function'" },
-        { "kind" : "IdRef", "name" : "'Definition'" }
+        { "kind" : "IdRef", "name" : "Function" },
+        { "kind" : "IdRef", "name" : "Definition" }
       ]
     },
     {
       "opname" : "DebugSourceContinued",
       "opcode" : 102,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Text'" }
+        { "kind" : "IdRef", "name" : "Text" }
       ]
     },
     {
       "opname" : "DebugLine",
       "opcode" : 103,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Source'" },
-        { "kind" : "IdRef", "name" : "'Line Start'" },
-        { "kind" : "IdRef", "name" : "'Line End'" },
-        { "kind" : "IdRef", "name" : "'Column Start'" },
-        { "kind" : "IdRef", "name" : "'Column End'" }
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "IdRef", "name" : "Line Start" },
+        { "kind" : "IdRef", "name" : "Line End" },
+        { "kind" : "IdRef", "name" : "Column Start" },
+        { "kind" : "IdRef", "name" : "Column End" }
       ]
     },
     {
@@ -429,34 +429,34 @@
       "opname" : "DebugBuildIdentifier",
       "opcode" : 105,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Identifier'" },
-        { "kind" : "IdRef", "name" : "'Flags'" }
+        { "kind" : "IdRef", "name" : "Identifier" },
+        { "kind" : "IdRef", "name" : "Flags" }
       ]
     },
     {
       "opname" : "DebugStoragePath",
       "opcode" : 106,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Path'" }
+        { "kind" : "IdRef", "name" : "Path" }
       ]
     },
     {
       "opname" : "DebugEntryPoint",
       "opcode" : 107,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Entry Point'" },
-        { "kind" : "IdRef", "name" : "'Compilation Unit'" },
-        { "kind" : "IdRef", "name" : "'Compiler Signature'" },
-        { "kind" : "IdRef", "name" : "'Command-line Arguments'" }
+        { "kind" : "IdRef", "name" : "Entry Point" },
+        { "kind" : "IdRef", "name" : "Compilation Unit" },
+        { "kind" : "IdRef", "name" : "Compiler Signature" },
+        { "kind" : "IdRef", "name" : "Command-line Arguments" }
       ]
     },
     {
       "opname" : "DebugTypeMatrix",
       "opcode" : 108,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Vector Type'" },
-        { "kind" : "IdRef", "name" : "'Vector Count'" },
-        { "kind" : "IdRef", "name" : "'Column Major'" }
+        { "kind" : "IdRef", "name" : "Vector Type" },
+        { "kind" : "IdRef", "name" : "Vector Count" },
+        { "kind" : "IdRef", "name" : "Column Major" }
       ]
     }
   ],

--- a/include/spirv/unified1/extinst.opencl.debuginfo.100.grammar.json
+++ b/include/spirv/unified1/extinst.opencl.debuginfo.100.grammar.json
@@ -35,256 +35,256 @@
       "opname" : "DebugCompilationUnit",
       "opcode" : 1,
       "operands" : [
-        { "kind" : "LiteralInteger", "name" : "'Version'" },
-        { "kind" : "LiteralInteger", "name" : "'DWARF Version'" },
-        { "kind" : "IdRef", "name" : "'Source'" },
-        { "kind" : "SourceLanguage", "name" : "'Language'" }
+        { "kind" : "LiteralInteger", "name" : "Version" },
+        { "kind" : "LiteralInteger", "name" : "DWARF Version" },
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "SourceLanguage", "name" : "Language" }
       ]
     },
     {
       "opname" : "DebugTypeBasic",
       "opcode" : 2,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Name'" },
-        { "kind" : "IdRef", "name" : "'Size'" },
-        { "kind" : "DebugBaseTypeAttributeEncoding", "name" : "'Encoding'" }
+        { "kind" : "IdRef", "name" : "Name" },
+        { "kind" : "IdRef", "name" : "Size" },
+        { "kind" : "DebugBaseTypeAttributeEncoding", "name" : "Encoding" }
       ]
     },
     {
       "opname" : "DebugTypePointer",
       "opcode" : 3,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Base Type'" },
-        { "kind" : "StorageClass", "name" : "'Storage Class'" },
-        { "kind" : "DebugInfoFlags", "name" : "'Flags'" }
+        { "kind" : "IdRef", "name" : "Base Type" },
+        { "kind" : "StorageClass", "name" : "Storage Class" },
+        { "kind" : "DebugInfoFlags", "name" : "Flags" }
       ]
     },
     {
       "opname" : "DebugTypeQualifier",
       "opcode" : 4,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Base Type'" },
-        { "kind" : "DebugTypeQualifier", "name" : "'Type Qualifier'" }
+        { "kind" : "IdRef", "name" : "Base Type" },
+        { "kind" : "DebugTypeQualifier", "name" : "Type Qualifier" }
       ]
     },
     {
       "opname" : "DebugTypeArray",
       "opcode" : 5,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Base Type'" },
-        { "kind" : "IdRef", "name" : "'Component Counts'", "quantifier" : "*" }
+        { "kind" : "IdRef", "name" : "Base Type" },
+        { "kind" : "IdRef", "name" : "Component Counts", "quantifier" : "*" }
       ]
     },
     {
       "opname" : "DebugTypeVector",
       "opcode" : 6,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Base Type'" },
-        { "kind" : "LiteralInteger", "name" : "'Component Count'" }
+        { "kind" : "IdRef", "name" : "Base Type" },
+        { "kind" : "LiteralInteger", "name" : "Component Count" }
       ]
     },
     {
       "opname" : "DebugTypedef",
       "opcode" : 7,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Name'" },
-        { "kind" : "IdRef", "name" : "'Base Type'" },
-        { "kind" : "IdRef", "name" : "'Source'" },
-        { "kind" : "LiteralInteger", "name" : "'Line'" },
-        { "kind" : "LiteralInteger", "name" : "'Column'" },
-        { "kind" : "IdRef", "name" : "'Parent'" }
+        { "kind" : "IdRef", "name" : "Name" },
+        { "kind" : "IdRef", "name" : "Base Type" },
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "LiteralInteger", "name" : "Line" },
+        { "kind" : "LiteralInteger", "name" : "Column" },
+        { "kind" : "IdRef", "name" : "Parent" }
       ]
     },
     {
       "opname" : "DebugTypeFunction",
       "opcode" : 8,
       "operands" : [
-        { "kind" : "DebugInfoFlags", "name" : "'Flags'" },
-        { "kind" : "IdRef", "name" : "'Return Type'" },
-        { "kind" : "IdRef", "name" : "'Parameter Types'", "quantifier" : "*" }
+        { "kind" : "DebugInfoFlags", "name" : "Flags" },
+        { "kind" : "IdRef", "name" : "Return Type" },
+        { "kind" : "IdRef", "name" : "Parameter Types", "quantifier" : "*" }
       ]
     },
     {
       "opname" : "DebugTypeEnum",
       "opcode" : 9,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Name'" },
-        { "kind" : "IdRef", "name" : "'Underlying Type'" },
-        { "kind" : "IdRef", "name" : "'Source'" },
-        { "kind" : "LiteralInteger", "name" : "'Line'" },
-        { "kind" : "LiteralInteger", "name" : "'Column'" },
-        { "kind" : "IdRef", "name" : "'Parent'" },
-        { "kind" : "IdRef", "name" : "'Size'" },
-        { "kind" : "DebugInfoFlags", "name" : "'Flags'" },
-        { "kind" : "PairIdRefIdRef", "name" : "'Value, Name, Value, Name, ...'", "quantifier" : "*" }
+        { "kind" : "IdRef", "name" : "Name" },
+        { "kind" : "IdRef", "name" : "Underlying Type" },
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "LiteralInteger", "name" : "Line" },
+        { "kind" : "LiteralInteger", "name" : "Column" },
+        { "kind" : "IdRef", "name" : "Parent" },
+        { "kind" : "IdRef", "name" : "Size" },
+        { "kind" : "DebugInfoFlags", "name" : "Flags" },
+        { "kind" : "PairIdRefIdRef", "name" : "Value, Name, Value, Name, ...", "quantifier" : "*" }
       ]
     },
     {
       "opname" : "DebugTypeComposite",
       "opcode" : 10,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Name'" },
-        { "kind" : "DebugCompositeType", "name" : "'Tag'" },
-        { "kind" : "IdRef", "name" : "'Source'" },
-        { "kind" : "LiteralInteger", "name" : "'Line'" },
-        { "kind" : "LiteralInteger", "name" : "'Column'" },
-        { "kind" : "IdRef", "name" : "'Parent'" },
-        { "kind" : "IdRef", "name" : "'Linkage Name'" },
-        { "kind" : "IdRef", "name" : "'Size'" },
-        { "kind" : "DebugInfoFlags", "name" : "'Flags'" },
-        { "kind" : "IdRef", "name" : "'Members'", "quantifier" : "*" }
+        { "kind" : "IdRef", "name" : "Name" },
+        { "kind" : "DebugCompositeType", "name" : "Tag" },
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "LiteralInteger", "name" : "Line" },
+        { "kind" : "LiteralInteger", "name" : "Column" },
+        { "kind" : "IdRef", "name" : "Parent" },
+        { "kind" : "IdRef", "name" : "Linkage Name" },
+        { "kind" : "IdRef", "name" : "Size" },
+        { "kind" : "DebugInfoFlags", "name" : "Flags" },
+        { "kind" : "IdRef", "name" : "Members", "quantifier" : "*" }
       ]
     },
     {
       "opname" : "DebugTypeMember",
       "opcode" : 11,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Name'" },
-        { "kind" : "IdRef", "name" : "'Type'" },
-        { "kind" : "IdRef", "name" : "'Source'" },
-        { "kind" : "LiteralInteger", "name" : "'Line'" },
-        { "kind" : "LiteralInteger", "name" : "'Column'" },
-        { "kind" : "IdRef", "name" : "'Parent'" },
-        { "kind" : "IdRef", "name" : "'Offset'" },
-        { "kind" : "IdRef", "name" : "'Size'" },
-        { "kind" : "DebugInfoFlags", "name" : "'Flags'" },
-        { "kind" : "IdRef", "name" : "'Value'", "quantifier" : "?" }
+        { "kind" : "IdRef", "name" : "Name" },
+        { "kind" : "IdRef", "name" : "Type" },
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "LiteralInteger", "name" : "Line" },
+        { "kind" : "LiteralInteger", "name" : "Column" },
+        { "kind" : "IdRef", "name" : "Parent" },
+        { "kind" : "IdRef", "name" : "Offset" },
+        { "kind" : "IdRef", "name" : "Size" },
+        { "kind" : "DebugInfoFlags", "name" : "Flags" },
+        { "kind" : "IdRef", "name" : "Value", "quantifier" : "?" }
       ]
     },
     {
       "opname" : "DebugTypeInheritance",
       "opcode" : 12,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Child'" },
-        { "kind" : "IdRef", "name" : "'Parent'" },
-        { "kind" : "IdRef", "name" : "'Offset'" },
-        { "kind" : "IdRef", "name" : "'Size'" },
-        { "kind" : "DebugInfoFlags", "name" : "'Flags'" }
+        { "kind" : "IdRef", "name" : "Child" },
+        { "kind" : "IdRef", "name" : "Parent" },
+        { "kind" : "IdRef", "name" : "Offset" },
+        { "kind" : "IdRef", "name" : "Size" },
+        { "kind" : "DebugInfoFlags", "name" : "Flags" }
       ]
     },
     {
       "opname" : "DebugTypePtrToMember",
       "opcode" : 13,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Member Type'" },
-        { "kind" : "IdRef", "name" : "'Parent'" }
+        { "kind" : "IdRef", "name" : "Member Type" },
+        { "kind" : "IdRef", "name" : "Parent" }
       ]
     },
     {
       "opname" : "DebugTypeTemplate",
       "opcode" : 14,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Target'" },
-        { "kind" : "IdRef", "name" : "'Parameters'", "quantifier" : "*" }
+        { "kind" : "IdRef", "name" : "Target" },
+        { "kind" : "IdRef", "name" : "Parameters", "quantifier" : "*" }
       ]
     },
     {
       "opname" : "DebugTypeTemplateParameter",
       "opcode" : 15,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Name'" },
-        { "kind" : "IdRef", "name" : "'Actual Type'" },
-        { "kind" : "IdRef", "name" : "'Value'" },
-        { "kind" : "IdRef", "name" : "'Source'" },
-        { "kind" : "LiteralInteger", "name" : "'Line'" },
-        { "kind" : "LiteralInteger", "name" : "'Column'" }
+        { "kind" : "IdRef", "name" : "Name" },
+        { "kind" : "IdRef", "name" : "Actual Type" },
+        { "kind" : "IdRef", "name" : "Value" },
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "LiteralInteger", "name" : "Line" },
+        { "kind" : "LiteralInteger", "name" : "Column" }
       ]
     },
     {
       "opname" : "DebugTypeTemplateTemplateParameter",
       "opcode" : 16,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Name'" },
-        { "kind" : "IdRef", "name" : "'Template Name'" },
-        { "kind" : "IdRef", "name" : "'Source'" },
-        { "kind" : "LiteralInteger", "name" : "'Line'" },
-        { "kind" : "LiteralInteger", "name" : "'Column'" }
+        { "kind" : "IdRef", "name" : "Name" },
+        { "kind" : "IdRef", "name" : "Template Name" },
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "LiteralInteger", "name" : "Line" },
+        { "kind" : "LiteralInteger", "name" : "Column" }
       ]
     },
     {
       "opname" : "DebugTypeTemplateParameterPack",
       "opcode" : 17,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Name'" },
-        { "kind" : "IdRef", "name" : "'Source'" },
-        { "kind" : "LiteralInteger", "name" : "'Line'" },
-        { "kind" : "LiteralInteger", "name" : "'Column'" },
-        { "kind" : "IdRef", "name" : "'Template Parameters'", "quantifier" : "*" }
+        { "kind" : "IdRef", "name" : "Name" },
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "LiteralInteger", "name" : "Line" },
+        { "kind" : "LiteralInteger", "name" : "Column" },
+        { "kind" : "IdRef", "name" : "Template Parameters", "quantifier" : "*" }
       ]
     },
     {
       "opname" : "DebugGlobalVariable",
       "opcode" : 18,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Name'" },
-        { "kind" : "IdRef", "name" : "'Type'" },
-        { "kind" : "IdRef", "name" : "'Source'" },
-        { "kind" : "LiteralInteger", "name" : "'Line'" },
-        { "kind" : "LiteralInteger", "name" : "'Column'" },
-        { "kind" : "IdRef", "name" : "'Parent'" },
-        { "kind" : "IdRef", "name" : "'Linkage Name'" },
-        { "kind" : "IdRef", "name" : "'Variable'" },
-        { "kind" : "DebugInfoFlags", "name" : "'Flags'" },
-        { "kind" : "IdRef", "name" : "'Static Member Declaration'", "quantifier" : "?" }
+        { "kind" : "IdRef", "name" : "Name" },
+        { "kind" : "IdRef", "name" : "Type" },
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "LiteralInteger", "name" : "Line" },
+        { "kind" : "LiteralInteger", "name" : "Column" },
+        { "kind" : "IdRef", "name" : "Parent" },
+        { "kind" : "IdRef", "name" : "Linkage Name" },
+        { "kind" : "IdRef", "name" : "Variable" },
+        { "kind" : "DebugInfoFlags", "name" : "Flags" },
+        { "kind" : "IdRef", "name" : "Static Member Declaration", "quantifier" : "?" }
       ]
     },
     {
       "opname" : "DebugFunctionDeclaration",
       "opcode" : 19,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Name'" },
-        { "kind" : "IdRef", "name" : "'Type'" },
-        { "kind" : "IdRef", "name" : "'Source'" },
-        { "kind" : "LiteralInteger", "name" : "'Line'" },
-        { "kind" : "LiteralInteger", "name" : "'Column'" },
-        { "kind" : "IdRef", "name" : "'Parent'" },
-        { "kind" : "IdRef", "name" : "'Linkage Name'" },
-        { "kind" : "DebugInfoFlags", "name" : "'Flags'" }
+        { "kind" : "IdRef", "name" : "Name" },
+        { "kind" : "IdRef", "name" : "Type" },
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "LiteralInteger", "name" : "Line" },
+        { "kind" : "LiteralInteger", "name" : "Column" },
+        { "kind" : "IdRef", "name" : "Parent" },
+        { "kind" : "IdRef", "name" : "Linkage Name" },
+        { "kind" : "DebugInfoFlags", "name" : "Flags" }
       ]
     },
     {
       "opname" : "DebugFunction",
       "opcode" : 20,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Name'" },
-        { "kind" : "IdRef", "name" : "'Type'" },
-        { "kind" : "IdRef", "name" : "'Source'" },
-        { "kind" : "LiteralInteger", "name" : "'Line'" },
-        { "kind" : "LiteralInteger", "name" : "'Column'" },
-        { "kind" : "IdRef", "name" : "'Parent'" },
-        { "kind" : "IdRef", "name" : "'Linkage Name'" },
-        { "kind" : "DebugInfoFlags", "name" : "'Flags'" },
-        { "kind" : "LiteralInteger", "name" : "'Scope Line'" },
-        { "kind" : "IdRef", "name" : "'Function'" },
-        { "kind" : "IdRef", "name" : "'Declaration'", "quantifier" : "?" }
+        { "kind" : "IdRef", "name" : "Name" },
+        { "kind" : "IdRef", "name" : "Type" },
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "LiteralInteger", "name" : "Line" },
+        { "kind" : "LiteralInteger", "name" : "Column" },
+        { "kind" : "IdRef", "name" : "Parent" },
+        { "kind" : "IdRef", "name" : "Linkage Name" },
+        { "kind" : "DebugInfoFlags", "name" : "Flags" },
+        { "kind" : "LiteralInteger", "name" : "Scope Line" },
+        { "kind" : "IdRef", "name" : "Function" },
+        { "kind" : "IdRef", "name" : "Declaration", "quantifier" : "?" }
       ]
     },
     {
       "opname" : "DebugLexicalBlock",
       "opcode" : 21,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Source'" },
-        { "kind" : "LiteralInteger", "name" : "'Line'" },
-        { "kind" : "LiteralInteger", "name" : "'Column'" },
-        { "kind" : "IdRef", "name" : "'Parent'" },
-        { "kind" : "IdRef", "name" : "'Name'", "quantifier" : "?" }
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "LiteralInteger", "name" : "Line" },
+        { "kind" : "LiteralInteger", "name" : "Column" },
+        { "kind" : "IdRef", "name" : "Parent" },
+        { "kind" : "IdRef", "name" : "Name", "quantifier" : "?" }
       ]
     },
     {
       "opname" : "DebugLexicalBlockDiscriminator",
       "opcode" : 22,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Source'" },
-        { "kind" : "LiteralInteger", "name" : "'Discriminator'" },
-        { "kind" : "IdRef", "name" : "'Parent'" }
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "LiteralInteger", "name" : "Discriminator" },
+        { "kind" : "IdRef", "name" : "Parent" }
       ]
     },
     {
       "opname" : "DebugScope",
       "opcode" : 23,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Scope'" },
-        { "kind" : "IdRef", "name" : "'Inlined At'", "quantifier" : "?" }
+        { "kind" : "IdRef", "name" : "Scope" },
+        { "kind" : "IdRef", "name" : "Inlined At", "quantifier" : "?" }
       ]
     },
     {
@@ -295,119 +295,119 @@
       "opname" : "DebugInlinedAt",
       "opcode" : 25,
       "operands" : [
-        { "kind" : "LiteralInteger", "name" : "'Line'" },
-        { "kind" : "IdRef", "name" : "'Scope'" },
-        { "kind" : "IdRef", "name" : "'Inlined'", "quantifier" : "?" }
+        { "kind" : "LiteralInteger", "name" : "Line" },
+        { "kind" : "IdRef", "name" : "Scope" },
+        { "kind" : "IdRef", "name" : "Inlined", "quantifier" : "?" }
       ]
     },
     {
       "opname" : "DebugLocalVariable",
       "opcode" : 26,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Name'" },
-        { "kind" : "IdRef", "name" : "'Type'" },
-        { "kind" : "IdRef", "name" : "'Source'" },
-        { "kind" : "LiteralInteger", "name" : "'Line'" },
-        { "kind" : "LiteralInteger", "name" : "'Column'" },
-        { "kind" : "IdRef", "name" : "'Parent'" },
-        { "kind" : "DebugInfoFlags", "name" : "'Flags'" },
-        { "kind" : "LiteralInteger", "name" : "'Arg Number'", "quantifier" : "?" }
+        { "kind" : "IdRef", "name" : "Name" },
+        { "kind" : "IdRef", "name" : "Type" },
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "LiteralInteger", "name" : "Line" },
+        { "kind" : "LiteralInteger", "name" : "Column" },
+        { "kind" : "IdRef", "name" : "Parent" },
+        { "kind" : "DebugInfoFlags", "name" : "Flags" },
+        { "kind" : "LiteralInteger", "name" : "Arg Number", "quantifier" : "?" }
       ]
     },
     {
       "opname" : "DebugInlinedVariable",
       "opcode" : 27,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Variable'" },
-        { "kind" : "IdRef", "name" : "'Inlined'" }
+        { "kind" : "IdRef", "name" : "Variable" },
+        { "kind" : "IdRef", "name" : "Inlined" }
       ]
     },
     {
       "opname" : "DebugDeclare",
       "opcode" : 28,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Local Variable'" },
-        { "kind" : "IdRef", "name" : "'Variable'" },
-        { "kind" : "IdRef", "name" : "'Expression'" }
+        { "kind" : "IdRef", "name" : "Local Variable" },
+        { "kind" : "IdRef", "name" : "Variable" },
+        { "kind" : "IdRef", "name" : "Expression" }
       ]
     },
     {
       "opname" : "DebugValue",
       "opcode" : 29,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Local Variable'" },
-        { "kind" : "IdRef", "name" : "'Value'" },
-        { "kind" : "IdRef", "name" : "'Expression'" },
-        { "kind" : "IdRef", "name" : "'Indexes'", "quantifier" : "*" }
+        { "kind" : "IdRef", "name" : "Local Variable" },
+        { "kind" : "IdRef", "name" : "Value" },
+        { "kind" : "IdRef", "name" : "Expression" },
+        { "kind" : "IdRef", "name" : "Indexes", "quantifier" : "*" }
       ]
     },
     {
       "opname" : "DebugOperation",
       "opcode" : 30,
       "operands" : [
-        { "kind" : "DebugOperation", "name" : "'OpCode'" },
-        { "kind" : "LiteralInteger", "name" : "'Operands ...'", "quantifier" : "*" }
+        { "kind" : "DebugOperation", "name" : "OpCode" },
+        { "kind" : "LiteralInteger", "name" : "Operands ...", "quantifier" : "*" }
       ]
     },
     {
       "opname" : "DebugExpression",
       "opcode" : 31,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Operands ...'", "quantifier" : "*" }
+        { "kind" : "IdRef", "name" : "Operands ...", "quantifier" : "*" }
       ]
     },
     {
       "opname" : "DebugMacroDef",
       "opcode" : 32,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Source'" },
-        { "kind" : "LiteralInteger", "name" : "'Line'" },
-        { "kind" : "IdRef", "name" : "'Name'" },
-        { "kind" : "IdRef", "name" : "'Value'", "quantifier" : "?" }
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "LiteralInteger", "name" : "Line" },
+        { "kind" : "IdRef", "name" : "Name" },
+        { "kind" : "IdRef", "name" : "Value", "quantifier" : "?" }
       ]
     },
     {
       "opname" : "DebugMacroUndef",
       "opcode" : 33,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Source'" },
-        { "kind" : "LiteralInteger", "name" : "'Line'" },
-        { "kind" : "IdRef", "name" : "'Macro'" }
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "LiteralInteger", "name" : "Line" },
+        { "kind" : "IdRef", "name" : "Macro" }
       ]
     },
     {
       "opname" : "DebugImportedEntity",
       "opcode" : 34,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Name'" },
-        { "kind" : "DebugImportedEntity", "name" : "'Tag'" },
-        { "kind" : "IdRef", "name" : "'Source'" },
-        { "kind" : "IdRef", "name" : "'Entity'" },
-        { "kind" : "LiteralInteger", "name" : "'Line'" },
-        { "kind" : "LiteralInteger", "name" : "'Column'" },
-        { "kind" : "IdRef", "name" : "'Parent'" }
+        { "kind" : "IdRef", "name" : "Name" },
+        { "kind" : "DebugImportedEntity", "name" : "Tag" },
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "IdRef", "name" : "Entity" },
+        { "kind" : "LiteralInteger", "name" : "Line" },
+        { "kind" : "LiteralInteger", "name" : "Column" },
+        { "kind" : "IdRef", "name" : "Parent" }
       ]
     },
     {
       "opname" : "DebugSource",
       "opcode" : 35,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'File'" },
-        { "kind" : "IdRef", "name" : "'Text'", "quantifier" : "?" }
+        { "kind" : "IdRef", "name" : "File" },
+        { "kind" : "IdRef", "name" : "Text", "quantifier" : "?" }
       ]
     },
     {
       "opname" : "DebugModuleINTEL",
       "opcode" : 36,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Name'" },
-        { "kind" : "IdRef", "name" : "'Source'" },
-        { "kind" : "IdRef", "name" : "'Parent'" },
-        { "kind" : "LiteralInteger", "name" : "'Line'" },
-        { "kind" : "IdRef", "name" : "'ConfigurationMacros'" },
-        { "kind" : "IdRef", "name" : "'IncludePath'" },
-        { "kind" : "IdRef", "name" : "'APINotesFile'" },
-        { "kind" : "LiteralInteger", "name" : "'IsDeclaration'" }
+        { "kind" : "IdRef", "name" : "Name" },
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "IdRef", "name" : "Parent" },
+        { "kind" : "LiteralInteger", "name" : "Line" },
+        { "kind" : "IdRef", "name" : "ConfigurationMacros" },
+        { "kind" : "IdRef", "name" : "IncludePath" },
+        { "kind" : "IdRef", "name" : "APINotesFile" },
+        { "kind" : "LiteralInteger", "name" : "IsDeclaration" }
       ],
       "capability" : "DebugInfoModuleINTEL"
     }

--- a/include/spirv/unified1/extinst.opencl.std.100.grammar.json
+++ b/include/spirv/unified1/extinst.opencl.std.100.grammar.json
@@ -31,1248 +31,1248 @@
       "opname" : "acos",
       "opcode" : 0,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "acosh",
       "opcode" : 1,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "acospi",
       "opcode" : 2,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "asin",
       "opcode" : 3,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "asinh",
       "opcode" : 4,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "asinpi",
       "opcode" : 5,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "atan",
       "opcode" : 6,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "atan2",
       "opcode" : 7,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'y'" },
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "y" },
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "atanh",
       "opcode" : 8,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "atanpi",
       "opcode" : 9,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "atan2pi",
       "opcode" : 10,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'y'" },
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "y" },
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "cbrt",
       "opcode" : 11,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "ceil",
       "opcode" : 12,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "copysign",
       "opcode" : 13,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" }
       ]
     },
     {
       "opname" : "cos",
       "opcode" : 14,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "cosh",
       "opcode" : 15,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "cospi",
       "opcode" : 16,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "erfc",
       "opcode" : 17,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "erf",
       "opcode" : 18,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "exp",
       "opcode" : 19,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "exp2",
       "opcode" : 20,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "exp10",
       "opcode" : 21,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "expm1",
       "opcode" : 22,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "fabs",
       "opcode" : 23,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "fdim",
       "opcode" : 24,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" }
       ]
     },
     {
       "opname" : "floor",
       "opcode" : 25,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "fma",
       "opcode" : 26,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'a'" },
-        { "kind" : "IdRef", "name" : "'b'" },
-        { "kind" : "IdRef", "name" : "'c'" }
+        { "kind" : "IdRef", "name" : "a" },
+        { "kind" : "IdRef", "name" : "b" },
+        { "kind" : "IdRef", "name" : "c" }
       ]
     },
     {
       "opname" : "fmax",
       "opcode" : 27,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" }
       ]
     },
     {
       "opname" : "fmin",
       "opcode" : 28,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" }
       ]
     },
     {
       "opname" : "fmod",
       "opcode" : 29,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" }
       ]
     },
     {
       "opname" : "fract",
       "opcode" : 30,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'ptr'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "ptr" }
       ]
     },
     {
       "opname" : "frexp",
       "opcode" : 31,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'exp'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "exp" }
       ]
     },
     {
       "opname" : "hypot",
       "opcode" : 32,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" }
       ]
     },
     {
       "opname" : "ilogb",
       "opcode" : 33,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "ldexp",
       "opcode" : 34,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'k'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "k" }
       ]
     },
     {
       "opname" : "lgamma",
       "opcode" : 35,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "lgamma_r",
       "opcode" : 36,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'signp'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "signp" }
       ]
     },
     {
       "opname" : "log",
       "opcode" : 37,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "log2",
       "opcode" : 38,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "log10",
       "opcode" : 39,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "log1p",
       "opcode" : 40,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "logb",
       "opcode" : 41,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "mad",
       "opcode" : 42,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'a'" },
-        { "kind" : "IdRef", "name" : "'b'" },
-        { "kind" : "IdRef", "name" : "'c'" }
+        { "kind" : "IdRef", "name" : "a" },
+        { "kind" : "IdRef", "name" : "b" },
+        { "kind" : "IdRef", "name" : "c" }
       ]
     },
     {
       "opname" : "maxmag",
       "opcode" : 43,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" }
       ]
     },
     {
       "opname" : "minmag",
       "opcode" : 44,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" }
       ]
     },
     {
       "opname" : "modf",
       "opcode" : 45,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'iptr'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "iptr" }
       ]
     },
     {
       "opname" : "nan",
       "opcode" : 46,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'nancode'" }
+        { "kind" : "IdRef", "name" : "nancode" }
       ]
     },
     {
       "opname" : "nextafter",
       "opcode" : 47,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" }
       ]
     },
     {
       "opname" : "pow",
       "opcode" : 48,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" }
       ]
     },
     {
       "opname" : "pown",
       "opcode" : 49,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" }
       ]
     },
     {
       "opname" : "powr",
       "opcode" : 50,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" }
       ]
     },
     {
       "opname" : "remainder",
       "opcode" : 51,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" }
       ]
     },
     {
       "opname" : "remquo",
       "opcode" : 52,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" },
-        { "kind" : "IdRef", "name" : "'quo'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" },
+        { "kind" : "IdRef", "name" : "quo" }
       ]
     },
     {
       "opname" : "rint",
       "opcode" : 53,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "rootn",
       "opcode" : 54,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" }
       ]
     },
     {
       "opname" : "round",
       "opcode" : 55,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "rsqrt",
       "opcode" : 56,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "sin",
       "opcode" : 57,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "sincos",
       "opcode" : 58,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'cosval'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "cosval" }
       ]
     },
     {
       "opname" : "sinh",
       "opcode" : 59,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "sinpi",
       "opcode" : 60,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "sqrt",
       "opcode" : 61,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "tan",
       "opcode" : 62,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "tanh",
       "opcode" : 63,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "tanpi",
       "opcode" : 64,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "tgamma",
       "opcode" : 65,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "trunc",
       "opcode" : 66,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "half_cos",
       "opcode" : 67,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "half_divide",
       "opcode" : 68,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" }
       ]
     },
     {
       "opname" : "half_exp",
       "opcode" : 69,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "half_exp2",
       "opcode" : 70,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "half_exp10",
       "opcode" : 71,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "half_log",
       "opcode" : 72,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "half_log2",
       "opcode" : 73,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "half_log10",
       "opcode" : 74,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "half_powr",
       "opcode" : 75,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" }
       ]
     },
     {
       "opname" : "half_recip",
       "opcode" : 76,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "half_rsqrt",
       "opcode" : 77,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "half_sin",
       "opcode" : 78,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "half_sqrt",
       "opcode" : 79,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "half_tan",
       "opcode" : 80,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "native_cos",
       "opcode" : 81,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "native_divide",
       "opcode" : 82,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" }
       ]
     },
     {
       "opname" : "native_exp",
       "opcode" : 83,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "native_exp2",
       "opcode" : 84,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "native_exp10",
       "opcode" : 85,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "native_log",
       "opcode" : 86,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "native_log2",
       "opcode" : 87,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "native_log10",
       "opcode" : 88,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "native_powr",
       "opcode" : 89,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" }
       ]
     },
     {
       "opname" : "native_recip",
       "opcode" : 90,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "native_rsqrt",
       "opcode" : 91,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "native_sin",
       "opcode" : 92,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "native_sqrt",
       "opcode" : 93,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "native_tan",
       "opcode" : 94,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "s_abs",
       "opcode" : 141,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "s_abs_diff",
       "opcode" : 142,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" }
       ]
     },
     {
       "opname" : "s_add_sat",
       "opcode" : 143,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" }
       ]
     },
     {
       "opname" : "u_add_sat",
       "opcode" : 144,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" }
       ]
     },
     {
       "opname" : "s_hadd",
       "opcode" : 145,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" }
       ]
     },
     {
       "opname" : "u_hadd",
       "opcode" : 146,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" }
       ]
     },
     {
       "opname" : "s_rhadd",
       "opcode" : 147,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" }
       ]
     },
     {
       "opname" : "u_rhadd",
       "opcode" : 148,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" }
       ]
     },
     {
       "opname" : "s_clamp",
       "opcode" : 149,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'minval'" },
-        { "kind" : "IdRef", "name" : "'maxval'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "minval" },
+        { "kind" : "IdRef", "name" : "maxval" }
       ]
     },
     {
       "opname" : "u_clamp",
       "opcode" : 150,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'minval'" },
-        { "kind" : "IdRef", "name" : "'maxval'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "minval" },
+        { "kind" : "IdRef", "name" : "maxval" }
       ]
     },
     {
       "opname" : "clz",
       "opcode" : 151,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "ctz",
       "opcode" : 152,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "s_mad_hi",
       "opcode" : 153,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'a'" },
-        { "kind" : "IdRef", "name" : "'b'" },
-        { "kind" : "IdRef", "name" : "'c'" }
+        { "kind" : "IdRef", "name" : "a" },
+        { "kind" : "IdRef", "name" : "b" },
+        { "kind" : "IdRef", "name" : "c" }
       ]
     },
     {
       "opname" : "u_mad_sat",
       "opcode" : 154,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" },
-        { "kind" : "IdRef", "name" : "'z'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" },
+        { "kind" : "IdRef", "name" : "z" }
       ]
     },
     {
       "opname" : "s_mad_sat",
       "opcode" : 155,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" },
-        { "kind" : "IdRef", "name" : "'z'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" },
+        { "kind" : "IdRef", "name" : "z" }
       ]
     },
     {
       "opname" : "s_max",
       "opcode" : 156,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" }
       ]
     },
     {
       "opname" : "u_max",
       "opcode" : 157,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" }
       ]
     },
     {
       "opname" : "s_min",
       "opcode" : 158,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" }
       ]
     },
     {
       "opname" : "u_min",
       "opcode" : 159,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" }
       ]
     },
     {
       "opname" : "s_mul_hi",
       "opcode" : 160,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" }
       ]
     },
     {
       "opname" : "rotate",
       "opcode" : 161,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'v'" },
-        { "kind" : "IdRef", "name" : "'i'" }
+        { "kind" : "IdRef", "name" : "v" },
+        { "kind" : "IdRef", "name" : "i" }
       ]
     },
     {
       "opname" : "s_sub_sat",
       "opcode" : 162,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" }
       ]
     },
     {
       "opname" : "u_sub_sat",
       "opcode" : 163,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" }
       ]
     },
     {
       "opname" : "u_upsample",
       "opcode" : 164,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'hi'" },
-        { "kind" : "IdRef", "name" : "'lo'" }
+        { "kind" : "IdRef", "name" : "hi" },
+        { "kind" : "IdRef", "name" : "lo" }
       ]
     },
     {
       "opname" : "s_upsample",
       "opcode" : 165,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'hi'" },
-        { "kind" : "IdRef", "name" : "'lo'" }
+        { "kind" : "IdRef", "name" : "hi" },
+        { "kind" : "IdRef", "name" : "lo" }
       ]
     },
     {
       "opname" : "popcount",
       "opcode" : 166,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "s_mad24",
       "opcode" : 167,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" },
-        { "kind" : "IdRef", "name" : "'z'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" },
+        { "kind" : "IdRef", "name" : "z" }
       ]
     },
     {
       "opname" : "u_mad24",
       "opcode" : 168,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" },
-        { "kind" : "IdRef", "name" : "'z'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" },
+        { "kind" : "IdRef", "name" : "z" }
       ]
     },
     {
       "opname" : "s_mul24",
       "opcode" : 169,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" }
       ]
     },
     {
       "opname" : "u_mul24",
       "opcode" : 170,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" }
       ]
     },
     {
       "opname" : "u_abs",
       "opcode" : 201,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "u_abs_diff",
       "opcode" : 202,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" }
       ]
     },
     {
       "opname" : "u_mul_hi",
       "opcode" : 203,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" }
       ]
     },
     {
       "opname" : "u_mad_hi",
       "opcode" : 204,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'a'" },
-        { "kind" : "IdRef", "name" : "'b'" },
-        { "kind" : "IdRef", "name" : "'c'" }
+        { "kind" : "IdRef", "name" : "a" },
+        { "kind" : "IdRef", "name" : "b" },
+        { "kind" : "IdRef", "name" : "c" }
       ]
     },
     {
       "opname" : "fclamp",
       "opcode" : 95,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'minval'" },
-        { "kind" : "IdRef", "name" : "'maxval'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "minval" },
+        { "kind" : "IdRef", "name" : "maxval" }
       ]
     },
     {
       "opname" : "degrees",
       "opcode" :96,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'radians'" }
+        { "kind" : "IdRef", "name" : "radians" }
       ]
     },
     {
       "opname" : "fmax_common",
       "opcode" : 97,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" }
       ]
     },
     {
       "opname" : "fmin_common",
       "opcode" : 98,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" }
       ]
     },
     {
       "opname" : "mix",
       "opcode" : 99,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" },
-        { "kind" : "IdRef", "name" : "'a'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" },
+        { "kind" : "IdRef", "name" : "a" }
       ]
     },
     {
       "opname" : "radians",
       "opcode" : 100,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'degrees'" }
+        { "kind" : "IdRef", "name" : "degrees" }
       ]
     },
     {
       "opname" : "step",
       "opcode" : 101,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'edge'" },
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "edge" },
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "smoothstep",
       "opcode" : 102,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'edge0'" },
-        { "kind" : "IdRef", "name" : "'edge1'" },
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "edge0" },
+        { "kind" : "IdRef", "name" : "edge1" },
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "sign",
       "opcode" : 103,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" }
+        { "kind" : "IdRef", "name" : "x" }
       ]
     },
     {
       "opname" : "cross",
       "opcode" : 104,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'p0'" },
-        { "kind" : "IdRef", "name" : "'p1'" }
+        { "kind" : "IdRef", "name" : "p0" },
+        { "kind" : "IdRef", "name" : "p1" }
       ]
     },
     {
       "opname" : "distance",
       "opcode" : 105,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'p0'" },
-        { "kind" : "IdRef", "name" : "'p1'" }
+        { "kind" : "IdRef", "name" : "p0" },
+        { "kind" : "IdRef", "name" : "p1" }
       ]
     },
     {
       "opname" : "length",
       "opcode" : 106,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'p'" }
+        { "kind" : "IdRef", "name" : "p" }
       ]
     },
     {
       "opname" : "normalize",
       "opcode" : 107,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'p'" }
+        { "kind" : "IdRef", "name" : "p" }
       ]
     },
     {
       "opname" : "fast_distance",
       "opcode" : 108,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'p0'" },
-        { "kind" : "IdRef", "name" : "'p1'" }
+        { "kind" : "IdRef", "name" : "p0" },
+        { "kind" : "IdRef", "name" : "p1" }
       ]
     },
     {
       "opname" : "fast_length",
       "opcode" : 109,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'p'" }
+        { "kind" : "IdRef", "name" : "p" }
       ]
     },
     {
       "opname" : "fast_normalize",
       "opcode" : 110,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'p'" }
+        { "kind" : "IdRef", "name" : "p" }
       ]
     },
     {
       "opname" : "bitselect",
       "opcode" : 186,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'a'" },
-        { "kind" : "IdRef", "name" : "'b'" },
-        { "kind" : "IdRef", "name" : "'c'" }
+        { "kind" : "IdRef", "name" : "a" },
+        { "kind" : "IdRef", "name" : "b" },
+        { "kind" : "IdRef", "name" : "c" }
       ]
     },
     {
       "opname" : "select",
       "opcode" : 187,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'a'" },
-        { "kind" : "IdRef", "name" : "'b'" },
-        { "kind" : "IdRef", "name" : "'c'" }
+        { "kind" : "IdRef", "name" : "a" },
+        { "kind" : "IdRef", "name" : "b" },
+        { "kind" : "IdRef", "name" : "c" }
       ]
     },
     {
       "opname" : "vloadn",
       "opcode" : 171,
       "operands" : [
-        { "kind" : "IdRef",          "name" : "'offset'" },
-        { "kind" : "IdRef",          "name" : "'p'" },
-        { "kind" : "LiteralInteger", "name" : "'n'" }
+        { "kind" : "IdRef",          "name" : "offset" },
+        { "kind" : "IdRef",          "name" : "p" },
+        { "kind" : "LiteralInteger", "name" : "n" }
       ]
     },
     {
       "opname" : "vstoren",
       "opcode" : 172,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'data'" },
-        { "kind" : "IdRef", "name" : "'offset'" },
-        { "kind" : "IdRef", "name" : "'p'" }
+        { "kind" : "IdRef", "name" : "data" },
+        { "kind" : "IdRef", "name" : "offset" },
+        { "kind" : "IdRef", "name" : "p" }
       ]
     },
     {
       "opname" : "vload_half",
       "opcode" : 173,
       "operands" : [
-        { "kind" : "IdRef",          "name" : "'offset'" },
-        { "kind" : "IdRef",          "name" : "'p'" }
+        { "kind" : "IdRef",          "name" : "offset" },
+        { "kind" : "IdRef",          "name" : "p" }
       ]
     },
     {
       "opname" : "vload_halfn",
       "opcode" : 174,
       "operands" : [
-        { "kind" : "IdRef",          "name" : "'offset'" },
-        { "kind" : "IdRef",          "name" : "'p'" },
-        { "kind" : "LiteralInteger", "name" : "'n'" }
+        { "kind" : "IdRef",          "name" : "offset" },
+        { "kind" : "IdRef",          "name" : "p" },
+        { "kind" : "LiteralInteger", "name" : "n" }
       ]
     },
     {
       "opname" : "vstore_half",
       "opcode" : 175,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'data'" },
-        { "kind" : "IdRef", "name" : "'offset'" },
-        { "kind" : "IdRef", "name" : "'p'" }
+        { "kind" : "IdRef", "name" : "data" },
+        { "kind" : "IdRef", "name" : "offset" },
+        { "kind" : "IdRef", "name" : "p" }
       ]
     },
     {
       "opname" : "vstore_half_r",
       "opcode" : 176,
       "operands" : [
-        { "kind" : "IdRef",          "name" : "'data'" },
-        { "kind" : "IdRef",          "name" : "'offset'" },
-        { "kind" : "IdRef",          "name" : "'p'" },
-        { "kind" : "FPRoundingMode", "name" : "'mode'" }
+        { "kind" : "IdRef",          "name" : "data" },
+        { "kind" : "IdRef",          "name" : "offset" },
+        { "kind" : "IdRef",          "name" : "p" },
+        { "kind" : "FPRoundingMode", "name" : "mode" }
       ]
     },
     {
       "opname" : "vstore_halfn",
       "opcode" : 177,
       "operands" : [
-        { "kind" : "IdRef",          "name" : "'data'" },
-        { "kind" : "IdRef",          "name" : "'offset'" },
-        { "kind" : "IdRef",          "name" : "'p'" }
+        { "kind" : "IdRef",          "name" : "data" },
+        { "kind" : "IdRef",          "name" : "offset" },
+        { "kind" : "IdRef",          "name" : "p" }
       ]
     },
     {
       "opname" : "vstore_halfn_r",
       "opcode" : 178,
       "operands" : [
-        { "kind" : "IdRef",          "name" : "'data'" },
-        { "kind" : "IdRef",          "name" : "'offset'" },
-        { "kind" : "IdRef",          "name" : "'p'" },
-        { "kind" : "FPRoundingMode", "name" : "'mode'" }
+        { "kind" : "IdRef",          "name" : "data" },
+        { "kind" : "IdRef",          "name" : "offset" },
+        { "kind" : "IdRef",          "name" : "p" },
+        { "kind" : "FPRoundingMode", "name" : "mode" }
       ]
     },
     {
       "opname" : "vloada_halfn",
       "opcode" : 179,
       "operands" : [
-        { "kind" : "IdRef",          "name" : "'offset'" },
-        { "kind" : "IdRef",          "name" : "'p'" },
-        { "kind" : "LiteralInteger", "name" : "'n'" }
+        { "kind" : "IdRef",          "name" : "offset" },
+        { "kind" : "IdRef",          "name" : "p" },
+        { "kind" : "LiteralInteger", "name" : "n" }
       ]
     },
     {
       "opname" : "vstorea_halfn",
       "opcode" : 180,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'data'" },
-        { "kind" : "IdRef", "name" : "'offset'" },
-        { "kind" : "IdRef", "name" : "'p'" }
+        { "kind" : "IdRef", "name" : "data" },
+        { "kind" : "IdRef", "name" : "offset" },
+        { "kind" : "IdRef", "name" : "p" }
       ]
     },
     {
       "opname" : "vstorea_halfn_r",
       "opcode" : 181,
       "operands" : [
-        { "kind" : "IdRef",          "name" : "'data'" },
-        { "kind" : "IdRef",          "name" : "'offset'" },
-        { "kind" : "IdRef",          "name" : "'p'" },
-        { "kind" : "FPRoundingMode", "name" : "'mode'" }
+        { "kind" : "IdRef",          "name" : "data" },
+        { "kind" : "IdRef",          "name" : "offset" },
+        { "kind" : "IdRef",          "name" : "p" },
+        { "kind" : "FPRoundingMode", "name" : "mode" }
       ]
     },
     {
       "opname" : "shuffle",
       "opcode" : 182,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'shuffle mask'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "shuffle mask" }
       ]
     },
     {
       "opname" : "shuffle2",
       "opcode" : 183,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" },
-        { "kind" : "IdRef", "name" : "'shuffle mask'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" },
+        { "kind" : "IdRef", "name" : "shuffle mask" }
       ]
     },
     {
       "opname" : "printf",
       "opcode" : 184,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'format'" },
-        { "kind" : "IdRef", "name" : "'additional arguments'", "quantifier" : "*" }
+        { "kind" : "IdRef", "name" : "format" },
+        { "kind" : "IdRef", "name" : "additional arguments", "quantifier" : "*" }
       ]
     },
     {
       "opname" : "prefetch",
       "opcode" : 185,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'ptr'" },
-        { "kind" : "IdRef", "name" : "'num elements'" }
+        { "kind" : "IdRef", "name" : "ptr" },
+        { "kind" : "IdRef", "name" : "num elements" }
       ]
     }
   ]

--- a/include/spirv/unified1/extinst.spv-amd-gcn-shader.grammar.json
+++ b/include/spirv/unified1/extinst.spv-amd-gcn-shader.grammar.json
@@ -5,7 +5,7 @@
       "opname" : "CubeFaceIndexAMD",
       "opcode" : 1,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'P'" }
+        { "kind" : "IdRef", "name" : "P" }
       ],
       "extensions" : [ "SPV_AMD_gcn_shader" ]
     },
@@ -13,7 +13,7 @@
       "opname" : "CubeFaceCoordAMD",
       "opcode" : 2,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'P'" }
+        { "kind" : "IdRef", "name" : "P" }
       ],
       "extensions" : [ "SPV_AMD_gcn_shader" ]
     },

--- a/include/spirv/unified1/extinst.spv-amd-shader-ballot.grammar.json
+++ b/include/spirv/unified1/extinst.spv-amd-shader-ballot.grammar.json
@@ -5,8 +5,8 @@
       "opname" : "SwizzleInvocationsAMD",
       "opcode" : 1,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'data'" },
-        { "kind" : "IdRef", "name" : "'offset'" }
+        { "kind" : "IdRef", "name" : "data" },
+        { "kind" : "IdRef", "name" : "offset" }
       ],
       "extensions" : [ "SPV_AMD_shader_ballot" ]
     },
@@ -14,8 +14,8 @@
       "opname" : "SwizzleInvocationsMaskedAMD",
       "opcode" : 2,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'data'" },
-        { "kind" : "IdRef", "name" : "'mask'" }
+        { "kind" : "IdRef", "name" : "data" },
+        { "kind" : "IdRef", "name" : "mask" }
       ],
       "extensions" : [ "SPV_AMD_shader_ballot" ]
     },
@@ -23,9 +23,9 @@
       "opname" : "WriteInvocationAMD",
       "opcode" : 3,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'inputValue'" },
-        { "kind" : "IdRef", "name" : "'writeValue'" },
-        { "kind" : "IdRef", "name" : "'invocationIndex'" }
+        { "kind" : "IdRef", "name" : "inputValue" },
+        { "kind" : "IdRef", "name" : "writeValue" },
+        { "kind" : "IdRef", "name" : "invocationIndex" }
       ],
       "extensions" : [ "SPV_AMD_shader_ballot" ]
     },
@@ -33,7 +33,7 @@
       "opname" : "MbcntAMD",
       "opcode" : 4,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'mask'" }
+        { "kind" : "IdRef", "name" : "mask" }
       ],
       "extensions" : [ "SPV_AMD_shader_ballot" ]
     }

--- a/include/spirv/unified1/extinst.spv-amd-shader-explicit-vertex-parameter.grammar.json
+++ b/include/spirv/unified1/extinst.spv-amd-shader-explicit-vertex-parameter.grammar.json
@@ -5,8 +5,8 @@
       "opname" : "InterpolateAtVertexAMD",
       "opcode" : 1,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'interpolant'" },
-        { "kind" : "IdRef", "name" : "'vertexIdx'" }
+        { "kind" : "IdRef", "name" : "interpolant" },
+        { "kind" : "IdRef", "name" : "vertexIdx" }
       ],
       "extensions" : [ "SPV_AMD_shader_explicit_vertex_parameter" ]
     }

--- a/include/spirv/unified1/extinst.spv-amd-shader-trinary-minmax.grammar.json
+++ b/include/spirv/unified1/extinst.spv-amd-shader-trinary-minmax.grammar.json
@@ -5,9 +5,9 @@
       "opname" : "FMin3AMD",
       "opcode" : 1,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" },
-        { "kind" : "IdRef", "name" : "'z'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" },
+        { "kind" : "IdRef", "name" : "z" }
       ],
       "extensions" : [ "SPV_AMD_shader_trinary_minmax" ]
     },
@@ -15,9 +15,9 @@
       "opname" : "UMin3AMD",
       "opcode" : 2,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" },
-        { "kind" : "IdRef", "name" : "'z'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" },
+        { "kind" : "IdRef", "name" : "z" }
       ],
       "extensions" : [ "SPV_AMD_shader_trinary_minmax" ]
     },
@@ -25,9 +25,9 @@
       "opname" : "SMin3AMD",
       "opcode" : 3,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" },
-        { "kind" : "IdRef", "name" : "'z'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" },
+        { "kind" : "IdRef", "name" : "z" }
       ],
       "extensions" : [ "SPV_AMD_shader_trinary_minmax" ]
     },
@@ -35,9 +35,9 @@
       "opname" : "FMax3AMD",
       "opcode" : 4,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" },
-        { "kind" : "IdRef", "name" : "'z'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" },
+        { "kind" : "IdRef", "name" : "z" }
       ],
       "extensions" : [ "SPV_AMD_shader_trinary_minmax" ]
     },
@@ -45,9 +45,9 @@
       "opname" : "UMax3AMD",
       "opcode" : 5,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" },
-        { "kind" : "IdRef", "name" : "'z'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" },
+        { "kind" : "IdRef", "name" : "z" }
       ],
       "extensions" : [ "SPV_AMD_shader_trinary_minmax" ]
     },
@@ -55,9 +55,9 @@
       "opname" : "SMax3AMD",
       "opcode" : 6,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" },
-        { "kind" : "IdRef", "name" : "'z'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" },
+        { "kind" : "IdRef", "name" : "z" }
       ],
       "extensions" : [ "SPV_AMD_shader_trinary_minmax" ]
     },
@@ -65,9 +65,9 @@
       "opname" : "FMid3AMD",
       "opcode" : 7,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" },
-        { "kind" : "IdRef", "name" : "'z'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" },
+        { "kind" : "IdRef", "name" : "z" }
       ],
       "extensions" : [ "SPV_AMD_shader_trinary_minmax" ]
     },
@@ -75,9 +75,9 @@
       "opname" : "UMid3AMD",
       "opcode" : 8,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" },
-        { "kind" : "IdRef", "name" : "'z'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" },
+        { "kind" : "IdRef", "name" : "z" }
       ],
       "extensions" : [ "SPV_AMD_shader_trinary_minmax" ]
     },
@@ -85,9 +85,9 @@
       "opname" : "SMid3AMD",
       "opcode" : 9,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'x'" },
-        { "kind" : "IdRef", "name" : "'y'" },
-        { "kind" : "IdRef", "name" : "'z'" }
+        { "kind" : "IdRef", "name" : "x" },
+        { "kind" : "IdRef", "name" : "y" },
+        { "kind" : "IdRef", "name" : "z" }
       ],
       "extensions" : [ "SPV_AMD_shader_trinary_minmax" ]
     }

--- a/include/spirv/unified1/spirv.core.grammar.json
+++ b/include/spirv/unified1/spirv.core.grammar.json
@@ -155,7 +155,7 @@
       "class"  : "Debug",
       "opcode" : 2,
       "operands" : [
-        { "kind" : "LiteralString", "name" : "'Continued Source'" }
+        { "kind" : "LiteralString", "name" : "Continued Source" }
       ],
       "version": "1.0"
     },
@@ -165,9 +165,9 @@
       "opcode" : 3,
       "operands" : [
         { "kind" : "SourceLanguage" },
-        { "kind" : "LiteralInteger",                     "name" : "'Version'" },
-        { "kind" : "IdRef",          "quantifier" : "?", "name" : "'File'" },
-        { "kind" : "LiteralString",  "quantifier" : "?", "name" : "'Source'" }
+        { "kind" : "LiteralInteger",                     "name" : "Version" },
+        { "kind" : "IdRef",          "quantifier" : "?", "name" : "File" },
+        { "kind" : "LiteralString",  "quantifier" : "?", "name" : "Source" }
       ],
       "version": "1.0"
     },
@@ -176,7 +176,7 @@
       "class"  : "Debug",
       "opcode" : 4,
       "operands" : [
-        { "kind" : "LiteralString", "name" : "'Extension'" }
+        { "kind" : "LiteralString", "name" : "Extension" }
       ],
       "version": "1.0"
     },
@@ -185,8 +185,8 @@
       "class"  : "Debug",
       "opcode" : 5,
       "operands" : [
-        { "kind" : "IdRef",         "name" : "'Target'" },
-        { "kind" : "LiteralString", "name" : "'Name'" }
+        { "kind" : "IdRef",         "name" : "Target" },
+        { "kind" : "LiteralString", "name" : "Name" }
       ],
       "version": "1.0"
     },
@@ -195,9 +195,9 @@
       "class"  : "Debug",
       "opcode" : 6,
       "operands" : [
-        { "kind" : "IdRef",          "name" : "'Type'" },
-        { "kind" : "LiteralInteger", "name" : "'Member'" },
-        { "kind" : "LiteralString",  "name" : "'Name'" }
+        { "kind" : "IdRef",          "name" : "Type" },
+        { "kind" : "LiteralInteger", "name" : "Member" },
+        { "kind" : "LiteralString",  "name" : "Name" }
       ],
       "version": "1.0"
     },
@@ -207,7 +207,7 @@
       "opcode" : 7,
       "operands" : [
         { "kind" : "IdResult" },
-        { "kind" : "LiteralString", "name" : "'String'" }
+        { "kind" : "LiteralString", "name" : "String" }
       ],
       "version": "1.0"
     },
@@ -216,9 +216,9 @@
       "class"  : "Debug",
       "opcode" : 8,
       "operands" : [
-        { "kind" : "IdRef",          "name" : "'File'" },
-        { "kind" : "LiteralInteger", "name" : "'Line'" },
-        { "kind" : "LiteralInteger", "name" : "'Column'" }
+        { "kind" : "IdRef",          "name" : "File" },
+        { "kind" : "LiteralInteger", "name" : "Line" },
+        { "kind" : "LiteralInteger", "name" : "Column" }
       ],
       "version": "1.0"
     },
@@ -227,7 +227,7 @@
       "class"  : "Extension",
       "opcode" : 10,
       "operands" : [
-        { "kind" : "LiteralString", "name" : "'Name'" }
+        { "kind" : "LiteralString", "name" : "Name" }
       ],
       "version": "1.0"
     },
@@ -237,7 +237,7 @@
       "opcode" : 11,
       "operands" : [
         { "kind" : "IdResult" },
-        { "kind" : "LiteralString", "name" : "'Name'" }
+        { "kind" : "LiteralString", "name" : "Name" }
       ],
       "version": "1.0"
     },
@@ -248,9 +248,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",                                     "name" : "'Set'" },
-        { "kind" : "LiteralExtInstInteger",                     "name" : "'Instruction'" },
-        { "kind" : "IdRef",                 "quantifier" : "*", "name" : "'Operand 1', +\n'Operand 2', +\n..." }
+        { "kind" : "IdRef",                                     "name" : "Set" },
+        { "kind" : "LiteralExtInstInteger",                     "name" : "Instruction" },
+        { "kind" : "IdRef",                 "quantifier" : "*", "name" : "Operand 1, Operand 2, ..." }
       ],
       "version": "1.0"
     },
@@ -270,9 +270,9 @@
       "opcode" : 15,
       "operands" : [
         { "kind" : "ExecutionModel" },
-        { "kind" : "IdRef",                              "name" : "'Entry Point'" },
-        { "kind" : "LiteralString",                      "name" : "'Name'" },
-        { "kind" : "IdRef",          "quantifier" : "*", "name" : "'Interface'" }
+        { "kind" : "IdRef",                              "name" : "Entry Point" },
+        { "kind" : "LiteralString",                      "name" : "Name" },
+        { "kind" : "IdRef",          "quantifier" : "*", "name" : "Interface" }
       ],
       "version": "1.0"
     },
@@ -281,8 +281,8 @@
       "class"  : "Mode-Setting",
       "opcode" : 16,
       "operands" : [
-        { "kind" : "IdRef",         "name" : "'Entry Point'" },
-        { "kind" : "ExecutionMode", "name" : "'Mode'" }
+        { "kind" : "IdRef",         "name" : "Entry Point" },
+        { "kind" : "ExecutionMode", "name" : "Mode" }
       ],
       "version": "1.0"
     },
@@ -291,7 +291,7 @@
       "class"  : "Mode-Setting",
       "opcode" : 17,
       "operands" : [
-        { "kind" : "Capability", "name" : "'Capability'" }
+        { "kind" : "Capability", "name" : "Capability" }
       ],
       "version": "1.0"
     },
@@ -319,8 +319,8 @@
       "opcode" : 21,
       "operands" : [
         { "kind" : "IdResult" },
-        { "kind" : "LiteralInteger", "name" : "'Width'" },
-        { "kind" : "LiteralInteger", "name" : "'Signedness'" }
+        { "kind" : "LiteralInteger", "name" : "Width" },
+        { "kind" : "LiteralInteger", "name" : "Signedness" }
       ],
       "version": "1.0"
     },
@@ -330,8 +330,8 @@
       "opcode" : 22,
       "operands" : [
         { "kind" : "IdResult" },
-        { "kind" : "LiteralInteger", "name" : "'Width'" },
-        { "kind" : "FPEncoding", "quantifier" : "?", "name" : "'Floating Point Encoding'" }
+        { "kind" : "LiteralInteger", "name" : "Width" },
+        { "kind" : "FPEncoding", "quantifier" : "?", "name" : "Floating Point Encoding" }
       ],
       "version": "1.0"
     },
@@ -341,8 +341,8 @@
       "opcode" : 23,
       "operands" : [
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",          "name" : "'Component Type'" },
-        { "kind" : "LiteralInteger", "name" : "'Component Count'" }
+        { "kind" : "IdRef",          "name" : "Component Type" },
+        { "kind" : "LiteralInteger", "name" : "Component Count" }
       ],
       "version": "1.0"
     },
@@ -352,8 +352,8 @@
       "opcode" : 24,
       "operands" : [
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",          "name" : "'Column Type'" },
-        { "kind" : "LiteralInteger", "name" : "'Column Count'" }
+        { "kind" : "IdRef",          "name" : "Column Type" },
+        { "kind" : "LiteralInteger", "name" : "Column Count" }
       ],
       "capabilities" : [ "Matrix" ],
       "version": "1.0"
@@ -364,12 +364,12 @@
       "opcode" : 25,
       "operands" : [
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",                               "name" : "'Sampled Type'" },
+        { "kind" : "IdRef",                               "name" : "Sampled Type" },
         { "kind" : "Dim" },
-        { "kind" : "LiteralInteger",                      "name" : "'Depth'" },
-        { "kind" : "LiteralInteger",                      "name" : "'Arrayed'" },
-        { "kind" : "LiteralInteger",                      "name" : "'MS'" },
-        { "kind" : "LiteralInteger",                      "name" : "'Sampled'" },
+        { "kind" : "LiteralInteger",                      "name" : "Depth" },
+        { "kind" : "LiteralInteger",                      "name" : "Arrayed" },
+        { "kind" : "LiteralInteger",                      "name" : "MS" },
+        { "kind" : "LiteralInteger",                      "name" : "Sampled" },
         { "kind" : "ImageFormat" },
         { "kind" : "AccessQualifier", "quantifier" : "?" }
       ],
@@ -390,7 +390,7 @@
       "opcode" : 27,
       "operands" : [
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",    "name" : "'Image Type'" }
+        { "kind" : "IdRef",    "name" : "Image Type" }
       ],
       "version": "1.0"
     },
@@ -400,8 +400,8 @@
       "opcode" : 28,
       "operands" : [
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",    "name" : "'Element Type'" },
-        { "kind" : "IdRef",    "name" : "'Length'" }
+        { "kind" : "IdRef",    "name" : "Element Type" },
+        { "kind" : "IdRef",    "name" : "Length" }
       ],
       "version": "1.0"
     },
@@ -411,7 +411,7 @@
       "opcode" : 29,
       "operands" : [
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",    "name" : "'Element Type'" }
+        { "kind" : "IdRef",    "name" : "Element Type" }
       ],
       "capabilities" : [ "Shader" ],
       "version": "1.0"
@@ -422,7 +422,7 @@
       "opcode" : 30,
       "operands" : [
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",    "quantifier" : "*", "name" : "'Member 0 type', +\n'member 1 type', +\n..." }
+        { "kind" : "IdRef",    "quantifier" : "*", "name" : "Member 0 type, member 1 type, ..." }
       ],
       "version": "1.0"
     },
@@ -444,7 +444,7 @@
       "operands" : [
         { "kind" : "IdResult" },
         { "kind" : "StorageClass" },
-        { "kind" : "IdRef",        "name" : "'Type'" }
+        { "kind" : "IdRef",        "name" : "Type" }
       ],
       "version": "1.0"
     },
@@ -454,8 +454,8 @@
       "opcode" : 33,
       "operands" : [
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",                        "name" : "'Return Type'" },
-        { "kind" : "IdRef",    "quantifier" : "*", "name" : "'Parameter 0 Type', +\n'Parameter 1 Type', +\n..." }
+        { "kind" : "IdRef",                        "name" : "Return Type" },
+        { "kind" : "IdRef",    "quantifier" : "*", "name" : "Parameter 0 Type, Parameter 1 Type, ..." }
       ],
       "version": "1.0"
     },
@@ -505,7 +505,7 @@
       "opcode" : 38,
       "operands" : [
         { "kind" : "IdResult" },
-        { "kind" : "AccessQualifier", "name" : "'Qualifier'" }
+        { "kind" : "AccessQualifier", "name" : "Qualifier" }
       ],
       "capabilities" : [ "Pipes" ],
       "version": "1.0"
@@ -515,7 +515,7 @@
       "class"  : "Type-Declaration",
       "opcode" : 39,
       "operands" : [
-        { "kind" : "IdRef",        "name" : "'Pointer Type'" },
+        { "kind" : "IdRef",        "name" : "Pointer Type" },
         { "kind" : "StorageClass" }
       ],
       "capabilities" : [
@@ -551,7 +551,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "LiteralContextDependentNumber", "name" : "'Value'" }
+        { "kind" : "LiteralContextDependentNumber", "name" : "Value" }
       ],
       "version": "1.0"
     },
@@ -562,7 +562,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "quantifier" : "*", "name" : "'Constituents'" }
+        { "kind" : "IdRef",        "quantifier" : "*", "name" : "Constituents" }
       ],
       "version": "1.0"
     },
@@ -574,7 +574,7 @@
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
         { "kind" : "SamplerAddressingMode" },
-        { "kind" : "LiteralInteger",        "name" : "'Param'" },
+        { "kind" : "LiteralInteger",        "name" : "Param" },
         { "kind" : "SamplerFilterMode" }
       ],
       "capabilities" : [ "LiteralSampler" ],
@@ -617,7 +617,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "LiteralContextDependentNumber", "name" : "'Value'" }
+        { "kind" : "LiteralContextDependentNumber", "name" : "Value" }
       ],
       "version": "1.0"
     },
@@ -628,7 +628,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "quantifier" : "*", "name" : "'Constituents'" }
+        { "kind" : "IdRef",        "quantifier" : "*", "name" : "Constituents" }
       ],
       "version": "1.0"
     },
@@ -639,7 +639,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "LiteralSpecConstantOpInteger", "name" : "'Opcode'" }
+        { "kind" : "LiteralSpecConstantOpInteger", "name" : "Opcode" }
       ],
       "version": "1.0"
     },
@@ -651,7 +651,7 @@
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
         { "kind" : "FunctionControl" },
-        { "kind" : "IdRef",           "name" : "'Function Type'" }
+        { "kind" : "IdRef",           "name" : "Function Type" }
       ],
       "version": "1.0"
     },
@@ -678,8 +678,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",                            "name" : "'Function'" },
-        { "kind" : "IdRef",        "quantifier" : "*", "name" : "'Argument 0', +\n'Argument 1', +\n..." }
+        { "kind" : "IdRef",                            "name" : "Function" },
+        { "kind" : "IdRef",        "quantifier" : "*", "name" : "Argument 0, Argument 1, ..."}
       ],
       "version": "1.0"
     },
@@ -691,7 +691,7 @@
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
         { "kind" : "StorageClass" },
-        { "kind" : "IdRef",        "quantifier" : "?", "name" : "'Initializer'" }
+        { "kind" : "IdRef",        "quantifier" : "?", "name" : "Initializer" }
       ],
       "version": "1.0"
     },
@@ -702,9 +702,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Image'" },
-        { "kind" : "IdRef",        "name" : "'Coordinate'" },
-        { "kind" : "IdRef",        "name" : "'Sample'" }
+        { "kind" : "IdRef",        "name" : "Image" },
+        { "kind" : "IdRef",        "name" : "Coordinate" },
+        { "kind" : "IdRef",        "name" : "Sample" }
       ],
       "version": "1.0"
     },
@@ -715,7 +715,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",                            "name" : "'Pointer'" },
+        { "kind" : "IdRef",                            "name" : "Pointer" },
         { "kind" : "MemoryAccess", "quantifier" : "?" }
       ],
       "version": "1.0"
@@ -725,8 +725,8 @@
       "class"  : "Memory",
       "opcode" : 62,
       "operands" : [
-        { "kind" : "IdRef",                            "name" : "'Pointer'" },
-        { "kind" : "IdRef",                            "name" : "'Object'" },
+        { "kind" : "IdRef",                            "name" : "Pointer" },
+        { "kind" : "IdRef",                            "name" : "Object" },
         { "kind" : "MemoryAccess", "quantifier" : "?" }
       ],
       "version": "1.0"
@@ -736,8 +736,8 @@
       "class"  : "Memory",
       "opcode" : 63,
       "operands" : [
-        { "kind" : "IdRef",                            "name" : "'Target'" },
-        { "kind" : "IdRef",                            "name" : "'Source'" },
+        { "kind" : "IdRef",                            "name" : "Target" },
+        { "kind" : "IdRef",                            "name" : "Source" },
         { "kind" : "MemoryAccess", "quantifier" : "?" },
         { "kind" : "MemoryAccess", "quantifier" : "?" }
       ],
@@ -748,9 +748,9 @@
       "class"  : "Memory",
       "opcode" : 64,
       "operands" : [
-        { "kind" : "IdRef",                            "name" : "'Target'" },
-        { "kind" : "IdRef",                            "name" : "'Source'" },
-        { "kind" : "IdRef",                            "name" : "'Size'" },
+        { "kind" : "IdRef",                            "name" : "Target" },
+        { "kind" : "IdRef",                            "name" : "Source" },
+        { "kind" : "IdRef",                            "name" : "Size" },
         { "kind" : "MemoryAccess", "quantifier" : "?" },
         { "kind" : "MemoryAccess", "quantifier" : "?" }
       ],
@@ -767,8 +767,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",                            "name" : "'Base'" },
-        { "kind" : "IdRef",        "quantifier" : "*", "name" : "'Indexes'" }
+        { "kind" : "IdRef",                            "name" : "Base" },
+        { "kind" : "IdRef",        "quantifier" : "*", "name" : "Indexes" }
       ],
       "version": "1.0"
     },
@@ -779,8 +779,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",                            "name" : "'Base'" },
-        { "kind" : "IdRef",        "quantifier" : "*", "name" : "'Indexes'" }
+        { "kind" : "IdRef",                            "name" : "Base" },
+        { "kind" : "IdRef",        "quantifier" : "*", "name" : "Indexes" }
       ],
       "version": "1.0"
     },
@@ -791,9 +791,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",                            "name" : "'Base'" },
-        { "kind" : "IdRef",                            "name" : "'Element'" },
-        { "kind" : "IdRef",        "quantifier" : "*", "name" : "'Indexes'" }
+        { "kind" : "IdRef",                            "name" : "Base" },
+        { "kind" : "IdRef",                            "name" : "Element" },
+        { "kind" : "IdRef",        "quantifier" : "*", "name" : "Indexes" }
       ],
       "capabilities" : [
         "Addresses",
@@ -810,8 +810,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",          "name" : "'Structure'" },
-        { "kind" : "LiteralInteger", "name" : "'Array member'" }
+        { "kind" : "IdRef",          "name" : "Structure" },
+        { "kind" : "LiteralInteger", "name" : "Array member" }
       ],
       "capabilities" : [ "Shader" ],
       "version": "1.0"
@@ -823,7 +823,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Pointer'" }
+        { "kind" : "IdRef",        "name" : "Pointer" }
       ],
       "capabilities" : [ "Kernel" ],
       "version": "1.0"
@@ -835,9 +835,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",                            "name" : "'Base'" },
-        { "kind" : "IdRef",                            "name" : "'Element'" },
-        { "kind" : "IdRef",        "quantifier" : "*", "name" : "'Indexes'" }
+        { "kind" : "IdRef",                            "name" : "Base" },
+        { "kind" : "IdRef",                            "name" : "Element" },
+        { "kind" : "IdRef",        "quantifier" : "*", "name" : "Indexes" }
       ],
       "capabilities" : [ "Addresses" ],
       "version": "1.0"
@@ -847,7 +847,7 @@
       "class"  : "Annotation",
       "opcode" : 71,
       "operands" : [
-        { "kind" : "IdRef",      "name" : "'Target'" },
+        { "kind" : "IdRef",      "name" : "Target" },
         { "kind" : "Decoration" }
       ],
       "version": "1.0"
@@ -857,8 +857,8 @@
       "class"  : "Annotation",
       "opcode" : 72,
       "operands" : [
-        { "kind" : "IdRef",          "name" : "'Structure Type'" },
-        { "kind" : "LiteralInteger", "name" : "'Member'" },
+        { "kind" : "IdRef",          "name" : "Structure Type" },
+        { "kind" : "LiteralInteger", "name" : "Member" },
         { "kind" : "Decoration" }
       ],
       "version": "1.0"
@@ -877,8 +877,8 @@
       "class"  : "Annotation",
       "opcode" : 74,
       "operands" : [
-        { "kind" : "IdRef",                     "name" : "'Decoration Group'" },
-        { "kind" : "IdRef", "quantifier" : "*", "name" : "'Targets'" }
+        { "kind" : "IdRef",                     "name" : "Decoration Group" },
+        { "kind" : "IdRef", "quantifier" : "*", "name" : "Targets" }
       ],
       "version": "1.0"
     },
@@ -887,8 +887,8 @@
       "class"  : "Annotation",
       "opcode" : 75,
       "operands" : [
-        { "kind" : "IdRef",                                       "name" : "'Decoration Group'" },
-        { "kind" : "PairIdRefLiteralInteger", "quantifier" : "*", "name" : "'Targets'" }
+        { "kind" : "IdRef",                                       "name" : "Decoration Group" },
+        { "kind" : "PairIdRefLiteralInteger", "quantifier" : "*", "name" : "Targets" }
       ],
       "version": "1.0"
     },
@@ -899,8 +899,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Vector'" },
-        { "kind" : "IdRef",        "name" : "'Index'" }
+        { "kind" : "IdRef",        "name" : "Vector" },
+        { "kind" : "IdRef",        "name" : "Index" }
       ],
       "version": "1.0"
     },
@@ -911,9 +911,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Vector'" },
-        { "kind" : "IdRef",        "name" : "'Component'" },
-        { "kind" : "IdRef",        "name" : "'Index'" }
+        { "kind" : "IdRef",        "name" : "Vector" },
+        { "kind" : "IdRef",        "name" : "Component" },
+        { "kind" : "IdRef",        "name" : "Index" }
       ],
       "version": "1.0"
     },
@@ -924,9 +924,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",                              "name" : "'Vector 1'" },
-        { "kind" : "IdRef",                              "name" : "'Vector 2'" },
-        { "kind" : "LiteralInteger", "quantifier" : "*", "name" : "'Components'" }
+        { "kind" : "IdRef",                              "name" : "Vector 1" },
+        { "kind" : "IdRef",                              "name" : "Vector 2" },
+        { "kind" : "LiteralInteger", "quantifier" : "*", "name" : "Components" }
       ],
       "version": "1.0"
     },
@@ -937,7 +937,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "quantifier" : "*", "name" : "'Constituents'" }
+        { "kind" : "IdRef",        "quantifier" : "*", "name" : "Constituents" }
       ],
       "version": "1.0"
     },
@@ -948,8 +948,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",                              "name" : "'Composite'" },
-        { "kind" : "LiteralInteger", "quantifier" : "*", "name" : "'Indexes'" }
+        { "kind" : "IdRef",                              "name" : "Composite" },
+        { "kind" : "LiteralInteger", "quantifier" : "*", "name" : "Indexes" }
       ],
       "version": "1.0"
     },
@@ -960,9 +960,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",                              "name" : "'Object'" },
-        { "kind" : "IdRef",                              "name" : "'Composite'" },
-        { "kind" : "LiteralInteger", "quantifier" : "*", "name" : "'Indexes'" }
+        { "kind" : "IdRef",                              "name" : "Object" },
+        { "kind" : "IdRef",                              "name" : "Composite" },
+        { "kind" : "LiteralInteger", "quantifier" : "*", "name" : "Indexes" }
       ],
       "version": "1.0"
     },
@@ -973,7 +973,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand'" }
+        { "kind" : "IdRef",        "name" : "Operand" }
       ],
       "version": "1.0"
     },
@@ -984,7 +984,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Matrix'" }
+        { "kind" : "IdRef",        "name" : "Matrix" }
       ],
       "capabilities" : [ "Matrix" ],
       "version": "1.0"
@@ -996,8 +996,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Image'" },
-        { "kind" : "IdRef",        "name" : "'Sampler'" }
+        { "kind" : "IdRef",        "name" : "Image" },
+        { "kind" : "IdRef",        "name" : "Sampler" }
       ],
       "version": "1.0"
     },
@@ -1008,8 +1008,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",                             "name" : "'Sampled Image'" },
-        { "kind" : "IdRef",                             "name" : "'Coordinate'" },
+        { "kind" : "IdRef",                             "name" : "Sampled Image" },
+        { "kind" : "IdRef",                             "name" : "Coordinate" },
         { "kind" : "ImageOperands", "quantifier" : "?" }
       ],
       "capabilities" : [ "Shader" ],
@@ -1022,8 +1022,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",         "name" : "'Sampled Image'" },
-        { "kind" : "IdRef",         "name" : "'Coordinate'" },
+        { "kind" : "IdRef",         "name" : "Sampled Image" },
+        { "kind" : "IdRef",         "name" : "Coordinate" },
         { "kind" : "ImageOperands" }
       ],
       "version": "1.0"
@@ -1035,9 +1035,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",                             "name" : "'Sampled Image'" },
-        { "kind" : "IdRef",                             "name" : "'Coordinate'" },
-        { "kind" : "IdRef",                             "name" : "'D~ref~'" },
+        { "kind" : "IdRef",                             "name" : "Sampled Image" },
+        { "kind" : "IdRef",                             "name" : "Coordinate" },
+        { "kind" : "IdRef",                             "name" : "D~ref~" },
         { "kind" : "ImageOperands", "quantifier" : "?" }
       ],
       "capabilities" : [ "Shader" ],
@@ -1050,9 +1050,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",         "name" : "'Sampled Image'" },
-        { "kind" : "IdRef",         "name" : "'Coordinate'" },
-        { "kind" : "IdRef",         "name" : "'D~ref~'" },
+        { "kind" : "IdRef",         "name" : "Sampled Image" },
+        { "kind" : "IdRef",         "name" : "Coordinate" },
+        { "kind" : "IdRef",         "name" : "D~ref~" },
         { "kind" : "ImageOperands" }
       ],
       "capabilities" : [ "Shader" ],
@@ -1065,8 +1065,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",                             "name" : "'Sampled Image'" },
-        { "kind" : "IdRef",                             "name" : "'Coordinate'" },
+        { "kind" : "IdRef",                             "name" : "Sampled Image" },
+        { "kind" : "IdRef",                             "name" : "Coordinate" },
         { "kind" : "ImageOperands", "quantifier" : "?" }
       ],
       "capabilities" : [ "Shader" ],
@@ -1079,8 +1079,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",         "name" : "'Sampled Image'" },
-        { "kind" : "IdRef",         "name" : "'Coordinate'" },
+        { "kind" : "IdRef",         "name" : "Sampled Image" },
+        { "kind" : "IdRef",         "name" : "Coordinate" },
         { "kind" : "ImageOperands" }
       ],
       "capabilities" : [ "Shader" ],
@@ -1093,9 +1093,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",                             "name" : "'Sampled Image'" },
-        { "kind" : "IdRef",                             "name" : "'Coordinate'" },
-        { "kind" : "IdRef",                             "name" : "'D~ref~'" },
+        { "kind" : "IdRef",                             "name" : "Sampled Image" },
+        { "kind" : "IdRef",                             "name" : "Coordinate" },
+        { "kind" : "IdRef",                             "name" : "D~ref~" },
         { "kind" : "ImageOperands", "quantifier" : "?" }
       ],
       "capabilities" : [ "Shader" ],
@@ -1108,9 +1108,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",         "name" : "'Sampled Image'" },
-        { "kind" : "IdRef",         "name" : "'Coordinate'" },
-        { "kind" : "IdRef",         "name" : "'D~ref~'" },
+        { "kind" : "IdRef",         "name" : "Sampled Image" },
+        { "kind" : "IdRef",         "name" : "Coordinate" },
+        { "kind" : "IdRef",         "name" : "D~ref~" },
         { "kind" : "ImageOperands" }
       ],
       "capabilities" : [ "Shader" ],
@@ -1123,8 +1123,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",                             "name" : "'Image'" },
-        { "kind" : "IdRef",                             "name" : "'Coordinate'" },
+        { "kind" : "IdRef",                             "name" : "Image" },
+        { "kind" : "IdRef",                             "name" : "Coordinate" },
         { "kind" : "ImageOperands", "quantifier" : "?" }
       ],
       "version": "1.0"
@@ -1136,9 +1136,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",                             "name" : "'Sampled Image'" },
-        { "kind" : "IdRef",                             "name" : "'Coordinate'" },
-        { "kind" : "IdRef",                             "name" : "'Component'" },
+        { "kind" : "IdRef",                             "name" : "Sampled Image" },
+        { "kind" : "IdRef",                             "name" : "Coordinate" },
+        { "kind" : "IdRef",                             "name" : "Component" },
         { "kind" : "ImageOperands", "quantifier" : "?" }
       ],
       "capabilities" : [ "Shader" ],
@@ -1151,9 +1151,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",                             "name" : "'Sampled Image'" },
-        { "kind" : "IdRef",                             "name" : "'Coordinate'" },
-        { "kind" : "IdRef",                             "name" : "'D~ref~'" },
+        { "kind" : "IdRef",                             "name" : "Sampled Image" },
+        { "kind" : "IdRef",                             "name" : "Coordinate" },
+        { "kind" : "IdRef",                             "name" : "D~ref~" },
         { "kind" : "ImageOperands", "quantifier" : "?" }
       ],
       "capabilities" : [ "Shader" ],
@@ -1166,8 +1166,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",                             "name" : "'Image'" },
-        { "kind" : "IdRef",                             "name" : "'Coordinate'" },
+        { "kind" : "IdRef",                             "name" : "Image" },
+        { "kind" : "IdRef",                             "name" : "Coordinate" },
         { "kind" : "ImageOperands", "quantifier" : "?" }
       ],
       "version": "1.0"
@@ -1177,9 +1177,9 @@
       "class"  : "Image",
       "opcode" : 99,
       "operands" : [
-        { "kind" : "IdRef",                             "name" : "'Image'" },
-        { "kind" : "IdRef",                             "name" : "'Coordinate'" },
-        { "kind" : "IdRef",                             "name" : "'Texel'" },
+        { "kind" : "IdRef",                             "name" : "Image" },
+        { "kind" : "IdRef",                             "name" : "Coordinate" },
+        { "kind" : "IdRef",                             "name" : "Texel" },
         { "kind" : "ImageOperands", "quantifier" : "?" }
       ],
       "version": "1.0"
@@ -1191,7 +1191,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Sampled Image'" }
+        { "kind" : "IdRef",        "name" : "Sampled Image" }
       ],
       "version": "1.0"
     },
@@ -1202,7 +1202,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Image'" }
+        { "kind" : "IdRef",        "name" : "Image" }
       ],
       "capabilities" : [ "Kernel" ],
       "version": "1.0"
@@ -1214,7 +1214,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Image'" }
+        { "kind" : "IdRef",        "name" : "Image" }
       ],
       "capabilities" : [ "Kernel" ],
       "version": "1.0"
@@ -1226,8 +1226,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Image'" },
-        { "kind" : "IdRef",        "name" : "'Level of Detail'" }
+        { "kind" : "IdRef",        "name" : "Image" },
+        { "kind" : "IdRef",        "name" : "Level of Detail" }
       ],
       "capabilities" : [ "Kernel", "ImageQuery" ],
       "version": "1.0"
@@ -1239,7 +1239,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Image'" }
+        { "kind" : "IdRef",        "name" : "Image" }
       ],
       "capabilities" : [ "Kernel", "ImageQuery" ],
       "version": "1.0"
@@ -1251,8 +1251,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Sampled Image'" },
-        { "kind" : "IdRef",        "name" : "'Coordinate'" }
+        { "kind" : "IdRef",        "name" : "Sampled Image" },
+        { "kind" : "IdRef",        "name" : "Coordinate" }
       ],
       "capabilities" : [ "ImageQuery" ],
       "version": "1.0"
@@ -1264,7 +1264,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Image'" }
+        { "kind" : "IdRef",        "name" : "Image" }
       ],
       "capabilities" : [ "Kernel", "ImageQuery" ],
       "version": "1.0"
@@ -1276,7 +1276,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Image'" }
+        { "kind" : "IdRef",        "name" : "Image" }
       ],
       "capabilities" : [ "Kernel", "ImageQuery" ],
       "version": "1.0"
@@ -1288,7 +1288,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Float Value'" }
+        { "kind" : "IdRef",        "name" : "Float Value" }
       ],
       "version": "1.0"
     },
@@ -1299,7 +1299,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Float Value'" }
+        { "kind" : "IdRef",        "name" : "Float Value" }
       ],
       "version": "1.0"
     },
@@ -1310,7 +1310,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Signed Value'" }
+        { "kind" : "IdRef",        "name" : "Signed Value" }
       ],
       "version": "1.0"
     },
@@ -1321,7 +1321,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Unsigned Value'" }
+        { "kind" : "IdRef",        "name" : "Unsigned Value" }
       ],
       "version": "1.0"
     },
@@ -1332,7 +1332,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Unsigned Value'" }
+        { "kind" : "IdRef",        "name" : "Unsigned Value" }
       ],
       "version": "1.0"
     },
@@ -1343,7 +1343,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Signed Value'" }
+        { "kind" : "IdRef",        "name" : "Signed Value" }
       ],
       "version": "1.0"
     },
@@ -1354,7 +1354,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Float Value'" }
+        { "kind" : "IdRef",        "name" : "Float Value" }
       ],
       "version": "1.0"
     },
@@ -1365,7 +1365,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Value'" }
+        { "kind" : "IdRef",        "name" : "Value" }
       ],
       "version": "1.0"
     },
@@ -1376,7 +1376,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Pointer'" }
+        { "kind" : "IdRef",        "name" : "Pointer" }
       ],
       "capabilities" : [
         "Addresses",
@@ -1391,7 +1391,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Signed Value'" }
+        { "kind" : "IdRef",        "name" : "Signed Value" }
       ],
       "capabilities" : [ "Kernel" ],
       "version": "1.0"
@@ -1403,7 +1403,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Unsigned Value'" }
+        { "kind" : "IdRef",        "name" : "Unsigned Value" }
       ],
       "capabilities" : [ "Kernel" ],
       "version": "1.0"
@@ -1415,7 +1415,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Integer Value'" }
+        { "kind" : "IdRef",        "name" : "Integer Value" }
       ],
       "capabilities" : [
         "Addresses",
@@ -1430,7 +1430,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Pointer'" }
+        { "kind" : "IdRef",        "name" : "Pointer" }
       ],
       "capabilities" : [ "Kernel" ],
       "version": "1.0"
@@ -1442,7 +1442,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Pointer'" }
+        { "kind" : "IdRef",        "name" : "Pointer" }
       ],
       "capabilities" : [ "Kernel" ],
       "version": "1.0"
@@ -1454,8 +1454,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Pointer'" },
-        { "kind" : "StorageClass", "name" : "'Storage'" }
+        { "kind" : "IdRef",        "name" : "Pointer" },
+        { "kind" : "StorageClass", "name" : "Storage" }
       ],
       "capabilities" : [ "Kernel" ],
       "version": "1.0"
@@ -1467,7 +1467,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand'" }
+        { "kind" : "IdRef",        "name" : "Operand" }
       ],
       "version": "1.0"
     },
@@ -1478,7 +1478,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand'" }
+        { "kind" : "IdRef",        "name" : "Operand" }
       ],
       "version": "1.0"
     },
@@ -1489,7 +1489,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand'" }
+        { "kind" : "IdRef",        "name" : "Operand" }
       ],
       "version": "1.0"
     },
@@ -1500,8 +1500,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "version": "1.0"
     },
@@ -1512,8 +1512,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "version": "1.0"
     },
@@ -1524,8 +1524,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "version": "1.0"
     },
@@ -1536,8 +1536,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "version": "1.0"
     },
@@ -1548,8 +1548,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "version": "1.0"
     },
@@ -1560,8 +1560,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "version": "1.0"
     },
@@ -1572,8 +1572,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "version": "1.0"
     },
@@ -1584,8 +1584,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "version": "1.0"
     },
@@ -1596,8 +1596,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "version": "1.0"
     },
@@ -1608,8 +1608,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "version": "1.0"
     },
@@ -1620,8 +1620,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "version": "1.0"
     },
@@ -1632,8 +1632,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "version": "1.0"
     },
@@ -1644,8 +1644,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "version": "1.0"
     },
@@ -1656,8 +1656,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "version": "1.0"
     },
@@ -1668,8 +1668,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Vector'" },
-        { "kind" : "IdRef",        "name" : "'Scalar'" }
+        { "kind" : "IdRef",        "name" : "Vector" },
+        { "kind" : "IdRef",        "name" : "Scalar" }
       ],
       "version": "1.0"
     },
@@ -1680,8 +1680,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Matrix'" },
-        { "kind" : "IdRef",        "name" : "'Scalar'" }
+        { "kind" : "IdRef",        "name" : "Matrix" },
+        { "kind" : "IdRef",        "name" : "Scalar" }
       ],
       "capabilities" : [ "Matrix" ],
       "version": "1.0"
@@ -1693,8 +1693,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Vector'" },
-        { "kind" : "IdRef",        "name" : "'Matrix'" }
+        { "kind" : "IdRef",        "name" : "Vector" },
+        { "kind" : "IdRef",        "name" : "Matrix" }
       ],
       "capabilities" : [ "Matrix" ],
       "version": "1.0"
@@ -1706,8 +1706,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Matrix'" },
-        { "kind" : "IdRef",        "name" : "'Vector'" }
+        { "kind" : "IdRef",        "name" : "Matrix" },
+        { "kind" : "IdRef",        "name" : "Vector" }
       ],
       "capabilities" : [ "Matrix" ],
       "version": "1.0"
@@ -1719,8 +1719,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'LeftMatrix'" },
-        { "kind" : "IdRef",        "name" : "'RightMatrix'" }
+        { "kind" : "IdRef",        "name" : "LeftMatrix" },
+        { "kind" : "IdRef",        "name" : "RightMatrix" }
       ],
       "capabilities" : [ "Matrix" ],
       "version": "1.0"
@@ -1732,8 +1732,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Vector 1'" },
-        { "kind" : "IdRef",        "name" : "'Vector 2'" }
+        { "kind" : "IdRef",        "name" : "Vector 1" },
+        { "kind" : "IdRef",        "name" : "Vector 2" }
       ],
       "capabilities" : [ "Matrix" ],
       "version": "1.0"
@@ -1745,8 +1745,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Vector 1'" },
-        { "kind" : "IdRef",        "name" : "'Vector 2'" }
+        { "kind" : "IdRef",        "name" : "Vector 1" },
+        { "kind" : "IdRef",        "name" : "Vector 2" }
       ],
       "version": "1.0"
     },
@@ -1757,8 +1757,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "version": "1.0"
     },
@@ -1769,8 +1769,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "version": "1.0"
     },
@@ -1781,8 +1781,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "version": "1.0"
     },
@@ -1793,8 +1793,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "version": "1.0"
     },
@@ -1805,7 +1805,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Vector'" }
+        { "kind" : "IdRef",        "name" : "Vector" }
       ],
       "version": "1.0"
     },
@@ -1816,7 +1816,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Vector'" }
+        { "kind" : "IdRef",        "name" : "Vector" }
       ],
       "version": "1.0"
     },
@@ -1827,7 +1827,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'x'" }
+        { "kind" : "IdRef",        "name" : "x" }
       ],
       "version": "1.0"
     },
@@ -1838,7 +1838,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'x'" }
+        { "kind" : "IdRef",        "name" : "x" }
       ],
       "version": "1.0"
     },
@@ -1849,7 +1849,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'x'" }
+        { "kind" : "IdRef",        "name" : "x" }
       ],
       "capabilities" : [ "Kernel" ],
       "version": "1.0"
@@ -1861,7 +1861,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'x'" }
+        { "kind" : "IdRef",        "name" : "x" }
       ],
       "capabilities" : [ "Kernel" ],
       "version": "1.0"
@@ -1873,7 +1873,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'x'" }
+        { "kind" : "IdRef",        "name" : "x" }
       ],
       "capabilities" : [ "Kernel" ],
       "version": "1.0"
@@ -1885,8 +1885,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'x'" },
-        { "kind" : "IdRef",        "name" : "'y'" }
+        { "kind" : "IdRef",        "name" : "x" },
+        { "kind" : "IdRef",        "name" : "y" }
       ],
       "capabilities" : [ "Kernel" ],
       "version" : "1.0",
@@ -1899,8 +1899,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'x'" },
-        { "kind" : "IdRef",        "name" : "'y'" }
+        { "kind" : "IdRef",        "name" : "x" },
+        { "kind" : "IdRef",        "name" : "y" }
       ],
       "capabilities" : [ "Kernel" ],
       "version": "1.0"
@@ -1912,8 +1912,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'x'" },
-        { "kind" : "IdRef",        "name" : "'y'" }
+        { "kind" : "IdRef",        "name" : "x" },
+        { "kind" : "IdRef",        "name" : "y" }
       ],
       "capabilities" : [ "Kernel" ],
       "version": "1.0"
@@ -1925,8 +1925,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "version": "1.0"
     },
@@ -1937,8 +1937,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "version": "1.0"
     },
@@ -1949,8 +1949,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "version": "1.0"
     },
@@ -1961,8 +1961,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "version" : "1.0"
     },
@@ -1973,7 +1973,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand'" }
+        { "kind" : "IdRef",        "name" : "Operand" }
       ],
       "version": "1.0"
     },
@@ -1984,9 +1984,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Condition'" },
-        { "kind" : "IdRef",        "name" : "'Object 1'" },
-        { "kind" : "IdRef",        "name" : "'Object 2'" }
+        { "kind" : "IdRef",        "name" : "Condition" },
+        { "kind" : "IdRef",        "name" : "Object 1" },
+        { "kind" : "IdRef",        "name" : "Object 2" }
       ],
       "version": "1.0"
     },
@@ -1997,8 +1997,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "version": "1.0"
     },
@@ -2009,8 +2009,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "version": "1.0"
     },
@@ -2021,8 +2021,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "version": "1.0"
     },
@@ -2033,8 +2033,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "version": "1.0"
     },
@@ -2045,8 +2045,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "version": "1.0"
     },
@@ -2057,8 +2057,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "version": "1.0"
     },
@@ -2069,8 +2069,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "version": "1.0"
     },
@@ -2081,8 +2081,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "version": "1.0"
     },
@@ -2093,8 +2093,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "version": "1.0"
     },
@@ -2105,8 +2105,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "version": "1.0"
     },
@@ -2117,8 +2117,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "version": "1.0"
     },
@@ -2129,8 +2129,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "version": "1.0"
     },
@@ -2141,8 +2141,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "version": "1.0"
     },
@@ -2153,8 +2153,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "version": "1.0"
     },
@@ -2165,8 +2165,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "version": "1.0"
     },
@@ -2177,8 +2177,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "version": "1.0"
     },
@@ -2189,8 +2189,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "version": "1.0"
     },
@@ -2201,8 +2201,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "version": "1.0"
     },
@@ -2213,8 +2213,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "version": "1.0"
     },
@@ -2225,8 +2225,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "version": "1.0"
     },
@@ -2237,8 +2237,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "version": "1.0"
     },
@@ -2249,8 +2249,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "version": "1.0"
     },
@@ -2261,8 +2261,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Base'" },
-        { "kind" : "IdRef",        "name" : "'Shift'" }
+        { "kind" : "IdRef",        "name" : "Base" },
+        { "kind" : "IdRef",        "name" : "Shift" }
       ],
       "version": "1.0"
     },
@@ -2273,8 +2273,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Base'" },
-        { "kind" : "IdRef",        "name" : "'Shift'" }
+        { "kind" : "IdRef",        "name" : "Base" },
+        { "kind" : "IdRef",        "name" : "Shift" }
       ],
       "version": "1.0"
     },
@@ -2285,8 +2285,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Base'" },
-        { "kind" : "IdRef",        "name" : "'Shift'" }
+        { "kind" : "IdRef",        "name" : "Base" },
+        { "kind" : "IdRef",        "name" : "Shift" }
       ],
       "version": "1.0"
     },
@@ -2297,8 +2297,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "version": "1.0"
     },
@@ -2309,8 +2309,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "version": "1.0"
     },
@@ -2321,8 +2321,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "version": "1.0"
     },
@@ -2333,7 +2333,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand'" }
+        { "kind" : "IdRef",        "name" : "Operand" }
       ],
       "version": "1.0"
     },
@@ -2344,10 +2344,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Base'" },
-        { "kind" : "IdRef",        "name" : "'Insert'" },
-        { "kind" : "IdRef",        "name" : "'Offset'" },
-        { "kind" : "IdRef",        "name" : "'Count'" }
+        { "kind" : "IdRef",        "name" : "Base" },
+        { "kind" : "IdRef",        "name" : "Insert" },
+        { "kind" : "IdRef",        "name" : "Offset" },
+        { "kind" : "IdRef",        "name" : "Count" }
       ],
       "capabilities" : [ "Shader", "BitInstructions" ],
       "version": "1.0"
@@ -2359,9 +2359,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Base'" },
-        { "kind" : "IdRef",        "name" : "'Offset'" },
-        { "kind" : "IdRef",        "name" : "'Count'" }
+        { "kind" : "IdRef",        "name" : "Base" },
+        { "kind" : "IdRef",        "name" : "Offset" },
+        { "kind" : "IdRef",        "name" : "Count" }
       ],
       "capabilities" : [ "Shader", "BitInstructions" ],
       "version": "1.0"
@@ -2373,9 +2373,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Base'" },
-        { "kind" : "IdRef",        "name" : "'Offset'" },
-        { "kind" : "IdRef",        "name" : "'Count'" }
+        { "kind" : "IdRef",        "name" : "Base" },
+        { "kind" : "IdRef",        "name" : "Offset" },
+        { "kind" : "IdRef",        "name" : "Count" }
       ],
       "capabilities" : [ "Shader", "BitInstructions" ],
       "version": "1.0"
@@ -2387,7 +2387,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Base'" }
+        { "kind" : "IdRef",        "name" : "Base" }
       ],
       "capabilities" : [ "Shader", "BitInstructions" ],
       "version": "1.0"
@@ -2399,7 +2399,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Base'" }
+        { "kind" : "IdRef",        "name" : "Base" }
       ],
       "version": "1.0"
     },
@@ -2410,7 +2410,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'P'" }
+        { "kind" : "IdRef",        "name" : "P" }
       ],
       "capabilities" : [ "Shader" ],
       "version": "1.0"
@@ -2422,7 +2422,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'P'" }
+        { "kind" : "IdRef",        "name" : "P" }
       ],
       "capabilities" : [ "Shader" ],
       "version": "1.0"
@@ -2434,7 +2434,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'P'" }
+        { "kind" : "IdRef",        "name" : "P" }
       ],
       "capabilities" : [ "Shader" ],
       "version": "1.0"
@@ -2446,7 +2446,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'P'" }
+        { "kind" : "IdRef",        "name" : "P" }
       ],
       "capabilities" : [ "DerivativeControl" ],
       "version": "1.0"
@@ -2458,7 +2458,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'P'" }
+        { "kind" : "IdRef",        "name" : "P" }
       ],
       "capabilities" : [ "DerivativeControl" ],
       "version": "1.0"
@@ -2470,7 +2470,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'P'" }
+        { "kind" : "IdRef",        "name" : "P" }
       ],
       "capabilities" : [ "DerivativeControl" ],
       "version": "1.0"
@@ -2482,7 +2482,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'P'" }
+        { "kind" : "IdRef",        "name" : "P" }
       ],
       "capabilities" : [ "DerivativeControl" ],
       "version": "1.0"
@@ -2494,7 +2494,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'P'" }
+        { "kind" : "IdRef",        "name" : "P" }
       ],
       "capabilities" : [ "DerivativeControl" ],
       "version": "1.0"
@@ -2506,7 +2506,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'P'" }
+        { "kind" : "IdRef",        "name" : "P" }
       ],
       "capabilities" : [ "DerivativeControl" ],
       "version": "1.0"
@@ -2530,7 +2530,7 @@
       "class"  : "Primitive",
       "opcode" : 220,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Stream'" }
+        { "kind" : "IdRef", "name" : "Stream" }
       ],
       "capabilities" : [ "GeometryStreams" ],
       "version": "1.0"
@@ -2540,7 +2540,7 @@
       "class"  : "Primitive",
       "opcode" : 221,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Stream'" }
+        { "kind" : "IdRef", "name" : "Stream" }
       ],
       "capabilities" : [ "GeometryStreams" ],
       "version": "1.0"
@@ -2550,9 +2550,9 @@
       "class"  : "Barrier",
       "opcode" : 224,
       "operands" : [
-        { "kind" : "IdScope",           "name" : "'Execution'" },
-        { "kind" : "IdScope",           "name" : "'Memory'" },
-        { "kind" : "IdMemorySemantics", "name" : "'Semantics'" }
+        { "kind" : "IdScope",           "name" : "Execution" },
+        { "kind" : "IdScope",           "name" : "Memory" },
+        { "kind" : "IdMemorySemantics", "name" : "Semantics" }
       ],
       "version": "1.0"
     },
@@ -2561,8 +2561,8 @@
       "class"  : "Barrier",
       "opcode" : 225,
       "operands" : [
-        { "kind" : "IdScope",           "name" : "'Memory'" },
-        { "kind" : "IdMemorySemantics", "name" : "'Semantics'" }
+        { "kind" : "IdScope",           "name" : "Memory" },
+        { "kind" : "IdMemorySemantics", "name" : "Semantics" }
       ],
       "version": "1.0"
     },
@@ -2573,9 +2573,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",             "name" : "'Pointer'" },
-        { "kind" : "IdScope",           "name" : "'Memory'" },
-        { "kind" : "IdMemorySemantics", "name" : "'Semantics'" }
+        { "kind" : "IdRef",             "name" : "Pointer" },
+        { "kind" : "IdScope",           "name" : "Memory" },
+        { "kind" : "IdMemorySemantics", "name" : "Semantics" }
       ],
       "version": "1.0"
     },
@@ -2584,10 +2584,10 @@
       "class"  : "Atomic",
       "opcode" : 228,
       "operands" : [
-        { "kind" : "IdRef",             "name" : "'Pointer'" },
-        { "kind" : "IdScope",           "name" : "'Memory'" },
-        { "kind" : "IdMemorySemantics", "name" : "'Semantics'" },
-        { "kind" : "IdRef",             "name" : "'Value'" }
+        { "kind" : "IdRef",             "name" : "Pointer" },
+        { "kind" : "IdScope",           "name" : "Memory" },
+        { "kind" : "IdMemorySemantics", "name" : "Semantics" },
+        { "kind" : "IdRef",             "name" : "Value" }
       ],
       "version": "1.0"
     },
@@ -2598,10 +2598,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",             "name" : "'Pointer'" },
-        { "kind" : "IdScope",           "name" : "'Memory'" },
-        { "kind" : "IdMemorySemantics", "name" : "'Semantics'" },
-        { "kind" : "IdRef",             "name" : "'Value'" }
+        { "kind" : "IdRef",             "name" : "Pointer" },
+        { "kind" : "IdScope",           "name" : "Memory" },
+        { "kind" : "IdMemorySemantics", "name" : "Semantics" },
+        { "kind" : "IdRef",             "name" : "Value" }
       ],
       "version": "1.0"
     },
@@ -2612,12 +2612,12 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",             "name" : "'Pointer'" },
-        { "kind" : "IdScope",           "name" : "'Memory'" },
-        { "kind" : "IdMemorySemantics", "name" : "'Equal'" },
-        { "kind" : "IdMemorySemantics", "name" : "'Unequal'" },
-        { "kind" : "IdRef",             "name" : "'Value'" },
-        { "kind" : "IdRef",             "name" : "'Comparator'" }
+        { "kind" : "IdRef",             "name" : "Pointer" },
+        { "kind" : "IdScope",           "name" : "Memory" },
+        { "kind" : "IdMemorySemantics", "name" : "Equal" },
+        { "kind" : "IdMemorySemantics", "name" : "Unequal" },
+        { "kind" : "IdRef",             "name" : "Value" },
+        { "kind" : "IdRef",             "name" : "Comparator" }
       ],
       "version": "1.0"
     },
@@ -2628,12 +2628,12 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",             "name" : "'Pointer'" },
-        { "kind" : "IdScope",           "name" : "'Memory'" },
-        { "kind" : "IdMemorySemantics", "name" : "'Equal'" },
-        { "kind" : "IdMemorySemantics", "name" : "'Unequal'" },
-        { "kind" : "IdRef",             "name" : "'Value'" },
-        { "kind" : "IdRef",             "name" : "'Comparator'" }
+        { "kind" : "IdRef",             "name" : "Pointer" },
+        { "kind" : "IdScope",           "name" : "Memory" },
+        { "kind" : "IdMemorySemantics", "name" : "Equal" },
+        { "kind" : "IdMemorySemantics", "name" : "Unequal" },
+        { "kind" : "IdRef",             "name" : "Value" },
+        { "kind" : "IdRef",             "name" : "Comparator" }
       ],
       "capabilities" : [ "Kernel" ],
       "version" : "1.0",
@@ -2646,9 +2646,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",             "name" : "'Pointer'" },
-        { "kind" : "IdScope",           "name" : "'Memory'" },
-        { "kind" : "IdMemorySemantics", "name" : "'Semantics'" }
+        { "kind" : "IdRef",             "name" : "Pointer" },
+        { "kind" : "IdScope",           "name" : "Memory" },
+        { "kind" : "IdMemorySemantics", "name" : "Semantics" }
       ],
       "version": "1.0"
     },
@@ -2659,9 +2659,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",             "name" : "'Pointer'" },
-        { "kind" : "IdScope",           "name" : "'Memory'" },
-        { "kind" : "IdMemorySemantics", "name" : "'Semantics'" }
+        { "kind" : "IdRef",             "name" : "Pointer" },
+        { "kind" : "IdScope",           "name" : "Memory" },
+        { "kind" : "IdMemorySemantics", "name" : "Semantics" }
       ],
       "version": "1.0"
     },
@@ -2672,10 +2672,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",             "name" : "'Pointer'" },
-        { "kind" : "IdScope",           "name" : "'Memory'" },
-        { "kind" : "IdMemorySemantics", "name" : "'Semantics'" },
-        { "kind" : "IdRef",             "name" : "'Value'" }
+        { "kind" : "IdRef",             "name" : "Pointer" },
+        { "kind" : "IdScope",           "name" : "Memory" },
+        { "kind" : "IdMemorySemantics", "name" : "Semantics" },
+        { "kind" : "IdRef",             "name" : "Value" }
       ],
       "version": "1.0"
     },
@@ -2686,10 +2686,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",             "name" : "'Pointer'" },
-        { "kind" : "IdScope",           "name" : "'Memory'" },
-        { "kind" : "IdMemorySemantics", "name" : "'Semantics'" },
-        { "kind" : "IdRef",             "name" : "'Value'" }
+        { "kind" : "IdRef",             "name" : "Pointer" },
+        { "kind" : "IdScope",           "name" : "Memory" },
+        { "kind" : "IdMemorySemantics", "name" : "Semantics" },
+        { "kind" : "IdRef",             "name" : "Value" }
       ],
       "version": "1.0"
     },
@@ -2700,10 +2700,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",             "name" : "'Pointer'" },
-        { "kind" : "IdScope",           "name" : "'Memory'" },
-        { "kind" : "IdMemorySemantics", "name" : "'Semantics'" },
-        { "kind" : "IdRef",             "name" : "'Value'" }
+        { "kind" : "IdRef",             "name" : "Pointer" },
+        { "kind" : "IdScope",           "name" : "Memory" },
+        { "kind" : "IdMemorySemantics", "name" : "Semantics" },
+        { "kind" : "IdRef",             "name" : "Value" }
       ],
       "version": "1.0"
     },
@@ -2714,10 +2714,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",             "name" : "'Pointer'" },
-        { "kind" : "IdScope",           "name" : "'Memory'" },
-        { "kind" : "IdMemorySemantics", "name" : "'Semantics'" },
-        { "kind" : "IdRef",             "name" : "'Value'" }
+        { "kind" : "IdRef",             "name" : "Pointer" },
+        { "kind" : "IdScope",           "name" : "Memory" },
+        { "kind" : "IdMemorySemantics", "name" : "Semantics" },
+        { "kind" : "IdRef",             "name" : "Value" }
       ],
       "version": "1.0"
     },
@@ -2728,10 +2728,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",             "name" : "'Pointer'" },
-        { "kind" : "IdScope",           "name" : "'Memory'" },
-        { "kind" : "IdMemorySemantics", "name" : "'Semantics'" },
-        { "kind" : "IdRef",             "name" : "'Value'" }
+        { "kind" : "IdRef",             "name" : "Pointer" },
+        { "kind" : "IdScope",           "name" : "Memory" },
+        { "kind" : "IdMemorySemantics", "name" : "Semantics" },
+        { "kind" : "IdRef",             "name" : "Value" }
       ],
       "version": "1.0"
     },
@@ -2742,10 +2742,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",             "name" : "'Pointer'" },
-        { "kind" : "IdScope",           "name" : "'Memory'" },
-        { "kind" : "IdMemorySemantics", "name" : "'Semantics'" },
-        { "kind" : "IdRef",             "name" : "'Value'" }
+        { "kind" : "IdRef",             "name" : "Pointer" },
+        { "kind" : "IdScope",           "name" : "Memory" },
+        { "kind" : "IdMemorySemantics", "name" : "Semantics" },
+        { "kind" : "IdRef",             "name" : "Value" }
       ],
       "version": "1.0"
     },
@@ -2756,10 +2756,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",             "name" : "'Pointer'" },
-        { "kind" : "IdScope",           "name" : "'Memory'" },
-        { "kind" : "IdMemorySemantics", "name" : "'Semantics'" },
-        { "kind" : "IdRef",             "name" : "'Value'" }
+        { "kind" : "IdRef",             "name" : "Pointer" },
+        { "kind" : "IdScope",           "name" : "Memory" },
+        { "kind" : "IdMemorySemantics", "name" : "Semantics" },
+        { "kind" : "IdRef",             "name" : "Value" }
       ],
       "version": "1.0"
     },
@@ -2770,10 +2770,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",             "name" : "'Pointer'" },
-        { "kind" : "IdScope",           "name" : "'Memory'" },
-        { "kind" : "IdMemorySemantics", "name" : "'Semantics'" },
-        { "kind" : "IdRef",             "name" : "'Value'" }
+        { "kind" : "IdRef",             "name" : "Pointer" },
+        { "kind" : "IdScope",           "name" : "Memory" },
+        { "kind" : "IdMemorySemantics", "name" : "Semantics" },
+        { "kind" : "IdRef",             "name" : "Value" }
       ],
       "version": "1.0"
     },
@@ -2784,10 +2784,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",             "name" : "'Pointer'" },
-        { "kind" : "IdScope",           "name" : "'Memory'" },
-        { "kind" : "IdMemorySemantics", "name" : "'Semantics'" },
-        { "kind" : "IdRef",             "name" : "'Value'" }
+        { "kind" : "IdRef",             "name" : "Pointer" },
+        { "kind" : "IdScope",           "name" : "Memory" },
+        { "kind" : "IdMemorySemantics", "name" : "Semantics" },
+        { "kind" : "IdRef",             "name" : "Value" }
       ],
       "version": "1.0"
     },
@@ -2798,7 +2798,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "PairIdRefIdRef", "quantifier" : "*", "name" : "'Variable, Parent, ...'" }
+        { "kind" : "PairIdRefIdRef", "quantifier" : "*", "name" : "Variable, Parent, ..." }
       ],
       "version": "1.0"
     },
@@ -2807,8 +2807,8 @@
       "class"  : "Control-Flow",
       "opcode" : 246,
       "operands" : [
-        { "kind" : "IdRef",       "name" : "'Merge Block'" },
-        { "kind" : "IdRef",       "name" : "'Continue Target'" },
+        { "kind" : "IdRef",       "name" : "Merge Block" },
+        { "kind" : "IdRef",       "name" : "Continue Target" },
         { "kind" : "LoopControl" }
       ],
       "version": "1.0"
@@ -2818,7 +2818,7 @@
       "class"  : "Control-Flow",
       "opcode" : 247,
       "operands" : [
-        { "kind" : "IdRef",            "name" : "'Merge Block'" },
+        { "kind" : "IdRef",            "name" : "Merge Block" },
         { "kind" : "SelectionControl" }
       ],
       "version": "1.0"
@@ -2837,7 +2837,7 @@
       "class"  : "Control-Flow",
       "opcode" : 249,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Target Label'" }
+        { "kind" : "IdRef", "name" : "Target Label" }
       ],
       "version": "1.0"
     },
@@ -2846,10 +2846,10 @@
       "class"  : "Control-Flow",
       "opcode" : 250,
       "operands" : [
-        { "kind" : "IdRef",                              "name" : "'Condition'" },
-        { "kind" : "IdRef",                              "name" : "'True Label'" },
-        { "kind" : "IdRef",                              "name" : "'False Label'" },
-        { "kind" : "LiteralInteger", "quantifier" : "*", "name" : "'Branch weights'" }
+        { "kind" : "IdRef",                              "name" : "Condition" },
+        { "kind" : "IdRef",                              "name" : "True Label" },
+        { "kind" : "IdRef",                              "name" : "False Label" },
+        { "kind" : "LiteralInteger", "quantifier" : "*", "name" : "Branch weights" }
       ],
       "version": "1.0"
     },
@@ -2858,9 +2858,9 @@
       "class"  : "Control-Flow",
       "opcode" : 251,
       "operands" : [
-        { "kind" : "IdRef",                                       "name" : "'Selector'" },
-        { "kind" : "IdRef",                                       "name" : "'Default'" },
-        { "kind" : "PairLiteralIntegerIdRef", "quantifier" : "*", "name" : "'Target'" }
+        { "kind" : "IdRef",                                       "name" : "Selector" },
+        { "kind" : "IdRef",                                       "name" : "Default" },
+        { "kind" : "PairLiteralIntegerIdRef", "quantifier" : "*", "name" : "Target" }
       ],
       "version": "1.0"
     },
@@ -2882,7 +2882,7 @@
       "class"  : "Control-Flow",
       "opcode" : 254,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Value'" }
+        { "kind" : "IdRef", "name" : "Value" }
       ],
       "version": "1.0"
     },
@@ -2897,8 +2897,8 @@
       "class"  : "Control-Flow",
       "opcode" : 256,
       "operands" : [
-        { "kind" : "IdRef",          "name" : "'Pointer'" },
-        { "kind" : "LiteralInteger", "name" : "'Size'" }
+        { "kind" : "IdRef",          "name" : "Pointer" },
+        { "kind" : "LiteralInteger", "name" : "Size" }
       ],
       "capabilities" : [ "Kernel" ],
       "version": "1.0"
@@ -2908,8 +2908,8 @@
       "class"  : "Control-Flow",
       "opcode" : 257,
       "operands" : [
-        { "kind" : "IdRef",          "name" : "'Pointer'" },
-        { "kind" : "LiteralInteger", "name" : "'Size'" }
+        { "kind" : "IdRef",          "name" : "Pointer" },
+        { "kind" : "LiteralInteger", "name" : "Size" }
       ],
       "capabilities" : [ "Kernel" ],
       "version": "1.0"
@@ -2921,12 +2921,12 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope",      "name" : "'Execution'" },
-        { "kind" : "IdRef",        "name" : "'Destination'" },
-        { "kind" : "IdRef",        "name" : "'Source'" },
-        { "kind" : "IdRef",        "name" : "'Num Elements'" },
-        { "kind" : "IdRef",        "name" : "'Stride'" },
-        { "kind" : "IdRef",        "name" : "'Event'" }
+        { "kind" : "IdScope",      "name" : "Execution" },
+        { "kind" : "IdRef",        "name" : "Destination" },
+        { "kind" : "IdRef",        "name" : "Source" },
+        { "kind" : "IdRef",        "name" : "Num Elements" },
+        { "kind" : "IdRef",        "name" : "Stride" },
+        { "kind" : "IdRef",        "name" : "Event" }
       ],
       "capabilities" : [ "Kernel" ],
       "version": "1.0"
@@ -2936,9 +2936,9 @@
       "class"  : "Group",
       "opcode" : 260,
       "operands" : [
-        { "kind" : "IdScope", "name" : "'Execution'" },
-        { "kind" : "IdRef",   "name" : "'Num Events'" },
-        { "kind" : "IdRef",   "name" : "'Events List'" }
+        { "kind" : "IdScope", "name" : "Execution" },
+        { "kind" : "IdRef",   "name" : "Num Events" },
+        { "kind" : "IdRef",   "name" : "Events List" }
       ],
       "capabilities" : [ "Kernel" ],
       "version": "1.0"
@@ -2950,8 +2950,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope",      "name" : "'Execution'" },
-        { "kind" : "IdRef",        "name" : "'Predicate'" }
+        { "kind" : "IdScope",      "name" : "Execution" },
+        { "kind" : "IdRef",        "name" : "Predicate" }
       ],
       "capabilities" : [ "Groups" ],
       "version": "1.0"
@@ -2963,8 +2963,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope",      "name" : "'Execution'" },
-        { "kind" : "IdRef",        "name" : "'Predicate'" }
+        { "kind" : "IdScope",      "name" : "Execution" },
+        { "kind" : "IdRef",        "name" : "Predicate" }
       ],
       "capabilities" : [ "Groups" ],
       "version": "1.0"
@@ -2976,9 +2976,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope",      "name" : "'Execution'" },
-        { "kind" : "IdRef",        "name" : "'Value'" },
-        { "kind" : "IdRef",        "name" : "'LocalId'" }
+        { "kind" : "IdScope",      "name" : "Execution" },
+        { "kind" : "IdRef",        "name" : "Value" },
+        { "kind" : "IdRef",        "name" : "LocalId" }
       ],
       "capabilities" : [ "Groups" ],
       "version": "1.0"
@@ -2990,9 +2990,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope",        "name" : "'Execution'" },
-        { "kind" : "GroupOperation", "name" : "'Operation'" },
-        { "kind" : "IdRef",          "name" : "'X'" }
+        { "kind" : "IdScope",        "name" : "Execution" },
+        { "kind" : "GroupOperation", "name" : "Operation" },
+        { "kind" : "IdRef",          "name" : "X" }
       ],
       "capabilities" : [ "Groups" ],
       "version": "1.0"
@@ -3004,9 +3004,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope",        "name" : "'Execution'" },
-        { "kind" : "GroupOperation", "name" : "'Operation'" },
-        { "kind" : "IdRef",          "name" : "'X'" }
+        { "kind" : "IdScope",        "name" : "Execution" },
+        { "kind" : "GroupOperation", "name" : "Operation" },
+        { "kind" : "IdRef",          "name" : "X" }
       ],
       "capabilities" : [ "Groups" ],
       "version": "1.0"
@@ -3018,9 +3018,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope",        "name" : "'Execution'" },
-        { "kind" : "GroupOperation", "name" : "'Operation'" },
-        { "kind" : "IdRef",          "name" : "'X'" }
+        { "kind" : "IdScope",        "name" : "Execution" },
+        { "kind" : "GroupOperation", "name" : "Operation" },
+        { "kind" : "IdRef",          "name" : "X" }
       ],
       "capabilities" : [ "Groups" ],
       "version": "1.0"
@@ -3032,9 +3032,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope",        "name" : "'Execution'" },
-        { "kind" : "GroupOperation", "name" : "'Operation'" },
-        { "kind" : "IdRef",          "name" : "'X'" }
+        { "kind" : "IdScope",        "name" : "Execution" },
+        { "kind" : "GroupOperation", "name" : "Operation" },
+        { "kind" : "IdRef",          "name" : "X" }
       ],
       "capabilities" : [ "Groups" ],
       "version": "1.0"
@@ -3046,9 +3046,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope",        "name" : "'Execution'" },
-        { "kind" : "GroupOperation", "name" : "'Operation'" },
-        { "kind" : "IdRef",          "name" : "'X'" }
+        { "kind" : "IdScope",        "name" : "Execution" },
+        { "kind" : "GroupOperation", "name" : "Operation" },
+        { "kind" : "IdRef",          "name" : "X" }
       ],
       "capabilities" : [ "Groups" ],
       "version": "1.0"
@@ -3060,9 +3060,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope",        "name" : "'Execution'" },
-        { "kind" : "GroupOperation", "name" : "'Operation'" },
-        { "kind" : "IdRef",          "name" : "'X'" }
+        { "kind" : "IdScope",        "name" : "Execution" },
+        { "kind" : "GroupOperation", "name" : "Operation" },
+        { "kind" : "IdRef",          "name" : "X" }
       ],
       "capabilities" : [ "Groups" ],
       "version": "1.0"
@@ -3074,9 +3074,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope",        "name" : "'Execution'" },
-        { "kind" : "GroupOperation", "name" : "'Operation'" },
-        { "kind" : "IdRef",          "name" : "'X'" }
+        { "kind" : "IdScope",        "name" : "Execution" },
+        { "kind" : "GroupOperation", "name" : "Operation" },
+        { "kind" : "IdRef",          "name" : "X" }
       ],
       "capabilities" : [ "Groups" ],
       "version": "1.0"
@@ -3088,9 +3088,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope",        "name" : "'Execution'" },
-        { "kind" : "GroupOperation", "name" : "'Operation'" },
-        { "kind" : "IdRef",          "name" : "'X'" }
+        { "kind" : "IdScope",        "name" : "Execution" },
+        { "kind" : "GroupOperation", "name" : "Operation" },
+        { "kind" : "IdRef",          "name" : "X" }
       ],
       "capabilities" : [ "Groups" ],
       "version": "1.0"
@@ -3102,10 +3102,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Pipe'" },
-        { "kind" : "IdRef",        "name" : "'Pointer'" },
-        { "kind" : "IdRef",        "name" : "'Packet Size'" },
-        { "kind" : "IdRef",        "name" : "'Packet Alignment'" }
+        { "kind" : "IdRef",        "name" : "Pipe" },
+        { "kind" : "IdRef",        "name" : "Pointer" },
+        { "kind" : "IdRef",        "name" : "Packet Size" },
+        { "kind" : "IdRef",        "name" : "Packet Alignment" }
       ],
       "capabilities" : [ "Pipes" ],
       "version": "1.0"
@@ -3117,10 +3117,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Pipe'" },
-        { "kind" : "IdRef",        "name" : "'Pointer'" },
-        { "kind" : "IdRef",        "name" : "'Packet Size'" },
-        { "kind" : "IdRef",        "name" : "'Packet Alignment'" }
+        { "kind" : "IdRef",        "name" : "Pipe" },
+        { "kind" : "IdRef",        "name" : "Pointer" },
+        { "kind" : "IdRef",        "name" : "Packet Size" },
+        { "kind" : "IdRef",        "name" : "Packet Alignment" }
       ],
       "capabilities" : [ "Pipes" ],
       "version": "1.0"
@@ -3132,12 +3132,12 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Pipe'" },
-        { "kind" : "IdRef",        "name" : "'Reserve Id'" },
-        { "kind" : "IdRef",        "name" : "'Index'" },
-        { "kind" : "IdRef",        "name" : "'Pointer'" },
-        { "kind" : "IdRef",        "name" : "'Packet Size'" },
-        { "kind" : "IdRef",        "name" : "'Packet Alignment'" }
+        { "kind" : "IdRef",        "name" : "Pipe" },
+        { "kind" : "IdRef",        "name" : "Reserve Id" },
+        { "kind" : "IdRef",        "name" : "Index" },
+        { "kind" : "IdRef",        "name" : "Pointer" },
+        { "kind" : "IdRef",        "name" : "Packet Size" },
+        { "kind" : "IdRef",        "name" : "Packet Alignment" }
       ],
       "capabilities" : [ "Pipes" ],
       "version": "1.0"
@@ -3149,12 +3149,12 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Pipe'" },
-        { "kind" : "IdRef",        "name" : "'Reserve Id'" },
-        { "kind" : "IdRef",        "name" : "'Index'" },
-        { "kind" : "IdRef",        "name" : "'Pointer'" },
-        { "kind" : "IdRef",        "name" : "'Packet Size'" },
-        { "kind" : "IdRef",        "name" : "'Packet Alignment'" }
+        { "kind" : "IdRef",        "name" : "Pipe" },
+        { "kind" : "IdRef",        "name" : "Reserve Id" },
+        { "kind" : "IdRef",        "name" : "Index" },
+        { "kind" : "IdRef",        "name" : "Pointer" },
+        { "kind" : "IdRef",        "name" : "Packet Size" },
+        { "kind" : "IdRef",        "name" : "Packet Alignment" }
       ],
       "capabilities" : [ "Pipes" ],
       "version": "1.0"
@@ -3166,10 +3166,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Pipe'" },
-        { "kind" : "IdRef",        "name" : "'Num Packets'" },
-        { "kind" : "IdRef",        "name" : "'Packet Size'" },
-        { "kind" : "IdRef",        "name" : "'Packet Alignment'" }
+        { "kind" : "IdRef",        "name" : "Pipe" },
+        { "kind" : "IdRef",        "name" : "Num Packets" },
+        { "kind" : "IdRef",        "name" : "Packet Size" },
+        { "kind" : "IdRef",        "name" : "Packet Alignment" }
       ],
       "capabilities" : [ "Pipes" ],
       "version": "1.0"
@@ -3181,10 +3181,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Pipe'" },
-        { "kind" : "IdRef",        "name" : "'Num Packets'" },
-        { "kind" : "IdRef",        "name" : "'Packet Size'" },
-        { "kind" : "IdRef",        "name" : "'Packet Alignment'" }
+        { "kind" : "IdRef",        "name" : "Pipe" },
+        { "kind" : "IdRef",        "name" : "Num Packets" },
+        { "kind" : "IdRef",        "name" : "Packet Size" },
+        { "kind" : "IdRef",        "name" : "Packet Alignment" }
       ],
       "capabilities" : [ "Pipes" ],
       "version": "1.0"
@@ -3194,10 +3194,10 @@
       "class"  : "Pipe",
       "opcode" : 280,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Pipe'" },
-        { "kind" : "IdRef", "name" : "'Reserve Id'" },
-        { "kind" : "IdRef", "name" : "'Packet Size'" },
-        { "kind" : "IdRef", "name" : "'Packet Alignment'" }
+        { "kind" : "IdRef", "name" : "Pipe" },
+        { "kind" : "IdRef", "name" : "Reserve Id" },
+        { "kind" : "IdRef", "name" : "Packet Size" },
+        { "kind" : "IdRef", "name" : "Packet Alignment" }
       ],
       "capabilities" : [ "Pipes" ],
       "version": "1.0"
@@ -3207,10 +3207,10 @@
       "class"  : "Pipe",
       "opcode" : 281,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Pipe'" },
-        { "kind" : "IdRef", "name" : "'Reserve Id'" },
-        { "kind" : "IdRef", "name" : "'Packet Size'" },
-        { "kind" : "IdRef", "name" : "'Packet Alignment'" }
+        { "kind" : "IdRef", "name" : "Pipe" },
+        { "kind" : "IdRef", "name" : "Reserve Id" },
+        { "kind" : "IdRef", "name" : "Packet Size" },
+        { "kind" : "IdRef", "name" : "Packet Alignment" }
       ],
       "capabilities" : [ "Pipes" ],
       "version": "1.0"
@@ -3222,7 +3222,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Reserve Id'" }
+        { "kind" : "IdRef",        "name" : "Reserve Id" }
       ],
       "capabilities" : [ "Pipes" ],
       "version": "1.0"
@@ -3234,9 +3234,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Pipe'" },
-        { "kind" : "IdRef",        "name" : "'Packet Size'" },
-        { "kind" : "IdRef",        "name" : "'Packet Alignment'" }
+        { "kind" : "IdRef",        "name" : "Pipe" },
+        { "kind" : "IdRef",        "name" : "Packet Size" },
+        { "kind" : "IdRef",        "name" : "Packet Alignment" }
       ],
       "capabilities" : [ "Pipes" ],
       "version": "1.0"
@@ -3248,9 +3248,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Pipe'" },
-        { "kind" : "IdRef",        "name" : "'Packet Size'" },
-        { "kind" : "IdRef",        "name" : "'Packet Alignment'" }
+        { "kind" : "IdRef",        "name" : "Pipe" },
+        { "kind" : "IdRef",        "name" : "Packet Size" },
+        { "kind" : "IdRef",        "name" : "Packet Alignment" }
       ],
       "capabilities" : [ "Pipes" ],
       "version": "1.0"
@@ -3262,11 +3262,11 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope",      "name" : "'Execution'" },
-        { "kind" : "IdRef",        "name" : "'Pipe'" },
-        { "kind" : "IdRef",        "name" : "'Num Packets'" },
-        { "kind" : "IdRef",        "name" : "'Packet Size'" },
-        { "kind" : "IdRef",        "name" : "'Packet Alignment'" }
+        { "kind" : "IdScope",      "name" : "Execution" },
+        { "kind" : "IdRef",        "name" : "Pipe" },
+        { "kind" : "IdRef",        "name" : "Num Packets" },
+        { "kind" : "IdRef",        "name" : "Packet Size" },
+        { "kind" : "IdRef",        "name" : "Packet Alignment" }
       ],
       "capabilities" : [ "Pipes" ],
       "version": "1.0"
@@ -3278,11 +3278,11 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope",      "name" : "'Execution'" },
-        { "kind" : "IdRef",        "name" : "'Pipe'" },
-        { "kind" : "IdRef",        "name" : "'Num Packets'" },
-        { "kind" : "IdRef",        "name" : "'Packet Size'" },
-        { "kind" : "IdRef",        "name" : "'Packet Alignment'" }
+        { "kind" : "IdScope",      "name" : "Execution" },
+        { "kind" : "IdRef",        "name" : "Pipe" },
+        { "kind" : "IdRef",        "name" : "Num Packets" },
+        { "kind" : "IdRef",        "name" : "Packet Size" },
+        { "kind" : "IdRef",        "name" : "Packet Alignment" }
       ],
       "capabilities" : [ "Pipes" ],
       "version": "1.0"
@@ -3292,11 +3292,11 @@
       "class"  : "Pipe",
       "opcode" : 287,
       "operands" : [
-        { "kind" : "IdScope", "name" : "'Execution'" },
-        { "kind" : "IdRef",   "name" : "'Pipe'" },
-        { "kind" : "IdRef",   "name" : "'Reserve Id'" },
-        { "kind" : "IdRef",   "name" : "'Packet Size'" },
-        { "kind" : "IdRef",   "name" : "'Packet Alignment'" }
+        { "kind" : "IdScope", "name" : "Execution" },
+        { "kind" : "IdRef",   "name" : "Pipe" },
+        { "kind" : "IdRef",   "name" : "Reserve Id" },
+        { "kind" : "IdRef",   "name" : "Packet Size" },
+        { "kind" : "IdRef",   "name" : "Packet Alignment" }
       ],
       "capabilities" : [ "Pipes" ],
       "version": "1.0"
@@ -3306,11 +3306,11 @@
       "class"  : "Pipe",
       "opcode" : 288,
       "operands" : [
-        { "kind" : "IdScope", "name" : "'Execution'" },
-        { "kind" : "IdRef",   "name" : "'Pipe'" },
-        { "kind" : "IdRef",   "name" : "'Reserve Id'" },
-        { "kind" : "IdRef",   "name" : "'Packet Size'" },
-        { "kind" : "IdRef",   "name" : "'Packet Alignment'" }
+        { "kind" : "IdScope", "name" : "Execution" },
+        { "kind" : "IdRef",   "name" : "Pipe" },
+        { "kind" : "IdRef",   "name" : "Reserve Id" },
+        { "kind" : "IdRef",   "name" : "Packet Size" },
+        { "kind" : "IdRef",   "name" : "Packet Alignment" }
       ],
       "capabilities" : [ "Pipes" ],
       "version": "1.0"
@@ -3322,10 +3322,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Queue'" },
-        { "kind" : "IdRef",        "name" : "'Num Events'" },
-        { "kind" : "IdRef",        "name" : "'Wait Events'" },
-        { "kind" : "IdRef",        "name" : "'Ret Event'" }
+        { "kind" : "IdRef",        "name" : "Queue" },
+        { "kind" : "IdRef",        "name" : "Num Events" },
+        { "kind" : "IdRef",        "name" : "Wait Events" },
+        { "kind" : "IdRef",        "name" : "Ret Event" }
       ],
       "capabilities" : [ "DeviceEnqueue" ],
       "version": "1.0"
@@ -3337,17 +3337,17 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",                            "name" : "'Queue'" },
-        { "kind" : "IdRef",                            "name" : "'Flags'" },
-        { "kind" : "IdRef",                            "name" : "'ND Range'" },
-        { "kind" : "IdRef",                            "name" : "'Num Events'" },
-        { "kind" : "IdRef",                            "name" : "'Wait Events'" },
-        { "kind" : "IdRef",                            "name" : "'Ret Event'" },
-        { "kind" : "IdRef",                            "name" : "'Invoke'" },
-        { "kind" : "IdRef",                            "name" : "'Param'" },
-        { "kind" : "IdRef",                            "name" : "'Param Size'" },
-        { "kind" : "IdRef",                            "name" : "'Param Align'" },
-        { "kind" : "IdRef",        "quantifier" : "*", "name" : "'Local Size'" }
+        { "kind" : "IdRef",                            "name" : "Queue" },
+        { "kind" : "IdRef",                            "name" : "Flags" },
+        { "kind" : "IdRef",                            "name" : "ND Range" },
+        { "kind" : "IdRef",                            "name" : "Num Events" },
+        { "kind" : "IdRef",                            "name" : "Wait Events" },
+        { "kind" : "IdRef",                            "name" : "Ret Event" },
+        { "kind" : "IdRef",                            "name" : "Invoke" },
+        { "kind" : "IdRef",                            "name" : "Param" },
+        { "kind" : "IdRef",                            "name" : "Param Size" },
+        { "kind" : "IdRef",                            "name" : "Param Align" },
+        { "kind" : "IdRef",        "quantifier" : "*", "name" : "Local Size" }
       ],
       "capabilities" : [ "DeviceEnqueue" ],
       "version": "1.0"
@@ -3359,11 +3359,11 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'ND Range'" },
-        { "kind" : "IdRef",        "name" : "'Invoke'" },
-        { "kind" : "IdRef",        "name" : "'Param'" },
-        { "kind" : "IdRef",        "name" : "'Param Size'" },
-        { "kind" : "IdRef",        "name" : "'Param Align'" }
+        { "kind" : "IdRef",        "name" : "ND Range" },
+        { "kind" : "IdRef",        "name" : "Invoke" },
+        { "kind" : "IdRef",        "name" : "Param" },
+        { "kind" : "IdRef",        "name" : "Param Size" },
+        { "kind" : "IdRef",        "name" : "Param Align" }
       ],
       "capabilities" : [ "DeviceEnqueue" ],
       "version": "1.0"
@@ -3375,11 +3375,11 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'ND Range'" },
-        { "kind" : "IdRef",        "name" : "'Invoke'" },
-        { "kind" : "IdRef",        "name" : "'Param'" },
-        { "kind" : "IdRef",        "name" : "'Param Size'" },
-        { "kind" : "IdRef",        "name" : "'Param Align'" }
+        { "kind" : "IdRef",        "name" : "ND Range" },
+        { "kind" : "IdRef",        "name" : "Invoke" },
+        { "kind" : "IdRef",        "name" : "Param" },
+        { "kind" : "IdRef",        "name" : "Param Size" },
+        { "kind" : "IdRef",        "name" : "Param Align" }
       ],
       "capabilities" : [ "DeviceEnqueue" ],
       "version": "1.0"
@@ -3391,10 +3391,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Invoke'" },
-        { "kind" : "IdRef",        "name" : "'Param'" },
-        { "kind" : "IdRef",        "name" : "'Param Size'" },
-        { "kind" : "IdRef",        "name" : "'Param Align'" }
+        { "kind" : "IdRef",        "name" : "Invoke" },
+        { "kind" : "IdRef",        "name" : "Param" },
+        { "kind" : "IdRef",        "name" : "Param Size" },
+        { "kind" : "IdRef",        "name" : "Param Align" }
       ],
       "capabilities" : [ "DeviceEnqueue" ],
       "version": "1.0"
@@ -3406,10 +3406,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Invoke'" },
-        { "kind" : "IdRef",        "name" : "'Param'" },
-        { "kind" : "IdRef",        "name" : "'Param Size'" },
-        { "kind" : "IdRef",        "name" : "'Param Align'" }
+        { "kind" : "IdRef",        "name" : "Invoke" },
+        { "kind" : "IdRef",        "name" : "Param" },
+        { "kind" : "IdRef",        "name" : "Param Size" },
+        { "kind" : "IdRef",        "name" : "Param Align" }
       ],
       "capabilities" : [ "DeviceEnqueue" ],
       "version": "1.0"
@@ -3419,7 +3419,7 @@
       "class"  : "Device-Side_Enqueue",
       "opcode" : 297,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Event'" }
+        { "kind" : "IdRef", "name" : "Event" }
       ],
       "capabilities" : [ "DeviceEnqueue" ],
       "version": "1.0"
@@ -3429,7 +3429,7 @@
       "class"  : "Device-Side_Enqueue",
       "opcode" : 298,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Event'" }
+        { "kind" : "IdRef", "name" : "Event" }
       ],
       "capabilities" : [ "DeviceEnqueue" ],
       "version": "1.0"
@@ -3452,7 +3452,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Event'" }
+        { "kind" : "IdRef",        "name" : "Event" }
       ],
       "capabilities" : [ "DeviceEnqueue" ],
       "version": "1.0"
@@ -3462,8 +3462,8 @@
       "class"  : "Device-Side_Enqueue",
       "opcode" : 301,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Event'" },
-        { "kind" : "IdRef", "name" : "'Status'" }
+        { "kind" : "IdRef", "name" : "Event" },
+        { "kind" : "IdRef", "name" : "Status" }
       ],
       "capabilities" : [ "DeviceEnqueue" ],
       "version": "1.0"
@@ -3473,9 +3473,9 @@
       "class"  : "Device-Side_Enqueue",
       "opcode" : 302,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Event'" },
-        { "kind" : "IdRef", "name" : "'Profiling Info'" },
-        { "kind" : "IdRef", "name" : "'Value'" }
+        { "kind" : "IdRef", "name" : "Event" },
+        { "kind" : "IdRef", "name" : "Profiling Info" },
+        { "kind" : "IdRef", "name" : "Value" }
       ],
       "capabilities" : [ "DeviceEnqueue" ],
       "version": "1.0"
@@ -3498,9 +3498,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'GlobalWorkSize'" },
-        { "kind" : "IdRef",        "name" : "'LocalWorkSize'" },
-        { "kind" : "IdRef",        "name" : "'GlobalWorkOffset'" }
+        { "kind" : "IdRef",        "name" : "GlobalWorkSize" },
+        { "kind" : "IdRef",        "name" : "LocalWorkSize" },
+        { "kind" : "IdRef",        "name" : "GlobalWorkOffset" }
       ],
       "capabilities" : [ "DeviceEnqueue" ],
       "version": "1.0"
@@ -3512,8 +3512,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",                             "name" : "'Sampled Image'" },
-        { "kind" : "IdRef",                             "name" : "'Coordinate'" },
+        { "kind" : "IdRef",                             "name" : "Sampled Image" },
+        { "kind" : "IdRef",                             "name" : "Coordinate" },
         { "kind" : "ImageOperands", "quantifier" : "?" }
       ],
       "capabilities" : [ "SparseResidency" ],
@@ -3526,8 +3526,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",         "name" : "'Sampled Image'" },
-        { "kind" : "IdRef",         "name" : "'Coordinate'" },
+        { "kind" : "IdRef",         "name" : "Sampled Image" },
+        { "kind" : "IdRef",         "name" : "Coordinate" },
         { "kind" : "ImageOperands" }
       ],
       "capabilities" : [ "SparseResidency" ],
@@ -3540,9 +3540,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",                             "name" : "'Sampled Image'" },
-        { "kind" : "IdRef",                             "name" : "'Coordinate'" },
-        { "kind" : "IdRef",                             "name" : "'D~ref~'" },
+        { "kind" : "IdRef",                             "name" : "Sampled Image" },
+        { "kind" : "IdRef",                             "name" : "Coordinate" },
+        { "kind" : "IdRef",                             "name" : "D~ref~" },
         { "kind" : "ImageOperands", "quantifier" : "?" }
       ],
       "capabilities" : [ "SparseResidency" ],
@@ -3555,9 +3555,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",         "name" : "'Sampled Image'" },
-        { "kind" : "IdRef",         "name" : "'Coordinate'" },
-        { "kind" : "IdRef",         "name" : "'D~ref~'" },
+        { "kind" : "IdRef",         "name" : "Sampled Image" },
+        { "kind" : "IdRef",         "name" : "Coordinate" },
+        { "kind" : "IdRef",         "name" : "D~ref~" },
         { "kind" : "ImageOperands" }
       ],
       "capabilities" : [ "SparseResidency" ],
@@ -3570,8 +3570,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",                             "name" : "'Sampled Image'" },
-        { "kind" : "IdRef",                             "name" : "'Coordinate'" },
+        { "kind" : "IdRef",                             "name" : "Sampled Image" },
+        { "kind" : "IdRef",                             "name" : "Coordinate" },
         { "kind" : "ImageOperands", "quantifier" : "?" }
       ],
       "capabilities" : [ "SparseResidency" ],
@@ -3584,8 +3584,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",         "name" : "'Sampled Image'" },
-        { "kind" : "IdRef",         "name" : "'Coordinate'" },
+        { "kind" : "IdRef",         "name" : "Sampled Image" },
+        { "kind" : "IdRef",         "name" : "Coordinate" },
         { "kind" : "ImageOperands" }
       ],
       "capabilities" : [ "SparseResidency" ],
@@ -3598,9 +3598,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",                             "name" : "'Sampled Image'" },
-        { "kind" : "IdRef",                             "name" : "'Coordinate'" },
-        { "kind" : "IdRef",                             "name" : "'D~ref~'" },
+        { "kind" : "IdRef",                             "name" : "Sampled Image" },
+        { "kind" : "IdRef",                             "name" : "Coordinate" },
+        { "kind" : "IdRef",                             "name" : "D~ref~" },
         { "kind" : "ImageOperands", "quantifier" : "?" }
       ],
       "capabilities" : [ "SparseResidency" ],
@@ -3613,9 +3613,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",         "name" : "'Sampled Image'" },
-        { "kind" : "IdRef",         "name" : "'Coordinate'" },
-        { "kind" : "IdRef",         "name" : "'D~ref~'" },
+        { "kind" : "IdRef",         "name" : "Sampled Image" },
+        { "kind" : "IdRef",         "name" : "Coordinate" },
+        { "kind" : "IdRef",         "name" : "D~ref~" },
         { "kind" : "ImageOperands" }
       ],
       "capabilities" : [ "SparseResidency" ],
@@ -3628,8 +3628,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",                             "name" : "'Image'" },
-        { "kind" : "IdRef",                             "name" : "'Coordinate'" },
+        { "kind" : "IdRef",                             "name" : "Image" },
+        { "kind" : "IdRef",                             "name" : "Coordinate" },
         { "kind" : "ImageOperands", "quantifier" : "?" }
       ],
       "capabilities" : [ "SparseResidency" ],
@@ -3642,9 +3642,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",                             "name" : "'Sampled Image'" },
-        { "kind" : "IdRef",                             "name" : "'Coordinate'" },
-        { "kind" : "IdRef",                             "name" : "'Component'" },
+        { "kind" : "IdRef",                             "name" : "Sampled Image" },
+        { "kind" : "IdRef",                             "name" : "Coordinate" },
+        { "kind" : "IdRef",                             "name" : "Component" },
         { "kind" : "ImageOperands", "quantifier" : "?" }
       ],
       "capabilities" : [ "SparseResidency" ],
@@ -3657,9 +3657,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",                             "name" : "'Sampled Image'" },
-        { "kind" : "IdRef",                             "name" : "'Coordinate'" },
-        { "kind" : "IdRef",                             "name" : "'D~ref~'" },
+        { "kind" : "IdRef",                             "name" : "Sampled Image" },
+        { "kind" : "IdRef",                             "name" : "Coordinate" },
+        { "kind" : "IdRef",                             "name" : "D~ref~" },
         { "kind" : "ImageOperands", "quantifier" : "?" }
       ],
       "capabilities" : [ "SparseResidency" ],
@@ -3672,7 +3672,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Resident Code'" }
+        { "kind" : "IdRef",        "name" : "Resident Code" }
       ],
       "capabilities" : [ "SparseResidency" ],
       "version": "1.0"
@@ -3690,9 +3690,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",             "name" : "'Pointer'" },
-        { "kind" : "IdScope",           "name" : "'Memory'" },
-        { "kind" : "IdMemorySemantics", "name" : "'Semantics'" }
+        { "kind" : "IdRef",             "name" : "Pointer" },
+        { "kind" : "IdScope",           "name" : "Memory" },
+        { "kind" : "IdMemorySemantics", "name" : "Semantics" }
       ],
       "capabilities" : [ "Kernel" ],
       "version": "1.0"
@@ -3702,9 +3702,9 @@
       "class"  : "Atomic",
       "opcode" : 319,
       "operands" : [
-        { "kind" : "IdRef",             "name" : "'Pointer'" },
-        { "kind" : "IdScope",           "name" : "'Memory'" },
-        { "kind" : "IdMemorySemantics", "name" : "'Semantics'" }
+        { "kind" : "IdRef",             "name" : "Pointer" },
+        { "kind" : "IdScope",           "name" : "Memory" },
+        { "kind" : "IdMemorySemantics", "name" : "Semantics" }
       ],
       "capabilities" : [ "Kernel" ],
       "version": "1.0"
@@ -3716,8 +3716,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",                             "name" : "'Image'" },
-        { "kind" : "IdRef",                             "name" : "'Coordinate'" },
+        { "kind" : "IdRef",                             "name" : "Image" },
+        { "kind" : "IdRef",                             "name" : "Coordinate" },
         { "kind" : "ImageOperands", "quantifier" : "?" }
       ],
       "capabilities" : [ "SparseResidency" ],
@@ -3730,7 +3730,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Pointer'" }
+        { "kind" : "IdRef", "name" : "Pointer" }
       ],
       "capabilities" : [ "Addresses" ],
       "version" : "1.1"
@@ -3752,9 +3752,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "LiteralInteger", "name" : "'Packet Size'" },
-        { "kind" : "LiteralInteger", "name" : "'Packet Alignment'" },
-        { "kind" : "LiteralInteger", "name" : "'Capacity'" }
+        { "kind" : "LiteralInteger", "name" : "Packet Size" },
+        { "kind" : "LiteralInteger", "name" : "Packet Alignment" },
+        { "kind" : "LiteralInteger", "name" : "Capacity" }
       ],
       "capabilities" : [ "PipeStorage" ],
       "version" : "1.1"
@@ -3766,7 +3766,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Pipe Storage'" }
+        { "kind" : "IdRef", "name" : "Pipe Storage" }
       ],
       "capabilities" : [ "PipeStorage" ],
       "version" : "1.1"
@@ -3778,11 +3778,11 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Subgroup Count'" },
-        { "kind" : "IdRef", "name" : "'Invoke'" },
-        { "kind" : "IdRef", "name" : "'Param'" },
-        { "kind" : "IdRef", "name" : "'Param Size'" },
-        { "kind" : "IdRef", "name" : "'Param Align'" }
+        { "kind" : "IdRef", "name" : "Subgroup Count" },
+        { "kind" : "IdRef", "name" : "Invoke" },
+        { "kind" : "IdRef", "name" : "Param" },
+        { "kind" : "IdRef", "name" : "Param Size" },
+        { "kind" : "IdRef", "name" : "Param Align" }
       ],
       "capabilities" : [ "SubgroupDispatch" ],
       "version" : "1.1"
@@ -3794,10 +3794,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Invoke'" },
-        { "kind" : "IdRef", "name" : "'Param'" },
-        { "kind" : "IdRef", "name" : "'Param Size'" },
-        { "kind" : "IdRef", "name" : "'Param Align'" }
+        { "kind" : "IdRef", "name" : "Invoke" },
+        { "kind" : "IdRef", "name" : "Param" },
+        { "kind" : "IdRef", "name" : "Param Size" },
+        { "kind" : "IdRef", "name" : "Param Align" }
       ],
       "capabilities" : [ "SubgroupDispatch" ],
       "version" : "1.1"
@@ -3819,7 +3819,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Subgroup Count'" }
+        { "kind" : "IdRef", "name" : "Subgroup Count" }
       ],
       "capabilities" : [ "NamedBarrier" ],
       "version" : "1.1"
@@ -3829,9 +3829,9 @@
       "class"  : "Barrier",
       "opcode" : 329,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Named Barrier'" },
-        { "kind" : "IdScope", "name" : "'Memory'" },
-        { "kind" : "IdMemorySemantics", "name" : "'Semantics'" }
+        { "kind" : "IdRef", "name" : "Named Barrier" },
+        { "kind" : "IdScope", "name" : "Memory" },
+        { "kind" : "IdMemorySemantics", "name" : "Semantics" }
       ],
       "capabilities" : [ "NamedBarrier" ],
       "version" : "1.1"
@@ -3841,7 +3841,7 @@
       "class"  : "Debug",
       "opcode" : 330,
       "operands" : [
-        { "kind" : "LiteralString", "name" : "'Process'" }
+        { "kind" : "LiteralString", "name" : "Process" }
       ],
       "version" : "1.1"
     },
@@ -3850,8 +3850,8 @@
       "class"  : "Mode-Setting",
       "opcode" : 331,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Entry Point'" },
-        { "kind" : "ExecutionMode", "name" : "'Mode'" }
+        { "kind" : "IdRef", "name" : "Entry Point" },
+        { "kind" : "ExecutionMode", "name" : "Mode" }
       ],
       "version" : "1.2"
     },
@@ -3860,7 +3860,7 @@
       "class"  : "Annotation",
       "opcode" : 332,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Target'" },
+        { "kind" : "IdRef", "name" : "Target" },
         { "kind" : "Decoration" }
       ],
       "extensions" : [ "SPV_GOOGLE_hlsl_functionality1" ],
@@ -3873,7 +3873,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope", "name" : "'Execution'" }
+        { "kind" : "IdScope", "name" : "Execution" }
       ],
       "capabilities" : [ "GroupNonUniform" ],
       "version" : "1.3"
@@ -3885,8 +3885,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope", "name" : "'Execution'" },
-        { "kind" : "IdRef", "name" : "'Predicate'" }
+        { "kind" : "IdScope", "name" : "Execution" },
+        { "kind" : "IdRef", "name" : "Predicate" }
       ],
       "capabilities" : [ "GroupNonUniformVote" ],
       "version" : "1.3"
@@ -3898,8 +3898,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope", "name" : "'Execution'" },
-        { "kind" : "IdRef", "name" : "'Predicate'" }
+        { "kind" : "IdScope", "name" : "Execution" },
+        { "kind" : "IdRef", "name" : "Predicate" }
       ],
       "capabilities" : [ "GroupNonUniformVote" ],
       "version" : "1.3"
@@ -3911,8 +3911,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope", "name" : "'Execution'" },
-        { "kind" : "IdRef", "name" : "'Value'" }
+        { "kind" : "IdScope", "name" : "Execution" },
+        { "kind" : "IdRef", "name" : "Value" }
       ],
       "capabilities" : [ "GroupNonUniformVote" ],
       "version" : "1.3"
@@ -3924,9 +3924,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope", "name" : "'Execution'" },
-        { "kind" : "IdRef", "name" : "'Value'" },
-        { "kind" : "IdRef", "name" : "'Id'" }
+        { "kind" : "IdScope", "name" : "Execution" },
+        { "kind" : "IdRef", "name" : "Value" },
+        { "kind" : "IdRef", "name" : "Id" }
       ],
       "capabilities" : [ "GroupNonUniformBallot" ],
       "version" : "1.3"
@@ -3938,8 +3938,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope", "name" : "'Execution'" },
-        { "kind" : "IdRef", "name" : "'Value'" }
+        { "kind" : "IdScope", "name" : "Execution" },
+        { "kind" : "IdRef", "name" : "Value" }
       ],
       "capabilities" : [ "GroupNonUniformBallot" ],
       "version" : "1.3"
@@ -3951,8 +3951,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope", "name" : "'Execution'" },
-        { "kind" : "IdRef", "name" : "'Predicate'" }
+        { "kind" : "IdScope", "name" : "Execution" },
+        { "kind" : "IdRef", "name" : "Predicate" }
       ],
       "capabilities" : [ "GroupNonUniformBallot" ],
       "version" : "1.3"
@@ -3964,8 +3964,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope", "name" : "'Execution'" },
-        { "kind" : "IdRef", "name" : "'Value'" }
+        { "kind" : "IdScope", "name" : "Execution" },
+        { "kind" : "IdRef", "name" : "Value" }
       ],
       "capabilities" : [ "GroupNonUniformBallot" ],
       "version" : "1.3"
@@ -3977,9 +3977,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope", "name" : "'Execution'" },
-        { "kind" : "IdRef", "name" : "'Value'" },
-        { "kind" : "IdRef", "name" : "'Index'" }
+        { "kind" : "IdScope", "name" : "Execution" },
+        { "kind" : "IdRef", "name" : "Value" },
+        { "kind" : "IdRef", "name" : "Index" }
       ],
       "capabilities" : [ "GroupNonUniformBallot" ],
       "version" : "1.3"
@@ -3991,9 +3991,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope", "name" : "'Execution'" },
-        { "kind" : "GroupOperation", "name" : "'Operation'" },
-        { "kind" : "IdRef", "name" : "'Value'" }
+        { "kind" : "IdScope", "name" : "Execution" },
+        { "kind" : "GroupOperation", "name" : "Operation" },
+        { "kind" : "IdRef", "name" : "Value" }
       ],
       "capabilities" : [ "GroupNonUniformBallot" ],
       "version" : "1.3"
@@ -4005,8 +4005,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope", "name" : "'Execution'" },
-        { "kind" : "IdRef", "name" : "'Value'" }
+        { "kind" : "IdScope", "name" : "Execution" },
+        { "kind" : "IdRef", "name" : "Value" }
       ],
       "capabilities" : [ "GroupNonUniformBallot" ],
       "version" : "1.3"
@@ -4018,8 +4018,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope", "name" : "'Execution'" },
-        { "kind" : "IdRef", "name" : "'Value'" }
+        { "kind" : "IdScope", "name" : "Execution" },
+        { "kind" : "IdRef", "name" : "Value" }
       ],
       "capabilities" : [ "GroupNonUniformBallot" ],
       "version" : "1.3"
@@ -4031,9 +4031,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope", "name" : "'Execution'" },
-        { "kind" : "IdRef", "name" : "'Value'" },
-        { "kind" : "IdRef", "name" : "'Id'" }
+        { "kind" : "IdScope", "name" : "Execution" },
+        { "kind" : "IdRef", "name" : "Value" },
+        { "kind" : "IdRef", "name" : "Id" }
       ],
       "capabilities" : [ "GroupNonUniformShuffle" ],
       "version" : "1.3"
@@ -4045,9 +4045,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope", "name" : "'Execution'" },
-        { "kind" : "IdRef", "name" : "'Value'" },
-        { "kind" : "IdRef", "name" : "'Mask'" }
+        { "kind" : "IdScope", "name" : "Execution" },
+        { "kind" : "IdRef", "name" : "Value" },
+        { "kind" : "IdRef", "name" : "Mask" }
       ],
       "capabilities" : [ "GroupNonUniformShuffle" ],
       "version" : "1.3"
@@ -4059,9 +4059,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope", "name" : "'Execution'" },
-        { "kind" : "IdRef", "name" : "'Value'" },
-        { "kind" : "IdRef", "name" : "'Delta'" }
+        { "kind" : "IdScope", "name" : "Execution" },
+        { "kind" : "IdRef", "name" : "Value" },
+        { "kind" : "IdRef", "name" : "Delta" }
       ],
       "capabilities" : [ "GroupNonUniformShuffleRelative" ],
       "version" : "1.3"
@@ -4073,9 +4073,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope", "name" : "'Execution'" },
-        { "kind" : "IdRef", "name" : "'Value'" },
-        { "kind" : "IdRef", "name" : "'Delta'" }
+        { "kind" : "IdScope", "name" : "Execution" },
+        { "kind" : "IdRef", "name" : "Value" },
+        { "kind" : "IdRef", "name" : "Delta" }
       ],
       "capabilities" : [ "GroupNonUniformShuffleRelative" ],
       "version" : "1.3"
@@ -4087,10 +4087,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope", "name" : "'Execution'" },
-        { "kind" : "GroupOperation", "name" : "'Operation'" },
-        { "kind" : "IdRef", "name" : "'Value'" },
-        { "kind" : "IdRef", "name" : "'ClusterSize'", "quantifier" : "?" }
+        { "kind" : "IdScope", "name" : "Execution" },
+        { "kind" : "GroupOperation", "name" : "Operation" },
+        { "kind" : "IdRef", "name" : "Value" },
+        { "kind" : "IdRef", "name" : "ClusterSize", "quantifier" : "?" }
       ],
       "capabilities" : [ "GroupNonUniformArithmetic", "GroupNonUniformClustered", "GroupNonUniformPartitionedNV" ],
       "version" : "1.3"
@@ -4102,10 +4102,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope", "name" : "'Execution'" },
-        { "kind" : "GroupOperation", "name" : "'Operation'" },
-        { "kind" : "IdRef", "name" : "'Value'" },
-        { "kind" : "IdRef", "name" : "'ClusterSize'", "quantifier" : "?" }
+        { "kind" : "IdScope", "name" : "Execution" },
+        { "kind" : "GroupOperation", "name" : "Operation" },
+        { "kind" : "IdRef", "name" : "Value" },
+        { "kind" : "IdRef", "name" : "ClusterSize", "quantifier" : "?" }
       ],
       "capabilities" : [ "GroupNonUniformArithmetic", "GroupNonUniformClustered", "GroupNonUniformPartitionedNV" ],
       "version" : "1.3"
@@ -4117,10 +4117,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope", "name" : "'Execution'" },
-        { "kind" : "GroupOperation", "name" : "'Operation'" },
-        { "kind" : "IdRef", "name" : "'Value'" },
-        { "kind" : "IdRef", "name" : "'ClusterSize'", "quantifier" : "?" }
+        { "kind" : "IdScope", "name" : "Execution" },
+        { "kind" : "GroupOperation", "name" : "Operation" },
+        { "kind" : "IdRef", "name" : "Value" },
+        { "kind" : "IdRef", "name" : "ClusterSize", "quantifier" : "?" }
       ],
       "capabilities" : [ "GroupNonUniformArithmetic", "GroupNonUniformClustered", "GroupNonUniformPartitionedNV" ],
       "version" : "1.3"
@@ -4132,10 +4132,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope", "name" : "'Execution'" },
-        { "kind" : "GroupOperation", "name" : "'Operation'" },
-        { "kind" : "IdRef", "name" : "'Value'" },
-        { "kind" : "IdRef", "name" : "'ClusterSize'", "quantifier" : "?" }
+        { "kind" : "IdScope", "name" : "Execution" },
+        { "kind" : "GroupOperation", "name" : "Operation" },
+        { "kind" : "IdRef", "name" : "Value" },
+        { "kind" : "IdRef", "name" : "ClusterSize", "quantifier" : "?" }
       ],
       "capabilities" : [ "GroupNonUniformArithmetic", "GroupNonUniformClustered", "GroupNonUniformPartitionedNV" ],
       "version" : "1.3"
@@ -4147,10 +4147,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope", "name" : "'Execution'" },
-        { "kind" : "GroupOperation", "name" : "'Operation'" },
-        { "kind" : "IdRef", "name" : "'Value'" },
-        { "kind" : "IdRef", "name" : "'ClusterSize'", "quantifier" : "?" }
+        { "kind" : "IdScope", "name" : "Execution" },
+        { "kind" : "GroupOperation", "name" : "Operation" },
+        { "kind" : "IdRef", "name" : "Value" },
+        { "kind" : "IdRef", "name" : "ClusterSize", "quantifier" : "?" }
       ],
       "capabilities" : [ "GroupNonUniformArithmetic", "GroupNonUniformClustered", "GroupNonUniformPartitionedNV" ],
       "version" : "1.3"
@@ -4162,10 +4162,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope", "name" : "'Execution'" },
-        { "kind" : "GroupOperation", "name" : "'Operation'" },
-        { "kind" : "IdRef", "name" : "'Value'" },
-        { "kind" : "IdRef", "name" : "'ClusterSize'", "quantifier" : "?" }
+        { "kind" : "IdScope", "name" : "Execution" },
+        { "kind" : "GroupOperation", "name" : "Operation" },
+        { "kind" : "IdRef", "name" : "Value" },
+        { "kind" : "IdRef", "name" : "ClusterSize", "quantifier" : "?" }
       ],
       "capabilities" : [ "GroupNonUniformArithmetic", "GroupNonUniformClustered", "GroupNonUniformPartitionedNV" ],
       "version" : "1.3"
@@ -4177,10 +4177,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope", "name" : "'Execution'" },
-        { "kind" : "GroupOperation", "name" : "'Operation'" },
-        { "kind" : "IdRef", "name" : "'Value'" },
-        { "kind" : "IdRef", "name" : "'ClusterSize'", "quantifier" : "?" }
+        { "kind" : "IdScope", "name" : "Execution" },
+        { "kind" : "GroupOperation", "name" : "Operation" },
+        { "kind" : "IdRef", "name" : "Value" },
+        { "kind" : "IdRef", "name" : "ClusterSize", "quantifier" : "?" }
       ],
       "capabilities" : [ "GroupNonUniformArithmetic", "GroupNonUniformClustered", "GroupNonUniformPartitionedNV" ],
       "version" : "1.3"
@@ -4192,10 +4192,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope", "name" : "'Execution'" },
-        { "kind" : "GroupOperation", "name" : "'Operation'" },
-        { "kind" : "IdRef", "name" : "'Value'" },
-        { "kind" : "IdRef", "name" : "'ClusterSize'", "quantifier" : "?" }
+        { "kind" : "IdScope", "name" : "Execution" },
+        { "kind" : "GroupOperation", "name" : "Operation" },
+        { "kind" : "IdRef", "name" : "Value" },
+        { "kind" : "IdRef", "name" : "ClusterSize", "quantifier" : "?" }
       ],
       "capabilities" : [ "GroupNonUniformArithmetic", "GroupNonUniformClustered", "GroupNonUniformPartitionedNV" ],
       "version" : "1.3"
@@ -4207,10 +4207,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope", "name" : "'Execution'" },
-        { "kind" : "GroupOperation", "name" : "'Operation'" },
-        { "kind" : "IdRef", "name" : "'Value'" },
-        { "kind" : "IdRef", "name" : "'ClusterSize'", "quantifier" : "?" }
+        { "kind" : "IdScope", "name" : "Execution" },
+        { "kind" : "GroupOperation", "name" : "Operation" },
+        { "kind" : "IdRef", "name" : "Value" },
+        { "kind" : "IdRef", "name" : "ClusterSize", "quantifier" : "?" }
       ],
       "capabilities" : [ "GroupNonUniformArithmetic", "GroupNonUniformClustered", "GroupNonUniformPartitionedNV" ],
       "version" : "1.3"
@@ -4222,10 +4222,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope", "name" : "'Execution'" },
-        { "kind" : "GroupOperation", "name" : "'Operation'" },
-        { "kind" : "IdRef", "name" : "'Value'" },
-        { "kind" : "IdRef", "name" : "'ClusterSize'", "quantifier" : "?" }
+        { "kind" : "IdScope", "name" : "Execution" },
+        { "kind" : "GroupOperation", "name" : "Operation" },
+        { "kind" : "IdRef", "name" : "Value" },
+        { "kind" : "IdRef", "name" : "ClusterSize", "quantifier" : "?" }
       ],
       "capabilities" : [ "GroupNonUniformArithmetic", "GroupNonUniformClustered", "GroupNonUniformPartitionedNV" ],
       "version" : "1.3"
@@ -4237,10 +4237,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope", "name" : "'Execution'" },
-        { "kind" : "GroupOperation", "name" : "'Operation'" },
-        { "kind" : "IdRef", "name" : "'Value'" },
-        { "kind" : "IdRef", "name" : "'ClusterSize'", "quantifier" : "?" }
+        { "kind" : "IdScope", "name" : "Execution" },
+        { "kind" : "GroupOperation", "name" : "Operation" },
+        { "kind" : "IdRef", "name" : "Value" },
+        { "kind" : "IdRef", "name" : "ClusterSize", "quantifier" : "?" }
       ],
       "capabilities" : [ "GroupNonUniformArithmetic", "GroupNonUniformClustered", "GroupNonUniformPartitionedNV" ],
       "version" : "1.3"
@@ -4252,10 +4252,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope", "name" : "'Execution'" },
-        { "kind" : "GroupOperation", "name" : "'Operation'" },
-        { "kind" : "IdRef", "name" : "'Value'" },
-        { "kind" : "IdRef", "name" : "'ClusterSize'", "quantifier" : "?" }
+        { "kind" : "IdScope", "name" : "Execution" },
+        { "kind" : "GroupOperation", "name" : "Operation" },
+        { "kind" : "IdRef", "name" : "Value" },
+        { "kind" : "IdRef", "name" : "ClusterSize", "quantifier" : "?" }
       ],
       "capabilities" : [ "GroupNonUniformArithmetic", "GroupNonUniformClustered", "GroupNonUniformPartitionedNV" ],
       "version" : "1.3"
@@ -4267,10 +4267,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope", "name" : "'Execution'" },
-        { "kind" : "GroupOperation", "name" : "'Operation'" },
-        { "kind" : "IdRef", "name" : "'Value'" },
-        { "kind" : "IdRef", "name" : "'ClusterSize'", "quantifier" : "?" }
+        { "kind" : "IdScope", "name" : "Execution" },
+        { "kind" : "GroupOperation", "name" : "Operation" },
+        { "kind" : "IdRef", "name" : "Value" },
+        { "kind" : "IdRef", "name" : "ClusterSize", "quantifier" : "?" }
       ],
       "capabilities" : [ "GroupNonUniformArithmetic", "GroupNonUniformClustered", "GroupNonUniformPartitionedNV" ],
       "version" : "1.3"
@@ -4282,10 +4282,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope", "name" : "'Execution'" },
-        { "kind" : "GroupOperation", "name" : "'Operation'" },
-        { "kind" : "IdRef", "name" : "'Value'" },
-        { "kind" : "IdRef", "name" : "'ClusterSize'", "quantifier" : "?" }
+        { "kind" : "IdScope", "name" : "Execution" },
+        { "kind" : "GroupOperation", "name" : "Operation" },
+        { "kind" : "IdRef", "name" : "Value" },
+        { "kind" : "IdRef", "name" : "ClusterSize", "quantifier" : "?" }
       ],
       "capabilities" : [ "GroupNonUniformArithmetic", "GroupNonUniformClustered", "GroupNonUniformPartitionedNV" ],
       "version" : "1.3"
@@ -4297,10 +4297,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope", "name" : "'Execution'" },
-        { "kind" : "GroupOperation", "name" : "'Operation'" },
-        { "kind" : "IdRef", "name" : "'Value'" },
-        { "kind" : "IdRef", "name" : "'ClusterSize'", "quantifier" : "?" }
+        { "kind" : "IdScope", "name" : "Execution" },
+        { "kind" : "GroupOperation", "name" : "Operation" },
+        { "kind" : "IdRef", "name" : "Value" },
+        { "kind" : "IdRef", "name" : "ClusterSize", "quantifier" : "?" }
       ],
       "capabilities" : [ "GroupNonUniformArithmetic", "GroupNonUniformClustered", "GroupNonUniformPartitionedNV" ],
       "version" : "1.3"
@@ -4312,10 +4312,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope", "name" : "'Execution'" },
-        { "kind" : "GroupOperation", "name" : "'Operation'" },
-        { "kind" : "IdRef", "name" : "'Value'" },
-        { "kind" : "IdRef", "name" : "'ClusterSize'", "quantifier" : "?" }
+        { "kind" : "IdScope", "name" : "Execution" },
+        { "kind" : "GroupOperation", "name" : "Operation" },
+        { "kind" : "IdRef", "name" : "Value" },
+        { "kind" : "IdRef", "name" : "ClusterSize", "quantifier" : "?" }
       ],
       "capabilities" : [ "GroupNonUniformArithmetic", "GroupNonUniformClustered", "GroupNonUniformPartitionedNV" ],
       "version" : "1.3"
@@ -4327,9 +4327,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope", "name" : "'Execution'" },
-        { "kind" : "IdRef", "name" : "'Value'" },
-        { "kind" : "IdRef", "name" : "'Index'" }
+        { "kind" : "IdScope", "name" : "Execution" },
+        { "kind" : "IdRef", "name" : "Value" },
+        { "kind" : "IdRef", "name" : "Index" }
       ],
       "capabilities" : [ "GroupNonUniformQuad" ],
       "version" : "1.3"
@@ -4341,9 +4341,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope", "name" : "'Execution'" },
-        { "kind" : "IdRef", "name" : "'Value'" },
-        { "kind" : "IdRef", "name" : "'Direction'" }
+        { "kind" : "IdScope", "name" : "Execution" },
+        { "kind" : "IdRef", "name" : "Value" },
+        { "kind" : "IdRef", "name" : "Direction" }
       ],
       "capabilities" : [ "GroupNonUniformQuad" ],
       "version" : "1.3"
@@ -4355,7 +4355,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand'" }
+        { "kind" : "IdRef",        "name" : "Operand" }
       ],
       "version" : "1.4"
     },
@@ -4366,8 +4366,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "version" : "1.4"
     },
@@ -4378,8 +4378,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "version" : "1.4"
     },
@@ -4390,8 +4390,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "capabilities" : [ "Addresses", "VariablePointers", "VariablePointersStorageBuffer" ],
       "version" : "1.4"
@@ -4403,8 +4403,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Attachment'" },
-        { "kind" : "IdRef", "name" : "'Sample'", "quantifier" : "?" }
+        { "kind" : "IdRef", "name" : "Attachment" },
+        { "kind" : "IdRef", "name" : "Sample", "quantifier" : "?" }
       ],
       "capabilities": [ "TileImageColorReadAccessEXT" ],
       "version" : "None"
@@ -4416,7 +4416,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Sample'", "quantifier" : "?" }
+        { "kind" : "IdRef", "name" : "Sample", "quantifier" : "?" }
       ],
       "capabilities" : [ "TileImageDepthReadAccessEXT" ],
       "version" : "None"
@@ -4428,7 +4428,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Sample'", "quantifier" : "?" }
+        { "kind" : "IdRef", "name" : "Sample", "quantifier" : "?" }
       ],
       "capabilities" : [ "TileImageStencilReadAccessEXT" ],
       "version" : "None"
@@ -4468,8 +4468,8 @@
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
         { "kind" : "StorageClass" },
-        { "kind" : "IdRef", "quantifier" : "?",  "name" : "'Data Type'" },
-        { "kind" : "IdRef", "quantifier" : "?", "name" : "'Initializer'" }
+        { "kind" : "IdRef", "quantifier" : "?",  "name" : "Data Type" },
+        { "kind" : "IdRef", "quantifier" : "?", "name" : "Initializer" }
       ]
     },
     {
@@ -4482,9 +4482,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",                            "name" : "'Base Type'" },
-        { "kind" : "IdRef",                            "name" : "'Base'" },
-        { "kind" : "IdRef",        "quantifier" : "*", "name" : "'Indexes'" }
+        { "kind" : "IdRef",                            "name" : "Base Type" },
+        { "kind" : "IdRef",                            "name" : "Base" },
+        { "kind" : "IdRef",        "quantifier" : "*", "name" : "Indexes" }
       ]
     },
     {
@@ -4497,9 +4497,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",                            "name" : "'Base Type'" },
-        { "kind" : "IdRef",                            "name" : "'Base'" },
-        { "kind" : "IdRef",        "quantifier" : "*", "name" : "'Indexes'" }
+        { "kind" : "IdRef",                            "name" : "Base Type" },
+        { "kind" : "IdRef",                            "name" : "Base" },
+        { "kind" : "IdRef",        "quantifier" : "*", "name" : "Indexes" }
       ]
     },
     {
@@ -4509,7 +4509,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Predicate'" }
+        { "kind" : "IdRef", "name" : "Predicate" }
       ],
       "capabilities" : [ "SubgroupBallotKHR" ],
       "extensions" : [ "SPV_KHR_shader_ballot" ],
@@ -4522,7 +4522,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Value'" }
+        { "kind" : "IdRef", "name" : "Value" }
       ],
       "capabilities" : [ "SubgroupBallotKHR" ],
       "extensions" : [ "SPV_KHR_shader_ballot" ],
@@ -4538,10 +4538,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",                            "name" : "'Base Type'" },
-        { "kind" : "IdRef",                            "name" : "'Base'" },
-        { "kind" : "IdRef",                            "name" : "'Element'" },
-        { "kind" : "IdRef",        "quantifier" : "*", "name" : "'Indexes'" }
+        { "kind" : "IdRef",                            "name" : "Base Type" },
+        { "kind" : "IdRef",                            "name" : "Base" },
+        { "kind" : "IdRef",                            "name" : "Element" },
+        { "kind" : "IdRef",        "quantifier" : "*", "name" : "Indexes" }
       ]
     },
     {
@@ -4554,10 +4554,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",                            "name" : "'Base Type'" },
-        { "kind" : "IdRef",                            "name" : "'Base'" },
-        { "kind" : "IdRef",                            "name" : "'Element'" },
-        { "kind" : "IdRef",        "quantifier" : "*", "name" : "'Indexes'" }
+        { "kind" : "IdRef",                            "name" : "Base Type" },
+        { "kind" : "IdRef",                            "name" : "Base" },
+        { "kind" : "IdRef",                            "name" : "Element" },
+        { "kind" : "IdRef",        "quantifier" : "*", "name" : "Indexes" }
       ]
     },
     {
@@ -4570,9 +4570,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",                            "name" : "'Structure'" },
-        { "kind" : "IdRef",                            "name" : "'Pointer'" },
-        { "kind" : "LiteralInteger",                   "name" : "'Array member'" }
+        { "kind" : "IdRef",                            "name" : "Structure" },
+        { "kind" : "IdRef",                            "name" : "Pointer" },
+        { "kind" : "LiteralInteger",                   "name" : "Array member" }
       ]
     },
     {
@@ -4583,11 +4583,11 @@
       "provisional" : true,
       "version" : "None",
       "operands" : [
-        { "kind" : "IdRef",                            "name" : "'Pointer Type'" },
-        { "kind" : "IdRef",                            "name" : "'Num Bytes'" },
-        { "kind" : "IdRef",        "quantifier" : "?", "name" : "'RW'" },
-        { "kind" : "IdRef",        "quantifier" : "?", "name" : "'Locality'" },
-        { "kind" : "IdRef",        "quantifier" : "?", "name" : "'Cache Type'" }
+        { "kind" : "IdRef",                            "name" : "Pointer Type" },
+        { "kind" : "IdRef",                            "name" : "Num Bytes" },
+        { "kind" : "IdRef",        "quantifier" : "?", "name" : "RW" },
+        { "kind" : "IdRef",        "quantifier" : "?", "name" : "Locality" },
+        { "kind" : "IdRef",        "quantifier" : "?", "name" : "Cache Type" }
       ]
     },
     {
@@ -4597,7 +4597,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Predicate'" }
+        { "kind" : "IdRef", "name" : "Predicate" }
       ],
       "extensions" : [
         "SPV_KHR_subgroup_vote"
@@ -4612,7 +4612,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Predicate'" }
+        { "kind" : "IdRef", "name" : "Predicate" }
       ],
       "extensions" : [
         "SPV_KHR_subgroup_vote"
@@ -4627,7 +4627,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Predicate'" }
+        { "kind" : "IdRef", "name" : "Predicate" }
       ],
       "extensions" : [
         "SPV_KHR_subgroup_vote"
@@ -4642,10 +4642,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope", "name" : "'Execution'" },
-        { "kind" : "IdRef", "name" : "'Value'" },
-        { "kind" : "IdRef", "name" : "'Delta'" },
-        { "kind" : "IdRef", "name" : "'ClusterSize'", "quantifier" : "?" }
+        { "kind" : "IdScope", "name" : "Execution" },
+        { "kind" : "IdRef", "name" : "Value" },
+        { "kind" : "IdRef", "name" : "Delta" },
+        { "kind" : "IdRef", "name" : "ClusterSize", "quantifier" : "?" }
       ],
       "capabilities" : [ "GroupNonUniformRotateKHR" ],
       "version" : "None"
@@ -4657,8 +4657,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Value'" },
-        { "kind" : "IdRef", "name" : "'Index'" }
+        { "kind" : "IdRef", "name" : "Value" },
+        { "kind" : "IdRef", "name" : "Index" }
       ],
       "capabilities" : [ "SubgroupBallotKHR" ],
       "extensions" : [ "SPV_KHR_shader_ballot" ],
@@ -4671,9 +4671,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",                                     "name" : "'Set'" },
-        { "kind" : "LiteralExtInstInteger",                     "name" : "'Instruction'" },
-        { "kind" : "IdRef",                 "quantifier" : "*", "name" : "'Operand 1', +\n'Operand 2', +\n..." }
+        { "kind" : "IdRef",                                     "name" : "Set" },
+        { "kind" : "LiteralExtInstInteger",                     "name" : "Instruction" },
+        { "kind" : "IdRef",                 "quantifier" : "*", "name" : "Operand 1, Operand 2, ..." }
       ],
       "extensions" : [ "SPV_KHR_relaxed_extended_instruction" ],
       "version": "None"
@@ -4684,17 +4684,17 @@
       "opcode" : 4445,
       "operands" : [
 
-        { "kind" : "IdRef", "name" : "'Accel'" },
-        { "kind" : "IdRef", "name" : "'Ray Flags'" },
-        { "kind" : "IdRef", "name" : "'Cull Mask'" },
-        { "kind" : "IdRef", "name" : "'SBT Offset'" },
-        { "kind" : "IdRef", "name" : "'SBT Stride'" },
-        { "kind" : "IdRef", "name" : "'Miss Index'" },
-        { "kind" : "IdRef", "name" : "'Ray Origin'" },
-        { "kind" : "IdRef", "name" : "'Ray Tmin'" },
-        { "kind" : "IdRef", "name" : "'Ray Direction'" },
-        { "kind" : "IdRef", "name" : "'Ray Tmax'" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Accel" },
+        { "kind" : "IdRef", "name" : "Ray Flags" },
+        { "kind" : "IdRef", "name" : "Cull Mask" },
+        { "kind" : "IdRef", "name" : "SBT Offset" },
+        { "kind" : "IdRef", "name" : "SBT Stride" },
+        { "kind" : "IdRef", "name" : "Miss Index" },
+        { "kind" : "IdRef", "name" : "Ray Origin" },
+        { "kind" : "IdRef", "name" : "Ray Tmin" },
+        { "kind" : "IdRef", "name" : "Ray Direction" },
+        { "kind" : "IdRef", "name" : "Ray Tmax" },
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "RayTracingKHR" ],
       "extensions" : [ "SPV_KHR_ray_tracing" ],
@@ -4706,8 +4706,8 @@
       "opcode" : 4446,
       "operands" : [
 
-        { "kind" : "IdRef", "name" : "'SBT Index'" },
-        { "kind" : "IdRef", "name" : "'Callable Data'" }
+        { "kind" : "IdRef", "name" : "SBT Index" },
+        { "kind" : "IdRef", "name" : "Callable Data" }
       ],
       "capabilities" : [ "RayTracingKHR" ],
       "extensions" : [ "SPV_KHR_ray_tracing" ],
@@ -4720,7 +4720,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Accel'" }
+        { "kind" : "IdRef",        "name" : "Accel" }
       ],
       "capabilities" : [ "RayTracingKHR", "RayQueryKHR" ],
       "extensions" : [ "SPV_KHR_ray_tracing", "SPV_KHR_ray_query" ],
@@ -4750,9 +4750,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Vector 1'" },
-        { "kind" : "IdRef", "name" : "'Vector 2'" },
-        { "kind" : "PackedVectorFormat", "name" : "'Packed Vector Format'", "quantifier" : "?" }
+        { "kind" : "IdRef", "name" : "Vector 1" },
+        { "kind" : "IdRef", "name" : "Vector 2" },
+        { "kind" : "PackedVectorFormat", "name" : "Packed Vector Format", "quantifier" : "?" }
       ],
       "capabilities" : [ "DotProduct" ],
       "extensions" : [ "SPV_KHR_integer_dot_product" ],
@@ -4766,9 +4766,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Vector 1'" },
-        { "kind" : "IdRef", "name" : "'Vector 2'" },
-        { "kind" : "PackedVectorFormat", "name" : "'Packed Vector Format'", "quantifier" : "?" }
+        { "kind" : "IdRef", "name" : "Vector 1" },
+        { "kind" : "IdRef", "name" : "Vector 2" },
+        { "kind" : "PackedVectorFormat", "name" : "Packed Vector Format", "quantifier" : "?" }
       ],
       "capabilities" : [ "DotProduct" ],
       "extensions" : [ "SPV_KHR_integer_dot_product" ],
@@ -4782,9 +4782,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Vector 1'" },
-        { "kind" : "IdRef", "name" : "'Vector 2'" },
-        { "kind" : "PackedVectorFormat", "name" : "'Packed Vector Format'", "quantifier" : "?" }
+        { "kind" : "IdRef", "name" : "Vector 1" },
+        { "kind" : "IdRef", "name" : "Vector 2" },
+        { "kind" : "PackedVectorFormat", "name" : "Packed Vector Format", "quantifier" : "?" }
       ],
       "capabilities" : [ "DotProduct" ],
       "extensions" : [ "SPV_KHR_integer_dot_product" ],
@@ -4798,10 +4798,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Vector 1'" },
-        { "kind" : "IdRef", "name" : "'Vector 2'" },
-        { "kind" : "IdRef", "name" : "'Accumulator'" },
-        { "kind" : "PackedVectorFormat", "name" : "'Packed Vector Format'", "quantifier" : "?" }
+        { "kind" : "IdRef", "name" : "Vector 1" },
+        { "kind" : "IdRef", "name" : "Vector 2" },
+        { "kind" : "IdRef", "name" : "Accumulator" },
+        { "kind" : "PackedVectorFormat", "name" : "Packed Vector Format", "quantifier" : "?" }
       ],
       "capabilities" : [ "DotProduct" ],
       "extensions" : [ "SPV_KHR_integer_dot_product" ],
@@ -4815,10 +4815,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Vector 1'" },
-        { "kind" : "IdRef", "name" : "'Vector 2'" },
-        { "kind" : "IdRef", "name" : "'Accumulator'" },
-        { "kind" : "PackedVectorFormat", "name" : "'Packed Vector Format'", "quantifier" : "?" }
+        { "kind" : "IdRef", "name" : "Vector 1" },
+        { "kind" : "IdRef", "name" : "Vector 2" },
+        { "kind" : "IdRef", "name" : "Accumulator" },
+        { "kind" : "PackedVectorFormat", "name" : "Packed Vector Format", "quantifier" : "?" }
       ],
       "capabilities" : [ "DotProduct" ],
       "extensions" : [ "SPV_KHR_integer_dot_product" ],
@@ -4832,10 +4832,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Vector 1'" },
-        { "kind" : "IdRef", "name" : "'Vector 2'" },
-        { "kind" : "IdRef", "name" : "'Accumulator'" },
-        { "kind" : "PackedVectorFormat", "name" : "'Packed Vector Format'", "quantifier" : "?" }
+        { "kind" : "IdRef", "name" : "Vector 1" },
+        { "kind" : "IdRef", "name" : "Vector 2" },
+        { "kind" : "IdRef", "name" : "Accumulator" },
+        { "kind" : "PackedVectorFormat", "name" : "Packed Vector Format", "quantifier" : "?" }
       ],
       "capabilities" : [ "DotProduct" ],
       "extensions" : [ "SPV_KHR_integer_dot_product" ],
@@ -4847,11 +4847,11 @@
       "opcode" : 4456,
       "operands" : [
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Component Type'" },
-        { "kind" : "IdScope",      "name" : "'Scope'" },
-        { "kind" : "IdRef",        "name" : "'Rows'" },
-        { "kind" : "IdRef",        "name" : "'Columns'" },
-        { "kind" : "IdRef",        "name" : "'Use'" }
+        { "kind" : "IdRef",        "name" : "Component Type" },
+        { "kind" : "IdScope",      "name" : "Scope" },
+        { "kind" : "IdRef",        "name" : "Rows" },
+        { "kind" : "IdRef",        "name" : "Columns" },
+        { "kind" : "IdRef",        "name" : "Use" }
       ],
       "capabilities" : [ "CooperativeMatrixKHR" ],
       "version" : "None"
@@ -4863,10 +4863,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",             "name" : "'Pointer'" },
-        { "kind" : "IdRef",             "name" : "'MemoryLayout'" },
-        { "kind" : "IdRef",             "name" : "'Stride'", "quantifier": "?" },
-        { "kind" : "MemoryAccess",      "name" : "'Memory Operand'", "quantifier" : "?" }
+        { "kind" : "IdRef",             "name" : "Pointer" },
+        { "kind" : "IdRef",             "name" : "MemoryLayout" },
+        { "kind" : "IdRef",             "name" : "Stride", "quantifier": "?" },
+        { "kind" : "MemoryAccess",      "name" : "Memory Operand", "quantifier" : "?" }
       ],
       "capabilities" : [ "CooperativeMatrixKHR" ],
       "version" : "None"
@@ -4876,11 +4876,11 @@
       "class"  : "Memory",
       "opcode" : 4458,
       "operands" : [
-        { "kind" : "IdRef",             "name" : "'Pointer'" },
-        { "kind" : "IdRef",             "name" : "'Object'" },
-        { "kind" : "IdRef",             "name" : "'MemoryLayout'" },
-        { "kind" : "IdRef",             "name" : "'Stride'", "quantifier": "?" },
-        { "kind" : "MemoryAccess",      "name" : "'Memory Operand'", "quantifier" : "?" }
+        { "kind" : "IdRef",             "name" : "Pointer" },
+        { "kind" : "IdRef",             "name" : "Object" },
+        { "kind" : "IdRef",             "name" : "MemoryLayout" },
+        { "kind" : "IdRef",             "name" : "Stride", "quantifier": "?" },
+        { "kind" : "MemoryAccess",      "name" : "Memory Operand", "quantifier" : "?" }
       ],
       "capabilities" : [ "CooperativeMatrixKHR" ],
       "version" : "None"
@@ -4892,10 +4892,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",             "name" : "'A'" },
-        { "kind" : "IdRef",             "name" : "'B'" },
-        { "kind" : "IdRef",             "name" : "'C'" },
-        { "kind" : "CooperativeMatrixOperands", "name" : "'Cooperative Matrix Operands'", "quantifier" : "?" }
+        { "kind" : "IdRef",             "name" : "A" },
+        { "kind" : "IdRef",             "name" : "B" },
+        { "kind" : "IdRef",             "name" : "C" },
+        { "kind" : "CooperativeMatrixOperands", "name" : "Cooperative Matrix Operands", "quantifier" : "?" }
       ],
       "capabilities" : [ "CooperativeMatrixKHR" ],
       "version" : "None"
@@ -4907,7 +4907,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Type'" }
+        { "kind" : "IdRef",        "name" : "Type" }
       ],
       "capabilities" : [ "CooperativeMatrixKHR" ],
       "version" : "None"
@@ -4919,7 +4919,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Value'" }
+        { "kind" : "IdRef",        "name" : "Value" }
       ],
       "capabilities" : [ "ReplicatedCompositesEXT" ],
       "version" : "None"
@@ -4931,7 +4931,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Value'" }
+        { "kind" : "IdRef",        "name" : "Value" }
       ],
       "capabilities" : [ "ReplicatedCompositesEXT" ],
       "version" : "None"
@@ -4943,7 +4943,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Value'" }
+        { "kind" : "IdRef",        "name" : "Value" }
       ],
       "capabilities" : [ "ReplicatedCompositesEXT" ],
       "version" : "None"
@@ -4966,35 +4966,35 @@
         "operands" : [
             {
                 "kind" : "IdRef",
-                "name" : "'RayQuery'"
+                "name" : "RayQuery"
             },
             {
                 "kind" : "IdRef",
-                "name" : "'Accel'"
+                "name" : "Accel"
             },
             {
                 "kind" : "IdRef",
-                "name" : "'RayFlags'"
+                "name" : "RayFlags"
             },
             {
                 "kind" : "IdRef",
-                "name" : "'CullMask'"
+                "name" : "CullMask"
             },
             {
                 "kind" : "IdRef",
-                "name" : "'RayOrigin'"
+                "name" : "RayOrigin"
             },
             {
                 "kind" : "IdRef",
-                "name" : "'RayTMin'"
+                "name" : "RayTMin"
             },
             {
                 "kind" : "IdRef",
-                "name" : "'RayDirection'"
+                "name" : "RayDirection"
             },
             {
                 "kind" : "IdRef",
-                "name" : "'RayTMax'"
+                "name" : "RayTMax"
             }
 
         ],
@@ -5009,7 +5009,7 @@
         "operands" : [
             {
                 "kind" : "IdRef",
-                "name" : "'RayQuery'"
+                "name" : "RayQuery"
             }
         ],
         "capabilities" : [ "RayQueryKHR" ],
@@ -5023,11 +5023,11 @@
         "operands" : [
             {
                 "kind" : "IdRef",
-                "name" : "'RayQuery'"
+                "name" : "RayQuery"
             },
             {
                 "kind" : "IdRef",
-                "name" : "'HitT'"
+                "name" : "HitT"
             }
         ],
         "capabilities" : [ "RayQueryKHR" ],
@@ -5041,7 +5041,7 @@
         "operands" : [
             {
                 "kind" : "IdRef",
-                "name" : "'RayQuery'"
+                "name" : "RayQuery"
             }
         ],
         "capabilities" : [ "RayQueryKHR" ],
@@ -5057,7 +5057,7 @@
             { "kind" : "IdResult" },
             {
                 "kind" : "IdRef",
-                "name" : "'RayQuery'"
+                "name" : "RayQuery"
             }
         ],
         "capabilities" : [ "RayQueryKHR" ],
@@ -5073,11 +5073,11 @@
             { "kind" : "IdResult" },
             {
                 "kind" : "IdRef",
-                "name" : "'RayQuery'"
+                "name" : "RayQuery"
             },
             {
                 "kind" : "IdRef",
-                "name" : "'Intersection'"
+                "name" : "Intersection"
             }
         ],
         "capabilities" : [ "RayQueryKHR" ],
@@ -5091,9 +5091,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Texture'" },
-        { "kind" : "IdRef", "name" : "'Coordinates'" },
-        { "kind" : "IdRef", "name" : "'Weights'" }
+        { "kind" : "IdRef", "name" : "Texture" },
+        { "kind" : "IdRef", "name" : "Coordinates" },
+        { "kind" : "IdRef", "name" : "Weights" }
       ],
       "capabilities" : [ "TextureSampleWeightedQCOM" ],
       "version" : "None"
@@ -5105,9 +5105,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Texture'" },
-        { "kind" : "IdRef", "name" : "'Coordinates'" },
-        { "kind" : "IdRef", "name" : "'Box Size'" }
+        { "kind" : "IdRef", "name" : "Texture" },
+        { "kind" : "IdRef", "name" : "Coordinates" },
+        { "kind" : "IdRef", "name" : "Box Size" }
       ],
       "capabilities" : [ "TextureBoxFilterQCOM" ],
       "version" : "None"
@@ -5119,11 +5119,11 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Target'" },
-        { "kind" : "IdRef", "name" : "'Target Coordinates'" },
-        { "kind" : "IdRef", "name" : "'Reference'" },
-        { "kind" : "IdRef", "name" : "'Reference Coordinates'" },
-        { "kind" : "IdRef", "name" : "'Block Size'" }
+        { "kind" : "IdRef", "name" : "Target" },
+        { "kind" : "IdRef", "name" : "Target Coordinates" },
+        { "kind" : "IdRef", "name" : "Reference" },
+        { "kind" : "IdRef", "name" : "Reference Coordinates" },
+        { "kind" : "IdRef", "name" : "Block Size" }
       ],
       "capabilities" : [ "TextureBlockMatchQCOM" ],
       "version" : "None"
@@ -5135,11 +5135,11 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Target'" },
-        { "kind" : "IdRef", "name" : "'Target Coordinates'" },
-        { "kind" : "IdRef", "name" : "'Reference'" },
-        { "kind" : "IdRef", "name" : "'Reference Coordinates'" },
-        { "kind" : "IdRef", "name" : "'Block Size'" }
+        { "kind" : "IdRef", "name" : "Target" },
+        { "kind" : "IdRef", "name" : "Target Coordinates" },
+        { "kind" : "IdRef", "name" : "Reference" },
+        { "kind" : "IdRef", "name" : "Reference Coordinates" },
+        { "kind" : "IdRef", "name" : "Block Size" }
       ],
       "capabilities" : [ "TextureBlockMatchQCOM" ],
       "version" : "None"
@@ -5151,11 +5151,11 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Target Sampled Image'" },
-        { "kind" : "IdRef", "name" : "'Target Coordinates'" },
-        { "kind" : "IdRef", "name" : "'Reference Sampled Image'" },
-        { "kind" : "IdRef", "name" : "'Reference Coordinates'" },
-        { "kind" : "IdRef", "name" : "'Block Size'" }
+        { "kind" : "IdRef", "name" : "Target Sampled Image" },
+        { "kind" : "IdRef", "name" : "Target Coordinates" },
+        { "kind" : "IdRef", "name" : "Reference Sampled Image" },
+        { "kind" : "IdRef", "name" : "Reference Coordinates" },
+        { "kind" : "IdRef", "name" : "Block Size" }
       ],
       "capabilities" : [ "TextureBlockMatch2QCOM" ],
       "version" : "None"
@@ -5167,11 +5167,11 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Target Sampled Image'" },
-        { "kind" : "IdRef", "name" : "'Target Coordinates'" },
-        { "kind" : "IdRef", "name" : "'Reference Sampled Image'" },
-        { "kind" : "IdRef", "name" : "'Reference Coordinates'" },
-        { "kind" : "IdRef", "name" : "'Block Size'" }
+        { "kind" : "IdRef", "name" : "Target Sampled Image" },
+        { "kind" : "IdRef", "name" : "Target Coordinates" },
+        { "kind" : "IdRef", "name" : "Reference Sampled Image" },
+        { "kind" : "IdRef", "name" : "Reference Coordinates" },
+        { "kind" : "IdRef", "name" : "Block Size" }
       ],
       "capabilities" : [ "TextureBlockMatch2QCOM" ],
       "version" : "None"
@@ -5183,11 +5183,11 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Target Sampled Image'" },
-        { "kind" : "IdRef", "name" : "'Target Coordinates'" },
-        { "kind" : "IdRef", "name" : "'Reference Sampled Image'" },
-        { "kind" : "IdRef", "name" : "'Reference Coordinates'" },
-        { "kind" : "IdRef", "name" : "'Block Size'" }
+        { "kind" : "IdRef", "name" : "Target Sampled Image" },
+        { "kind" : "IdRef", "name" : "Target Coordinates" },
+        { "kind" : "IdRef", "name" : "Reference Sampled Image" },
+        { "kind" : "IdRef", "name" : "Reference Coordinates" },
+        { "kind" : "IdRef", "name" : "Block Size" }
       ],
       "capabilities" : [ "TextureBlockMatch2QCOM" ],
       "version" : "None"
@@ -5199,11 +5199,11 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Target Sampled Image'" },
-        { "kind" : "IdRef", "name" : "'Target Coordinates'" },
-        { "kind" : "IdRef", "name" : "'Reference Sampled Image'" },
-        { "kind" : "IdRef", "name" : "'Reference Coordinates'" },
-        { "kind" : "IdRef", "name" : "'Block Size'" }
+        { "kind" : "IdRef", "name" : "Target Sampled Image" },
+        { "kind" : "IdRef", "name" : "Target Coordinates" },
+        { "kind" : "IdRef", "name" : "Reference Sampled Image" },
+        { "kind" : "IdRef", "name" : "Reference Coordinates" },
+        { "kind" : "IdRef", "name" : "Block Size" }
       ],
       "capabilities" : [ "TextureBlockMatch2QCOM" ],
       "version" : "None"
@@ -5215,9 +5215,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope",        "name" : "'Execution'" },
-        { "kind" : "GroupOperation", "name" : "'Operation'" },
-        { "kind" : "IdRef",          "name" : "'X'" }
+        { "kind" : "IdScope",        "name" : "Execution" },
+        { "kind" : "GroupOperation", "name" : "Operation" },
+        { "kind" : "IdRef",          "name" : "X" }
       ],
       "capabilities" : [ "Groups" ],
       "extensions" : [ "SPV_AMD_shader_ballot" ],
@@ -5230,9 +5230,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope",        "name" : "'Execution'" },
-        { "kind" : "GroupOperation", "name" : "'Operation'" },
-        { "kind" : "IdRef",          "name" : "'X'" }
+        { "kind" : "IdScope",        "name" : "Execution" },
+        { "kind" : "GroupOperation", "name" : "Operation" },
+        { "kind" : "IdRef",          "name" : "X" }
       ],
       "capabilities" : [ "Groups" ],
       "extensions" : [ "SPV_AMD_shader_ballot" ],
@@ -5245,9 +5245,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope",        "name" : "'Execution'" },
-        { "kind" : "GroupOperation", "name" : "'Operation'" },
-        { "kind" : "IdRef",          "name" : "'X'" }
+        { "kind" : "IdScope",        "name" : "Execution" },
+        { "kind" : "GroupOperation", "name" : "Operation" },
+        { "kind" : "IdRef",          "name" : "X" }
       ],
       "capabilities" : [ "Groups" ],
       "extensions" : [ "SPV_AMD_shader_ballot" ],
@@ -5260,9 +5260,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope",        "name" : "'Execution'" },
-        { "kind" : "GroupOperation", "name" : "'Operation'" },
-        { "kind" : "IdRef",          "name" : "'X'" }
+        { "kind" : "IdScope",        "name" : "Execution" },
+        { "kind" : "GroupOperation", "name" : "Operation" },
+        { "kind" : "IdRef",          "name" : "X" }
       ],
       "capabilities" : [ "Groups" ],
       "extensions" : [ "SPV_AMD_shader_ballot" ],
@@ -5275,9 +5275,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope",        "name" : "'Execution'" },
-        { "kind" : "GroupOperation", "name" : "'Operation'" },
-        { "kind" : "IdRef",          "name" : "'X'" }
+        { "kind" : "IdScope",        "name" : "Execution" },
+        { "kind" : "GroupOperation", "name" : "Operation" },
+        { "kind" : "IdRef",          "name" : "X" }
       ],
       "capabilities" : [ "Groups" ],
       "extensions" : [ "SPV_AMD_shader_ballot" ],
@@ -5290,9 +5290,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope",        "name" : "'Execution'" },
-        { "kind" : "GroupOperation", "name" : "'Operation'" },
-        { "kind" : "IdRef",          "name" : "'X'" }
+        { "kind" : "IdScope",        "name" : "Execution" },
+        { "kind" : "GroupOperation", "name" : "Operation" },
+        { "kind" : "IdRef",          "name" : "X" }
       ],
       "capabilities" : [ "Groups" ],
       "extensions" : [ "SPV_AMD_shader_ballot" ],
@@ -5305,9 +5305,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope",        "name" : "'Execution'" },
-        { "kind" : "GroupOperation", "name" : "'Operation'" },
-        { "kind" : "IdRef",          "name" : "'X'" }
+        { "kind" : "IdScope",        "name" : "Execution" },
+        { "kind" : "GroupOperation", "name" : "Operation" },
+        { "kind" : "IdRef",          "name" : "X" }
       ],
       "capabilities" : [ "Groups" ],
       "extensions" : [ "SPV_AMD_shader_ballot" ],
@@ -5320,9 +5320,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope",        "name" : "'Execution'" },
-        { "kind" : "GroupOperation", "name" : "'Operation'" },
-        { "kind" : "IdRef",          "name" : "'X'" }
+        { "kind" : "IdScope",        "name" : "Execution" },
+        { "kind" : "GroupOperation", "name" : "Operation" },
+        { "kind" : "IdRef",          "name" : "X" }
       ],
       "capabilities" : [ "Groups" ],
       "extensions" : [ "SPV_AMD_shader_ballot" ],
@@ -5335,8 +5335,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Image'" },
-        { "kind" : "IdRef", "name" : "'Coordinate'" }
+        { "kind" : "IdRef", "name" : "Image" },
+        { "kind" : "IdRef", "name" : "Coordinate" }
       ],
       "capabilities" : [ "FragmentMaskAMD" ],
       "extensions" : [ "SPV_AMD_shader_fragment_mask" ],
@@ -5349,9 +5349,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Image'" },
-        { "kind" : "IdRef", "name" : "'Coordinate'" },
-        { "kind" : "IdRef", "name" : "'Fragment Index'" }
+        { "kind" : "IdRef", "name" : "Image" },
+        { "kind" : "IdRef", "name" : "Coordinate" },
+        { "kind" : "IdRef", "name" : "Fragment Index" }
       ],
       "capabilities" : [ "FragmentMaskAMD" ],
       "extensions" : [ "SPV_AMD_shader_fragment_mask" ],
@@ -5364,7 +5364,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope", "name" : "'Scope'" }
+        { "kind" : "IdScope", "name" : "Scope" }
       ],
       "capabilities" : [ "ShaderClockKHR" ],
       "version" : "None"
@@ -5376,9 +5376,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope", "name" : "'Visibility'" },
-        { "kind" : "IdRef", "name": "'Payload Count'" },
-        { "kind" : "IdRef", "name": "'Node Index'" }
+        { "kind" : "IdScope", "name" : "Visibility" },
+        { "kind" : "IdRef", "name": "Payload Count" },
+        { "kind" : "IdRef", "name": "Node Index" }
       ],
       "capabilities" : [ "ShaderEnqueueAMDX" ],
       "provisional" : true,
@@ -5389,7 +5389,7 @@
       "class"  : "Reserved",
       "opcode" : 5075,
       "operands" : [
-        { "kind" : "IdRef", "name": "'Payload Array'" }
+        { "kind" : "IdRef", "name": "Payload Array" }
       ],
       "capabilities" : [ "ShaderEnqueueAMDX" ],
       "provisional" : true,
@@ -5401,7 +5401,7 @@
       "opcode" : 5076,
       "operands" : [
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name": "'Payload Type'" }
+        { "kind" : "IdRef", "name": "Payload Type" }
       ],
       "capabilities" : [ "ShaderEnqueueAMDX" ],
       "provisional" : true,
@@ -5414,7 +5414,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name": "'Payload'" }
+        { "kind" : "IdRef", "name": "Payload" }
       ],
       "capabilities" : [ "ShaderEnqueueAMDX" ],
       "provisional" : true,
@@ -5427,7 +5427,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name": "'Payload Array'" }
+        { "kind" : "IdRef", "name": "Payload Array" }
       ],
       "capabilities" : [ "ShaderEnqueueAMDX" ],
       "provisional" : true,
@@ -5440,8 +5440,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name": "'Payload Type'" },
-        { "kind" : "IdRef", "name": "'Node Index'" }
+        { "kind" : "IdRef", "name": "Payload Type" },
+        { "kind" : "IdRef", "name": "Node Index" }
       ],
       "capabilities" : [ "ShaderEnqueueAMDX" ],
       "provisional" : true,
@@ -5453,7 +5453,7 @@
       "opcode" : 5103,
       "operands" : [
         { "kind" : "IdResult" },
-        { "kind" : "LiteralString", "name": "'Literal String'" }
+        { "kind" : "LiteralString", "name": "Literal String" }
       ],
       "capabilities" : [ "ShaderEnqueueAMDX" ],
       "provisional" : true,
@@ -5465,7 +5465,7 @@
       "opcode" : 5104,
       "operands" : [
         { "kind" : "IdResult" },
-        { "kind" : "LiteralString", "name": "'Literal String'" }
+        { "kind" : "LiteralString", "name": "Literal String" }
       ],
       "capabilities" : [ "ShaderEnqueueAMDX" ],
       "provisional" : true,
@@ -5478,7 +5478,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Predicate'" }
+        { "kind" : "IdRef", "name" : "Predicate" }
       ],
       "capabilities" : [ "QuadControlKHR" ],
       "version" : "None"
@@ -5490,7 +5490,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Predicate'" }
+        { "kind" : "IdRef", "name" : "Predicate" }
       ],
       "capabilities" : [ "QuadControlKHR" ],
       "version" : "None"
@@ -5500,20 +5500,20 @@
       "class"  : "Reserved",
       "opcode" : 5249,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Hit Object'" },
-        { "kind" : "IdRef", "name" : "'Acceleration Structure'" },
-        { "kind" : "IdRef", "name" : "'InstanceId'" },
-        { "kind" : "IdRef", "name" : "'PrimitiveId'" },
-        { "kind" : "IdRef", "name" : "'GeometryIndex'" },
-        { "kind" : "IdRef", "name" : "'Hit Kind'" },
-        { "kind" : "IdRef", "name" : "'SBT Record Offset'" },
-        { "kind" : "IdRef", "name" : "'SBT Record Stride'" },
-        { "kind" : "IdRef", "name" : "'Origin'" },
-        { "kind" : "IdRef", "name" : "'TMin'" },
-        { "kind" : "IdRef", "name" : "'Direction'" },
-        { "kind" : "IdRef", "name" : "'TMax'" },
-        { "kind" : "IdRef", "name" : "'Current Time'" },
-        { "kind" : "IdRef", "name" : "'HitObject Attributes'" }
+        { "kind" : "IdRef", "name" : "Hit Object" },
+        { "kind" : "IdRef", "name" : "Acceleration Structure" },
+        { "kind" : "IdRef", "name" : "InstanceId" },
+        { "kind" : "IdRef", "name" : "PrimitiveId" },
+        { "kind" : "IdRef", "name" : "GeometryIndex" },
+        { "kind" : "IdRef", "name" : "Hit Kind" },
+        { "kind" : "IdRef", "name" : "SBT Record Offset" },
+        { "kind" : "IdRef", "name" : "SBT Record Stride" },
+        { "kind" : "IdRef", "name" : "Origin" },
+        { "kind" : "IdRef", "name" : "TMin" },
+        { "kind" : "IdRef", "name" : "Direction" },
+        { "kind" : "IdRef", "name" : "TMax" },
+        { "kind" : "IdRef", "name" : "Current Time" },
+        { "kind" : "IdRef", "name" : "HitObject Attributes" }
       ],
       "capabilities" : [ "ShaderInvocationReorderNV", "RayTracingMotionBlurNV" ],
       "version" : "None"
@@ -5523,19 +5523,19 @@
       "class"  : "Reserved",
       "opcode" : 5250,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Hit Object'" },
-        { "kind" : "IdRef", "name" : "'Acceleration Structure'" },
-        { "kind" : "IdRef", "name" : "'InstanceId'" },
-        { "kind" : "IdRef", "name" : "'PrimitiveId'" },
-        { "kind" : "IdRef", "name" : "'GeometryIndex'" },
-        { "kind" : "IdRef", "name" : "'Hit Kind'" },
-        { "kind" : "IdRef", "name" : "'SBT Record Index'" },
-        { "kind" : "IdRef", "name" : "'Origin'" },
-        { "kind" : "IdRef", "name" : "'TMin'" },
-        { "kind" : "IdRef", "name" : "'Direction'" },
-        { "kind" : "IdRef", "name" : "'TMax'" },
-        { "kind" : "IdRef", "name" : "'Current Time'" },
-        { "kind" : "IdRef", "name" : "'HitObject Attributes'" }
+        { "kind" : "IdRef", "name" : "Hit Object" },
+        { "kind" : "IdRef", "name" : "Acceleration Structure" },
+        { "kind" : "IdRef", "name" : "InstanceId" },
+        { "kind" : "IdRef", "name" : "PrimitiveId" },
+        { "kind" : "IdRef", "name" : "GeometryIndex" },
+        { "kind" : "IdRef", "name" : "Hit Kind" },
+        { "kind" : "IdRef", "name" : "SBT Record Index" },
+        { "kind" : "IdRef", "name" : "Origin" },
+        { "kind" : "IdRef", "name" : "TMin" },
+        { "kind" : "IdRef", "name" : "Direction" },
+        { "kind" : "IdRef", "name" : "TMax" },
+        { "kind" : "IdRef", "name" : "Current Time" },
+        { "kind" : "IdRef", "name" : "HitObject Attributes" }
       ],
       "capabilities" : [ "ShaderInvocationReorderNV", "RayTracingMotionBlurNV" ],
       "version" : "None"
@@ -5545,13 +5545,13 @@
       "class"  : "Reserved",
       "opcode" : 5251,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Hit Object'" },
-        { "kind" : "IdRef", "name" : "'SBT Index'" },
-        { "kind" : "IdRef", "name" : "'Origin'" },
-        { "kind" : "IdRef", "name" : "'TMin'" },
-        { "kind" : "IdRef", "name" : "'Direction'" },
-        { "kind" : "IdRef", "name" : "'TMax'" },
-        { "kind" : "IdRef", "name" : "'Current Time'" }
+        { "kind" : "IdRef", "name" : "Hit Object" },
+        { "kind" : "IdRef", "name" : "SBT Index" },
+        { "kind" : "IdRef", "name" : "Origin" },
+        { "kind" : "IdRef", "name" : "TMin" },
+        { "kind" : "IdRef", "name" : "Direction" },
+        { "kind" : "IdRef", "name" : "TMax" },
+        { "kind" : "IdRef", "name" : "Current Time" }
       ],
       "capabilities" : [ "ShaderInvocationReorderNV", "RayTracingMotionBlurNV" ],
       "version" : "None"
@@ -5563,7 +5563,7 @@
       "operands" : [
         { "kind" : "IdResultType"},
         { "kind" : "IdResult"},
-        { "kind" : "IdRef", "name" : "'Hit Object'" }
+        { "kind" : "IdRef", "name" : "Hit Object" }
       ],
       "capabilities" : [ "ShaderInvocationReorderNV" ],
       "version" : "None"
@@ -5575,7 +5575,7 @@
       "operands" : [
         { "kind" : "IdResultType"},
         { "kind" : "IdResult"},
-        { "kind" : "IdRef", "name" : "'Hit Object'" }
+        { "kind" : "IdRef", "name" : "Hit Object" }
       ],
       "capabilities" : [ "ShaderInvocationReorderNV" ],
       "version" : "None"
@@ -5587,7 +5587,7 @@
       "operands" : [
         { "kind" : "IdResultType"},
         { "kind" : "IdResult"},
-        { "kind" : "IdRef", "name" : "'Hit Object'" }
+        { "kind" : "IdRef", "name" : "Hit Object" }
       ],
       "capabilities" : [ "ShaderInvocationReorderNV" ],
       "version" : "None"
@@ -5599,7 +5599,7 @@
       "operands" : [
         { "kind" : "IdResultType"},
         { "kind" : "IdResult"},
-        { "kind" : "IdRef", "name" : "'Hit Object'" }
+        { "kind" : "IdRef", "name" : "Hit Object" }
       ],
       "capabilities" : [ "ShaderInvocationReorderNV" ],
       "version" : "None"
@@ -5609,19 +5609,19 @@
       "class"  : "Reserved",
       "opcode" : 5256,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Hit Object'" },
-        { "kind" : "IdRef", "name" : "'Acceleration Structure'"},
-        { "kind" : "IdRef", "name" : "'RayFlags'"},
-        { "kind" : "IdRef", "name" : "'Cullmask'"},
-        { "kind" : "IdRef", "name" : "'SBT Record Offset'"},
-        { "kind" : "IdRef", "name" : "'SBT Record Stride'"},
-        { "kind" : "IdRef", "name" : "'Miss Index'"},
-        { "kind" : "IdRef", "name" : "'Origin'"},
-        { "kind" : "IdRef", "name" : "'TMin'"},
-        { "kind" : "IdRef", "name" : "'Direction'"},
-        { "kind" : "IdRef", "name" : "'TMax'"},
-        { "kind" : "IdRef", "name" : "'Time'"},
-        { "kind" : "IdRef", "name" : "'Payload'"}
+        { "kind" : "IdRef", "name" : "Hit Object" },
+        { "kind" : "IdRef", "name" : "Acceleration Structure"},
+        { "kind" : "IdRef", "name" : "RayFlags"},
+        { "kind" : "IdRef", "name" : "Cullmask"},
+        { "kind" : "IdRef", "name" : "SBT Record Offset"},
+        { "kind" : "IdRef", "name" : "SBT Record Stride"},
+        { "kind" : "IdRef", "name" : "Miss Index"},
+        { "kind" : "IdRef", "name" : "Origin"},
+        { "kind" : "IdRef", "name" : "TMin"},
+        { "kind" : "IdRef", "name" : "Direction"},
+        { "kind" : "IdRef", "name" : "TMax"},
+        { "kind" : "IdRef", "name" : "Time"},
+        { "kind" : "IdRef", "name" : "Payload"}
       ],
       "capabilities" : [ "ShaderInvocationReorderNV", "RayTracingMotionBlurNV" ],
       "version" : "None"
@@ -5633,7 +5633,7 @@
       "operands" : [
         { "kind" : "IdResultType"},
         { "kind" : "IdResult"},
-        { "kind" : "IdRef", "name" : "'Hit Object'" }
+        { "kind" : "IdRef", "name" : "Hit Object" }
       ],
       "capabilities" : [ "ShaderInvocationReorderNV" ],
       "version" : "None"
@@ -5645,7 +5645,7 @@
       "operands" : [
         { "kind" : "IdResultType"},
         { "kind" : "IdResult"},
-        { "kind" : "IdRef", "name" : "'Hit Object'" }
+        { "kind" : "IdRef", "name" : "Hit Object" }
       ],
       "capabilities" : [ "ShaderInvocationReorderNV" ],
       "version" : "None"
@@ -5655,7 +5655,7 @@
       "class"  : "Reserved",
       "opcode" : 5259,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Hit Object'" }
+        { "kind" : "IdRef", "name" : "Hit Object" }
       ],
       "capabilities" : [ "ShaderInvocationReorderNV" ],
       "version" : "None"
@@ -5665,18 +5665,18 @@
       "class"  : "Reserved",
       "opcode" : 5260,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Hit Object'" },
-        { "kind" : "IdRef", "name" : "'Acceleration Structure'"},
-        { "kind" : "IdRef", "name" : "'RayFlags'"},
-        { "kind" : "IdRef", "name" : "'Cullmask'"},
-        { "kind" : "IdRef", "name" : "'SBT Record Offset'"},
-        { "kind" : "IdRef", "name" : "'SBT Record Stride'"},
-        { "kind" : "IdRef", "name" : "'Miss Index'"},
-        { "kind" : "IdRef", "name" : "'Origin'"},
-        { "kind" : "IdRef", "name" : "'TMin'"},
-        { "kind" : "IdRef", "name" : "'Direction'"},
-        { "kind" : "IdRef", "name" : "'TMax'"},
-        { "kind" : "IdRef", "name" : "'Payload'"}
+        { "kind" : "IdRef", "name" : "Hit Object" },
+        { "kind" : "IdRef", "name" : "Acceleration Structure"},
+        { "kind" : "IdRef", "name" : "RayFlags"},
+        { "kind" : "IdRef", "name" : "Cullmask"},
+        { "kind" : "IdRef", "name" : "SBT Record Offset"},
+        { "kind" : "IdRef", "name" : "SBT Record Stride"},
+        { "kind" : "IdRef", "name" : "Miss Index"},
+        { "kind" : "IdRef", "name" : "Origin"},
+        { "kind" : "IdRef", "name" : "TMin"},
+        { "kind" : "IdRef", "name" : "Direction"},
+        { "kind" : "IdRef", "name" : "TMax"},
+        { "kind" : "IdRef", "name" : "Payload"}
       ],
       "capabilities" : [ "ShaderInvocationReorderNV" ],
       "version" : "None"
@@ -5686,19 +5686,19 @@
       "class"  : "Reserved",
       "opcode" : 5261,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Hit Object'" },
-        { "kind" : "IdRef", "name" : "'Acceleration Structure'" },
-        { "kind" : "IdRef", "name" : "'InstanceId'" },
-        { "kind" : "IdRef", "name" : "'PrimitiveId'" },
-        { "kind" : "IdRef", "name" : "'GeometryIndex'" },
-        { "kind" : "IdRef", "name" : "'Hit Kind'" },
-        { "kind" : "IdRef", "name" : "'SBT Record Offset'" },
-        { "kind" : "IdRef", "name" : "'SBT Record Stride'" },
-        { "kind" : "IdRef", "name" : "'Origin'" },
-        { "kind" : "IdRef", "name" : "'TMin'" },
-        { "kind" : "IdRef", "name" : "'Direction'" },
-        { "kind" : "IdRef", "name" : "'TMax'" },
-        { "kind" : "IdRef", "name" : "'HitObject Attributes'" }
+        { "kind" : "IdRef", "name" : "Hit Object" },
+        { "kind" : "IdRef", "name" : "Acceleration Structure" },
+        { "kind" : "IdRef", "name" : "InstanceId" },
+        { "kind" : "IdRef", "name" : "PrimitiveId" },
+        { "kind" : "IdRef", "name" : "GeometryIndex" },
+        { "kind" : "IdRef", "name" : "Hit Kind" },
+        { "kind" : "IdRef", "name" : "SBT Record Offset" },
+        { "kind" : "IdRef", "name" : "SBT Record Stride" },
+        { "kind" : "IdRef", "name" : "Origin" },
+        { "kind" : "IdRef", "name" : "TMin" },
+        { "kind" : "IdRef", "name" : "Direction" },
+        { "kind" : "IdRef", "name" : "TMax" },
+        { "kind" : "IdRef", "name" : "HitObject Attributes" }
       ],
       "capabilities" : [ "ShaderInvocationReorderNV" ],
       "version" : "None"
@@ -5708,18 +5708,18 @@
       "class"  : "Reserved",
       "opcode" : 5262,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Hit Object'" },
-        { "kind" : "IdRef", "name" : "'Acceleration Structure'" },
-        { "kind" : "IdRef", "name" : "'InstanceId'" },
-        { "kind" : "IdRef", "name" : "'PrimitiveId'" },
-        { "kind" : "IdRef", "name" : "'GeometryIndex'" },
-        { "kind" : "IdRef", "name" : "'Hit Kind'" },
-        { "kind" : "IdRef", "name" : "'SBT Record Index'" },
-        { "kind" : "IdRef", "name" : "'Origin'" },
-        { "kind" : "IdRef", "name" : "'TMin'" },
-        { "kind" : "IdRef", "name" : "'Direction'" },
-        { "kind" : "IdRef", "name" : "'TMax'" },
-        { "kind" : "IdRef", "name" : "'HitObject Attributes'" }
+        { "kind" : "IdRef", "name" : "Hit Object" },
+        { "kind" : "IdRef", "name" : "Acceleration Structure" },
+        { "kind" : "IdRef", "name" : "InstanceId" },
+        { "kind" : "IdRef", "name" : "PrimitiveId" },
+        { "kind" : "IdRef", "name" : "GeometryIndex" },
+        { "kind" : "IdRef", "name" : "Hit Kind" },
+        { "kind" : "IdRef", "name" : "SBT Record Index" },
+        { "kind" : "IdRef", "name" : "Origin" },
+        { "kind" : "IdRef", "name" : "TMin" },
+        { "kind" : "IdRef", "name" : "Direction" },
+        { "kind" : "IdRef", "name" : "TMax" },
+        { "kind" : "IdRef", "name" : "HitObject Attributes" }
       ],
       "capabilities" : [ "ShaderInvocationReorderNV" ],
       "version" : "None"
@@ -5729,12 +5729,12 @@
       "class"  : "Reserved",
       "opcode" : 5263,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Hit Object'" },
-        { "kind" : "IdRef", "name" : "'SBT Index'" },
-        { "kind" : "IdRef", "name" : "'Origin'" },
-        { "kind" : "IdRef", "name" : "'TMin'" },
-        { "kind" : "IdRef", "name" : "'Direction'" },
-        { "kind" : "IdRef", "name" : "'TMax'" }
+        { "kind" : "IdRef", "name" : "Hit Object" },
+        { "kind" : "IdRef", "name" : "SBT Index" },
+        { "kind" : "IdRef", "name" : "Origin" },
+        { "kind" : "IdRef", "name" : "TMin" },
+        { "kind" : "IdRef", "name" : "Direction" },
+        { "kind" : "IdRef", "name" : "TMax" }
       ],
       "capabilities" : [ "ShaderInvocationReorderNV" ],
       "version" : "None"
@@ -5744,8 +5744,8 @@
       "class"  : "Reserved",
       "opcode" : 5264,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Hit Object'" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Hit Object" },
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "ShaderInvocationReorderNV" ],
       "version" : "None"
@@ -5757,7 +5757,7 @@
       "operands" : [
         { "kind" : "IdResultType"},
         { "kind" : "IdResult"},
-        { "kind" : "IdRef", "name" : "'Hit Object'" }
+        { "kind" : "IdRef", "name" : "Hit Object" }
       ],
       "capabilities" : [ "ShaderInvocationReorderNV" ],
       "version" : "None"
@@ -5767,8 +5767,8 @@
       "class"  : "Reserved",
       "opcode" : 5266,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Hit Object'" },
-        { "kind" : "IdRef", "name" : "'Hit Object Attribute'" }
+        { "kind" : "IdRef", "name" : "Hit Object" },
+        { "kind" : "IdRef", "name" : "Hit Object Attribute" }
       ],
       "capabilities" : [ "ShaderInvocationReorderNV" ],
       "version" : "None"
@@ -5780,7 +5780,7 @@
       "operands" : [
         { "kind" : "IdResultType"},
         { "kind" : "IdResult"},
-        { "kind" : "IdRef", "name" : "'Hit Object'" }
+        { "kind" : "IdRef", "name" : "Hit Object" }
       ],
       "capabilities" : [ "ShaderInvocationReorderNV" ],
       "version" : "None"
@@ -5792,7 +5792,7 @@
       "operands" : [
         { "kind" : "IdResultType"},
         { "kind" : "IdResult"},
-        { "kind" : "IdRef", "name" : "'Hit Object'" }
+        { "kind" : "IdRef", "name" : "Hit Object" }
       ],
       "capabilities" : [ "ShaderInvocationReorderNV" ],
       "version" : "None"
@@ -5804,7 +5804,7 @@
       "operands" : [
         { "kind" : "IdResultType"},
         { "kind" : "IdResult"},
-        { "kind" : "IdRef", "name" : "'Hit Object'" }
+        { "kind" : "IdRef", "name" : "Hit Object" }
       ],
       "capabilities" : [ "ShaderInvocationReorderNV" ],
       "version" : "None"
@@ -5816,7 +5816,7 @@
       "operands" : [
         { "kind" : "IdResultType"},
         { "kind" : "IdResult"},
-        { "kind" : "IdRef", "name" : "'Hit Object'" }
+        { "kind" : "IdRef", "name" : "Hit Object" }
       ],
       "capabilities" : [ "ShaderInvocationReorderNV" ],
       "version" : "None"
@@ -5828,7 +5828,7 @@
       "operands" : [
         { "kind" : "IdResultType"},
         { "kind" : "IdResult"},
-        { "kind" : "IdRef", "name" : "'Hit Object'" }
+        { "kind" : "IdRef", "name" : "Hit Object" }
       ],
       "capabilities" : [ "ShaderInvocationReorderNV" ],
       "version" : "None"
@@ -5840,7 +5840,7 @@
       "operands" : [
         { "kind" : "IdResultType"},
         { "kind" : "IdResult"},
-        { "kind" : "IdRef", "name" : "'Hit Object'" }
+        { "kind" : "IdRef", "name" : "Hit Object" }
       ],
       "capabilities" : [ "ShaderInvocationReorderNV" ],
       "version" : "None"
@@ -5852,7 +5852,7 @@
       "operands" : [
         { "kind" : "IdResultType"},
         { "kind" : "IdResult"},
-        { "kind" : "IdRef", "name" : "'Hit Object'" }
+        { "kind" : "IdRef", "name" : "Hit Object" }
       ],
       "capabilities" : [ "ShaderInvocationReorderNV" ],
       "version" : "None"
@@ -5864,7 +5864,7 @@
       "operands" : [
         { "kind" : "IdResultType"},
         { "kind" : "IdResult"},
-        { "kind" : "IdRef", "name" : "'Hit Object'" }
+        { "kind" : "IdRef", "name" : "Hit Object" }
       ],
       "capabilities" : [ "ShaderInvocationReorderNV" ],
       "version" : "None"
@@ -5876,7 +5876,7 @@
       "operands" : [
         { "kind" : "IdResultType"},
         { "kind" : "IdResult"},
-        { "kind" : "IdRef", "name" : "'Hit Object'" }
+        { "kind" : "IdRef", "name" : "Hit Object" }
       ],
       "capabilities" : [ "ShaderInvocationReorderNV" ],
       "version" : "None"
@@ -5888,7 +5888,7 @@
       "operands" : [
         { "kind" : "IdResultType"},
         { "kind" : "IdResult"},
-        { "kind" : "IdRef", "name" : "'Hit Object'" }
+        { "kind" : "IdRef", "name" : "Hit Object" }
       ],
       "capabilities" : [ "ShaderInvocationReorderNV" ],
       "version" : "None"
@@ -5900,7 +5900,7 @@
       "operands" : [
         { "kind" : "IdResultType"},
         { "kind" : "IdResult"},
-        { "kind" : "IdRef", "name" : "'Hit Object'" }
+        { "kind" : "IdRef", "name" : "Hit Object" }
       ],
       "capabilities" : [ "ShaderInvocationReorderNV" ],
       "version" : "None"
@@ -5912,7 +5912,7 @@
       "operands" : [
         { "kind" : "IdResultType"},
         { "kind" : "IdResult"},
-        { "kind" : "IdRef", "name" : "'Hit Object'" }
+        { "kind" : "IdRef", "name" : "Hit Object" }
       ],
       "capabilities" : [ "ShaderInvocationReorderNV" ],
       "version" : "None"
@@ -5922,9 +5922,9 @@
       "class"  : "Reserved",
       "opcode" : 5279,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Hit Object'" },
-        { "kind" : "IdRef", "quantifier" : "?", "name" : "'Hint'" },
-        { "kind" : "IdRef", "quantifier" : "?", "name" : "'Bits'" }
+        { "kind" : "IdRef", "name" : "Hit Object" },
+        { "kind" : "IdRef", "quantifier" : "?", "name" : "Hint" },
+        { "kind" : "IdRef", "quantifier" : "?", "name" : "Bits" }
       ],
       "capabilities" : [ "ShaderInvocationReorderNV" ],
       "version" : "None"
@@ -5934,8 +5934,8 @@
       "class"  : "Reserved",
       "opcode" : 5280,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Hint'" },
-        { "kind" : "IdRef", "name" : "'Bits'" }
+        { "kind" : "IdRef", "name" : "Hint" },
+        { "kind" : "IdRef", "name" : "Bits" }
       ],
       "capabilities" : [ "ShaderInvocationReorderNV" ],
       "version" : "None"
@@ -5957,10 +5957,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Sampled Image'" },
-        { "kind" : "IdRef", "name" : "'Coordinate'" },
-        { "kind" : "IdRef", "name" : "'Granularity'" },
-        { "kind" : "IdRef", "name" : "'Coarse'" },
+        { "kind" : "IdRef", "name" : "Sampled Image" },
+        { "kind" : "IdRef", "name" : "Coordinate" },
+        { "kind" : "IdRef", "name" : "Granularity" },
+        { "kind" : "IdRef", "name" : "Coarse" },
         { "kind" : "ImageOperands", "quantifier" : "?" }
       ],
       "capabilities" : [ "ImageFootprintNV" ],
@@ -5973,8 +5973,8 @@
       "opcode" : 5288,
       "operands" : [
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Component Type'" },
-        { "kind" : "IdRef",        "name" : "'Component Count'" }
+        { "kind" : "IdRef",        "name" : "Component Type" },
+        { "kind" : "IdRef",        "name" : "Component Count" }
       ],
       "capabilities" : [ "CooperativeVectorNV" ],
       "version" : "None"
@@ -5986,16 +5986,16 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",             "name" : "'Input'" },
-        { "kind" : "IdRef",             "name" : "'InputInterpretation'" },
-        { "kind" : "IdRef",             "name" : "'Matrix'" },
-        { "kind" : "IdRef",             "name" : "'MatrixOffset'" },
-        { "kind" : "IdRef",             "name" : "'MatrixInterpretation'" },
-        { "kind" : "IdRef",             "name" : "'M'" },
-        { "kind" : "IdRef",             "name" : "'K'" },
-        { "kind" : "IdRef",             "name" : "'MemoryLayout'" },
-        { "kind" : "IdRef",             "name" : "'Transpose'" },
-        { "kind" : "IdRef",             "name" : "'MatrixStride'", "quantifier": "?" },
+        { "kind" : "IdRef",             "name" : "Input" },
+        { "kind" : "IdRef",             "name" : "InputInterpretation" },
+        { "kind" : "IdRef",             "name" : "Matrix" },
+        { "kind" : "IdRef",             "name" : "MatrixOffset" },
+        { "kind" : "IdRef",             "name" : "MatrixInterpretation" },
+        { "kind" : "IdRef",             "name" : "M" },
+        { "kind" : "IdRef",             "name" : "K" },
+        { "kind" : "IdRef",             "name" : "MemoryLayout" },
+        { "kind" : "IdRef",             "name" : "Transpose" },
+        { "kind" : "IdRef",             "name" : "MatrixStride", "quantifier": "?" },
         { "kind" : "CooperativeMatrixOperands",             "quantifier" : "?" }
       ],
       "capabilities" : [ "CooperativeVectorNV" ],
@@ -6006,13 +6006,13 @@
       "class"  : "Reserved",
       "opcode" : 5290,
       "operands" : [
-        { "kind" : "IdRef",             "name" : "'Pointer'" },
-        { "kind" : "IdRef",             "name" : "'Offset'" },
-        { "kind" : "IdRef",             "name" : "'A'" },
-        { "kind" : "IdRef",             "name" : "'B'" },
-        { "kind" : "IdRef",             "name" : "'MemoryLayout'" },
-        { "kind" : "IdRef",             "name" : "'MatrixInterpretation'" },
-        { "kind" : "IdRef",             "name" : "'MatrixStride'", "quantifier": "?" }
+        { "kind" : "IdRef",             "name" : "Pointer" },
+        { "kind" : "IdRef",             "name" : "Offset" },
+        { "kind" : "IdRef",             "name" : "A" },
+        { "kind" : "IdRef",             "name" : "B" },
+        { "kind" : "IdRef",             "name" : "MemoryLayout" },
+        { "kind" : "IdRef",             "name" : "MatrixInterpretation" },
+        { "kind" : "IdRef",             "name" : "MatrixStride", "quantifier": "?" }
       ],
       "capabilities" : [ "CooperativeVectorTrainingNV" ],
       "version" : "None"
@@ -6022,9 +6022,9 @@
       "class"  : "Reserved",
       "opcode" : 5291,
       "operands" : [
-        { "kind" : "IdRef",             "name" : "'Pointer'" },
-        { "kind" : "IdRef",             "name" : "'Offset'" },
-        { "kind" : "IdRef",             "name" : "'V'" }
+        { "kind" : "IdRef",             "name" : "Pointer" },
+        { "kind" : "IdRef",             "name" : "Offset" },
+        { "kind" : "IdRef",             "name" : "V" }
       ],
       "capabilities" : [ "CooperativeVectorTrainingNV" ],
       "version" : "None"
@@ -6036,19 +6036,19 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",             "name" : "'Input'" },
-        { "kind" : "IdRef",             "name" : "'InputInterpretation'" },
-        { "kind" : "IdRef",             "name" : "'Matrix'" },
-        { "kind" : "IdRef",             "name" : "'MatrixOffset'" },
-        { "kind" : "IdRef",             "name" : "'MatrixInterpretation'" },
-        { "kind" : "IdRef",             "name" : "'Bias'" },
-        { "kind" : "IdRef",             "name" : "'BiasOffset'" },
-        { "kind" : "IdRef",             "name" : "'BiasInterpretation'" },
-        { "kind" : "IdRef",             "name" : "'M'" },
-        { "kind" : "IdRef",             "name" : "'K'" },
-        { "kind" : "IdRef",             "name" : "'MemoryLayout'" },
-        { "kind" : "IdRef",             "name" : "'Transpose'" },
-        { "kind" : "IdRef",             "name" : "'MatrixStride'", "quantifier": "?" },
+        { "kind" : "IdRef",             "name" : "Input" },
+        { "kind" : "IdRef",             "name" : "InputInterpretation" },
+        { "kind" : "IdRef",             "name" : "Matrix" },
+        { "kind" : "IdRef",             "name" : "MatrixOffset" },
+        { "kind" : "IdRef",             "name" : "MatrixInterpretation" },
+        { "kind" : "IdRef",             "name" : "Bias" },
+        { "kind" : "IdRef",             "name" : "BiasOffset" },
+        { "kind" : "IdRef",             "name" : "BiasInterpretation" },
+        { "kind" : "IdRef",             "name" : "M" },
+        { "kind" : "IdRef",             "name" : "K" },
+        { "kind" : "IdRef",             "name" : "MemoryLayout" },
+        { "kind" : "IdRef",             "name" : "Transpose" },
+        { "kind" : "IdRef",             "name" : "MatrixStride", "quantifier": "?" },
         { "kind" : "CooperativeMatrixOperands",             "quantifier" : "?" }
       ],
       "capabilities" : [ "CooperativeVectorNV" ],
@@ -6061,7 +6061,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",             "name" : "'Matrix'" }
+        { "kind" : "IdRef",             "name" : "Matrix" }
       ],
       "capabilities" : [ "CooperativeMatrixConversionsNV" ],
       "version" : "None"
@@ -6071,10 +6071,10 @@
       "class"  : "Reserved",
       "opcode" : 5294,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Group Count X'" },
-        { "kind" : "IdRef", "name" : "'Group Count Y'" },
-        { "kind" : "IdRef", "name" : "'Group Count Z'" },
-        { "kind" : "IdRef", "quantifier" : "?", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Group Count X" },
+        { "kind" : "IdRef", "name" : "Group Count Y" },
+        { "kind" : "IdRef", "name" : "Group Count Z" },
+        { "kind" : "IdRef", "quantifier" : "?", "name" : "Payload" }
       ],
       "capabilities" : [ "MeshShadingEXT" ],
       "version" : "None"
@@ -6084,8 +6084,8 @@
       "class"  : "Reserved",
       "opcode" : 5295,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Vertex Count'" },
-        { "kind" : "IdRef", "name" : "'Primitive Count'" }
+        { "kind" : "IdRef", "name" : "Vertex Count" },
+        { "kind" : "IdRef", "name" : "Primitive Count" }
       ],
       "capabilities" : [ "MeshShadingEXT" ],
       "version" : "None"
@@ -6097,7 +6097,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Value'" }
+        { "kind" : "IdRef", "name" : "Value" }
       ],
       "capabilities" : [ "GroupNonUniformPartitionedNV" ],
       "extensions" : [ "SPV_NV_shader_subgroup_partitioned" ],
@@ -6108,8 +6108,8 @@
       "class"  : "Reserved",
       "opcode" : 5299,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Index Offset'" },
-        { "kind" : "IdRef", "name" : "'Packed Indices'" }
+        { "kind" : "IdRef", "name" : "Index Offset" },
+        { "kind" : "IdRef", "name" : "Packed Indices" }
       ],
       "capabilities" : [ "MeshShadingNV" ],
       "extensions" : [ "SPV_NV_mesh_shader" ],
@@ -6122,11 +6122,11 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Accel'" },
-        { "kind" : "IdRef", "name" : "'Instance Id'" },
-        { "kind" : "IdRef", "name" : "'Geometry Index'" },
-        { "kind" : "IdRef", "name" : "'Primitive Index'" },
-        { "kind" : "IdRef", "name" : "'Barycentric'" }
+        { "kind" : "IdRef", "name" : "Accel" },
+        { "kind" : "IdRef", "name" : "Instance Id" },
+        { "kind" : "IdRef", "name" : "Geometry Index" },
+        { "kind" : "IdRef", "name" : "Primitive Index" },
+        { "kind" : "IdRef", "name" : "Barycentric" }
       ],
       "capabilities" : [ "DisplacementMicromapNV" ],
       "version" : "None"
@@ -6138,11 +6138,11 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Accel'" },
-        { "kind" : "IdRef", "name" : "'Instance Id'" },
-        { "kind" : "IdRef", "name" : "'Geometry Index'" },
-        { "kind" : "IdRef", "name" : "'Primitive Index'" },
-        { "kind" : "IdRef", "name" : "'Barycentric'" }
+        { "kind" : "IdRef", "name" : "Accel" },
+        { "kind" : "IdRef", "name" : "Instance Id" },
+        { "kind" : "IdRef", "name" : "Geometry Index" },
+        { "kind" : "IdRef", "name" : "Primitive Index" },
+        { "kind" : "IdRef", "name" : "Barycentric" }
       ],
       "capabilities" : [ "DisplacementMicromapNV" ],
       "version" : "None"
@@ -6154,8 +6154,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",             "name" : "'Pointer'" },
-        { "kind" : "IdRef",             "name" : "'Offset'" },
+        { "kind" : "IdRef",             "name" : "Pointer" },
+        { "kind" : "IdRef",             "name" : "Offset" },
         { "kind" : "MemoryAccess",      "quantifier" : "?" }
       ],
       "capabilities" : [ "CooperativeVectorNV" ],
@@ -6166,9 +6166,9 @@
       "class"  : "Memory",
       "opcode" : 5303,
       "operands" : [
-        { "kind" : "IdRef",             "name" : "'Pointer'" },
-        { "kind" : "IdRef",             "name" : "'Offset'" },
-        { "kind" : "IdRef",             "name" : "'Object'" },
+        { "kind" : "IdRef",             "name" : "Pointer" },
+        { "kind" : "IdRef",             "name" : "Offset" },
+        { "kind" : "IdRef",             "name" : "Object" },
         { "kind" : "MemoryAccess",      "quantifier" : "?" }
       ],
       "capabilities" : [ "CooperativeVectorNV" ],
@@ -6182,8 +6182,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Hit'" },
-        { "kind" : "IdRef", "name" : "'HitKind'" }
+        { "kind" : "IdRef", "name" : "Hit" },
+        { "kind" : "IdRef", "name" : "HitKind" }
       ],
       "capabilities" : [ "RayTracingNV" , "RayTracingKHR" ],
       "extensions" : [ "SPV_NV_ray_tracing" , "SPV_KHR_ray_tracing" ],
@@ -6211,17 +6211,17 @@
       "opcode" : 5337,
       "operands" : [
 
-        { "kind" : "IdRef", "name" : "'Accel'" },
-        { "kind" : "IdRef", "name" : "'Ray Flags'" },
-        { "kind" : "IdRef", "name" : "'Cull Mask'" },
-        { "kind" : "IdRef", "name" : "'SBT Offset'" },
-        { "kind" : "IdRef", "name" : "'SBT Stride'" },
-        { "kind" : "IdRef", "name" : "'Miss Index'" },
-        { "kind" : "IdRef", "name" : "'Ray Origin'" },
-        { "kind" : "IdRef", "name" : "'Ray Tmin'" },
-        { "kind" : "IdRef", "name" : "'Ray Direction'" },
-        { "kind" : "IdRef", "name" : "'Ray Tmax'" },
-        { "kind" : "IdRef", "name" : "'PayloadId'" }
+        { "kind" : "IdRef", "name" : "Accel" },
+        { "kind" : "IdRef", "name" : "Ray Flags" },
+        { "kind" : "IdRef", "name" : "Cull Mask" },
+        { "kind" : "IdRef", "name" : "SBT Offset" },
+        { "kind" : "IdRef", "name" : "SBT Stride" },
+        { "kind" : "IdRef", "name" : "Miss Index" },
+        { "kind" : "IdRef", "name" : "Ray Origin" },
+        { "kind" : "IdRef", "name" : "Ray Tmin" },
+        { "kind" : "IdRef", "name" : "Ray Direction" },
+        { "kind" : "IdRef", "name" : "Ray Tmax" },
+        { "kind" : "IdRef", "name" : "PayloadId" }
       ],
       "capabilities" : [ "RayTracingNV" ],
       "extensions" : [ "SPV_NV_ray_tracing" ],
@@ -6233,18 +6233,18 @@
       "opcode" : 5338,
       "operands" : [
 
-        { "kind" : "IdRef", "name" : "'Accel'" },
-        { "kind" : "IdRef", "name" : "'Ray Flags'" },
-        { "kind" : "IdRef", "name" : "'Cull Mask'" },
-        { "kind" : "IdRef", "name" : "'SBT Offset'" },
-        { "kind" : "IdRef", "name" : "'SBT Stride'" },
-        { "kind" : "IdRef", "name" : "'Miss Index'" },
-        { "kind" : "IdRef", "name" : "'Ray Origin'" },
-        { "kind" : "IdRef", "name" : "'Ray Tmin'" },
-        { "kind" : "IdRef", "name" : "'Ray Direction'" },
-        { "kind" : "IdRef", "name" : "'Ray Tmax'" },
-        { "kind" : "IdRef", "name" : "'Time'" },
-        { "kind" : "IdRef", "name" : "'PayloadId'" }
+        { "kind" : "IdRef", "name" : "Accel" },
+        { "kind" : "IdRef", "name" : "Ray Flags" },
+        { "kind" : "IdRef", "name" : "Cull Mask" },
+        { "kind" : "IdRef", "name" : "SBT Offset" },
+        { "kind" : "IdRef", "name" : "SBT Stride" },
+        { "kind" : "IdRef", "name" : "Miss Index" },
+        { "kind" : "IdRef", "name" : "Ray Origin" },
+        { "kind" : "IdRef", "name" : "Ray Tmin" },
+        { "kind" : "IdRef", "name" : "Ray Direction" },
+        { "kind" : "IdRef", "name" : "Ray Tmax" },
+        { "kind" : "IdRef", "name" : "Time" },
+        { "kind" : "IdRef", "name" : "PayloadId" }
       ],
       "capabilities" : [ "RayTracingMotionBlurNV" ],
       "extensions" : [ "SPV_NV_ray_tracing_motion_blur" ],
@@ -6256,18 +6256,18 @@
       "opcode" : 5339,
       "operands" : [
 
-        { "kind" : "IdRef", "name" : "'Accel'" },
-        { "kind" : "IdRef", "name" : "'Ray Flags'" },
-        { "kind" : "IdRef", "name" : "'Cull Mask'" },
-        { "kind" : "IdRef", "name" : "'SBT Offset'" },
-        { "kind" : "IdRef", "name" : "'SBT Stride'" },
-        { "kind" : "IdRef", "name" : "'Miss Index'" },
-        { "kind" : "IdRef", "name" : "'Ray Origin'" },
-        { "kind" : "IdRef", "name" : "'Ray Tmin'" },
-        { "kind" : "IdRef", "name" : "'Ray Direction'" },
-        { "kind" : "IdRef", "name" : "'Ray Tmax'" },
-        { "kind" : "IdRef", "name" : "'Time'" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Accel" },
+        { "kind" : "IdRef", "name" : "Ray Flags" },
+        { "kind" : "IdRef", "name" : "Cull Mask" },
+        { "kind" : "IdRef", "name" : "SBT Offset" },
+        { "kind" : "IdRef", "name" : "SBT Stride" },
+        { "kind" : "IdRef", "name" : "Miss Index" },
+        { "kind" : "IdRef", "name" : "Ray Origin" },
+        { "kind" : "IdRef", "name" : "Ray Tmin" },
+        { "kind" : "IdRef", "name" : "Ray Direction" },
+        { "kind" : "IdRef", "name" : "Ray Tmax" },
+        { "kind" : "IdRef", "name" : "Time" },
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "RayTracingMotionBlurNV" ],
       "extensions" : [ "SPV_NV_ray_tracing_motion_blur" ],
@@ -6282,11 +6282,11 @@
             { "kind" : "IdResult" },
             {
                 "kind" : "IdRef",
-                "name" : "'RayQuery'"
+                "name" : "RayQuery"
             },
             {
                 "kind" : "IdRef",
-                "name" : "'Intersection'"
+                "name" : "Intersection"
             }
         ],
       "capabilities" : [ "RayQueryPositionFetchKHR" ],
@@ -6310,8 +6310,8 @@
       "opcode" : 5344,
       "operands" : [
 
-        { "kind" : "IdRef", "name" : "'SBT Index'" },
-        { "kind" : "IdRef", "name" : "'Callable DataId'" }
+        { "kind" : "IdRef", "name" : "SBT Index" },
+        { "kind" : "IdRef", "name" : "Callable DataId" }
       ],
       "capabilities" : [ "RayTracingNV" ],
       "extensions" : [ "SPV_NV_ray_tracing" ],
@@ -6326,11 +6326,11 @@
           { "kind" : "IdResult" },
           {
               "kind" : "IdRef",
-              "name" : "'RayQuery'"
+              "name" : "RayQuery"
           },
           {
               "kind" : "IdRef",
-              "name" : "'Intersection'"
+              "name" : "Intersection"
           }
       ],
       "capabilities" : [ "RayTracingClusterAccelerationStructureNV" ],
@@ -6343,7 +6343,7 @@
       "operands" : [
           { "kind" : "IdResultType" },
           { "kind" : "IdResult" },
-          { "kind" : "IdRef", "name" : "'Hit Object'" }
+          { "kind" : "IdRef", "name" : "Hit Object" }
       ],
       "capabilities" : [ "RayTracingClusterAccelerationStructureNV" ],
       "version" : "None"
@@ -6354,10 +6354,10 @@
       "opcode" : 5358,
       "operands" : [
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Component Type'" },
-        { "kind" : "IdScope",      "name" : "'Execution'" },
-        { "kind" : "IdRef",        "name" : "'Rows'" },
-        { "kind" : "IdRef",        "name" : "'Columns'" }
+        { "kind" : "IdRef",        "name" : "Component Type" },
+        { "kind" : "IdScope",      "name" : "Execution" },
+        { "kind" : "IdRef",        "name" : "Rows" },
+        { "kind" : "IdRef",        "name" : "Columns" }
       ],
       "capabilities" : [ "CooperativeMatrixNV" ],
       "extensions" : [ "SPV_NV_cooperative_matrix" ],
@@ -6370,9 +6370,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",             "name" : "'Pointer'" },
-        { "kind" : "IdRef",             "name" : "'Stride'" },
-        { "kind" : "IdRef",             "name" : "'Column Major'" },
+        { "kind" : "IdRef",             "name" : "Pointer" },
+        { "kind" : "IdRef",             "name" : "Stride" },
+        { "kind" : "IdRef",             "name" : "Column Major" },
         { "kind" : "MemoryAccess",      "quantifier" : "?" }
       ],
       "capabilities" : [ "CooperativeMatrixNV" ],
@@ -6384,10 +6384,10 @@
       "class"  : "Reserved",
       "opcode" : 5360,
       "operands" : [
-        { "kind" : "IdRef",             "name" : "'Pointer'" },
-        { "kind" : "IdRef",             "name" : "'Object'" },
-        { "kind" : "IdRef",             "name" : "'Stride'" },
-        { "kind" : "IdRef",             "name" : "'Column Major'" },
+        { "kind" : "IdRef",             "name" : "Pointer" },
+        { "kind" : "IdRef",             "name" : "Object" },
+        { "kind" : "IdRef",             "name" : "Stride" },
+        { "kind" : "IdRef",             "name" : "Column Major" },
         { "kind" : "MemoryAccess",      "quantifier" : "?" }
       ],
       "capabilities" : [ "CooperativeMatrixNV" ],
@@ -6401,9 +6401,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",             "name" : "'A'" },
-        { "kind" : "IdRef",             "name" : "'B'" },
-        { "kind" : "IdRef",             "name" : "'C'" }
+        { "kind" : "IdRef",             "name" : "A" },
+        { "kind" : "IdRef",             "name" : "B" },
+        { "kind" : "IdRef",             "name" : "C" }
       ],
       "capabilities" : [ "CooperativeMatrixNV" ],
       "extensions" : [ "SPV_NV_cooperative_matrix" ],
@@ -6416,7 +6416,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Type'" }
+        { "kind" : "IdRef",        "name" : "Type" }
       ],
       "capabilities" : [ "CooperativeMatrixNV" ],
       "extensions" : [ "SPV_NV_cooperative_matrix" ],
@@ -6445,9 +6445,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Matrix'" },
-        { "kind" : "CooperativeMatrixReduce",      "name" : "'Reduce'" },
-        { "kind" : "IdRef", "name" : "'CombineFunc'" }
+        { "kind" : "IdRef", "name" : "Matrix" },
+        { "kind" : "CooperativeMatrixReduce",      "name" : "Reduce" },
+        { "kind" : "IdRef", "name" : "CombineFunc" }
       ],
       "capabilities" : [ "CooperativeMatrixReductionsNV" ],
       "version" : "None"
@@ -6459,11 +6459,11 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",             "name" : "'Pointer'" },
-        { "kind" : "IdRef",             "name" : "'Object'" },
-        { "kind" : "IdRef",             "name" : "'TensorLayout'" },
-        { "kind" : "MemoryAccess",      "name" : "'Memory Operand'"},
-        { "kind" : "TensorAddressingOperands", "name" : "'Tensor Addressing Operands'"}
+        { "kind" : "IdRef",             "name" : "Pointer" },
+        { "kind" : "IdRef",             "name" : "Object" },
+        { "kind" : "IdRef",             "name" : "TensorLayout" },
+        { "kind" : "MemoryAccess",      "name" : "Memory Operand"},
+        { "kind" : "TensorAddressingOperands", "name" : "Tensor Addressing Operands"}
       ],
       "capabilities" : [ "CooperativeMatrixTensorAddressingNV" ],
       "version" : "None"
@@ -6473,11 +6473,11 @@
       "class"  : "Memory",
       "opcode" : 5368,
       "operands" : [
-        { "kind" : "IdRef",             "name" : "'Pointer'" },
-        { "kind" : "IdRef",             "name" : "'Object'" },
-        { "kind" : "IdRef",             "name" : "'TensorLayout'" },
-        { "kind" : "MemoryAccess",      "name" : "'Memory Operand'"},
-        { "kind" : "TensorAddressingOperands", "name" : "'Tensor Addressing Operands'"}
+        { "kind" : "IdRef",             "name" : "Pointer" },
+        { "kind" : "IdRef",             "name" : "Object" },
+        { "kind" : "IdRef",             "name" : "TensorLayout" },
+        { "kind" : "MemoryAccess",      "name" : "Memory Operand"},
+        { "kind" : "TensorAddressingOperands", "name" : "Tensor Addressing Operands"}
       ],
       "capabilities" : [ "CooperativeMatrixTensorAddressingNV" ],
       "version" : "None"
@@ -6489,9 +6489,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Matrix'" },
-        { "kind" : "IdRef", "name" : "'Func'" },
-        { "kind" : "IdRef",        "quantifier" : "*", "name" : "'Operands'" }
+        { "kind" : "IdRef", "name" : "Matrix" },
+        { "kind" : "IdRef", "name" : "Func" },
+        { "kind" : "IdRef",        "quantifier" : "*", "name" : "Operands" }
       ],
       "capabilities" : [ "CooperativeMatrixPerElementOperationsNV" ],
       "version" : "None"
@@ -6502,8 +6502,8 @@
       "opcode" : 5370,
       "operands" : [
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",             "name" : "'Dim'" },
-        { "kind" : "IdRef",             "name" : "'ClampMode'" }
+        { "kind" : "IdRef",             "name" : "Dim" },
+        { "kind" : "IdRef",             "name" : "ClampMode" }
       ],
       "capabilities" : [ "TensorAddressingNV" ],
       "version" : "None"
@@ -6514,9 +6514,9 @@
       "opcode" : 5371,
       "operands" : [
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",             "name" : "'Dim'" },
-        { "kind" : "IdRef",             "name" : "'HasDimensions'" },
-        { "kind" : "IdRef", "quantifier" : "*", "name" : "'p'" }
+        { "kind" : "IdRef",             "name" : "Dim" },
+        { "kind" : "IdRef",             "name" : "HasDimensions" },
+        { "kind" : "IdRef", "quantifier" : "*", "name" : "p" }
       ],
       "capabilities" : [ "TensorAddressingNV" ],
       "version" : "None"
@@ -6539,8 +6539,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",                     "name" : "'TensorLayout'" },
-        { "kind" : "IdRef", "quantifier" : "*", "name" : "'Dim'" }
+        { "kind" : "IdRef",                     "name" : "TensorLayout" },
+        { "kind" : "IdRef", "quantifier" : "*", "name" : "Dim" }
 
       ],
       "capabilities" : [ "TensorAddressingNV" ],
@@ -6553,8 +6553,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",                     "name" : "'TensorLayout'" },
-        { "kind" : "IdRef", "quantifier" : "*", "name" : "'Stride'" }
+        { "kind" : "IdRef",                     "name" : "TensorLayout" },
+        { "kind" : "IdRef", "quantifier" : "*", "name" : "Stride" }
 
       ],
       "capabilities" : [ "TensorAddressingNV" ],
@@ -6567,8 +6567,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",                     "name" : "'TensorLayout'" },
-        { "kind" : "IdRef", "quantifier" : "*", "name" : "'Operands'" }
+        { "kind" : "IdRef",                     "name" : "TensorLayout" },
+        { "kind" : "IdRef", "quantifier" : "*", "name" : "Operands" }
 
       ],
       "capabilities" : [ "TensorAddressingNV" ],
@@ -6581,8 +6581,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",                     "name" : "'TensorLayout'" },
-        { "kind" : "IdRef",                     "name" : "'Value'" }
+        { "kind" : "IdRef",                     "name" : "TensorLayout" },
+        { "kind" : "IdRef",                     "name" : "Value" }
 
       ],
       "capabilities" : [ "TensorAddressingNV" ],
@@ -6606,8 +6606,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",                     "name" : "'TensorView'" },
-        { "kind" : "IdRef", "quantifier" : "*", "name" : "'Dim'" }
+        { "kind" : "IdRef",                     "name" : "TensorView" },
+        { "kind" : "IdRef", "quantifier" : "*", "name" : "Dim" }
 
       ],
       "capabilities" : [ "TensorAddressingNV" ],
@@ -6620,8 +6620,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",                     "name" : "'TensorView'" },
-        { "kind" : "IdRef", "quantifier" : "*", "name" : "'Stride'" }
+        { "kind" : "IdRef",                     "name" : "TensorView" },
+        { "kind" : "IdRef", "quantifier" : "*", "name" : "Stride" }
 
       ],
       "capabilities" : [ "TensorAddressingNV" ],
@@ -6654,11 +6654,11 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",                     "name" : "'TensorView'" },
-        { "kind" : "IdRef",                     "name" : "'ClipRowOffset'" },
-        { "kind" : "IdRef",                     "name" : "'ClipRowSpan'" },
-        { "kind" : "IdRef",                     "name" : "'ClipColOffset'" },
-        { "kind" : "IdRef",                     "name" : "'ClipColSpan'" }
+        { "kind" : "IdRef",                     "name" : "TensorView" },
+        { "kind" : "IdRef",                     "name" : "ClipRowOffset" },
+        { "kind" : "IdRef",                     "name" : "ClipRowSpan" },
+        { "kind" : "IdRef",                     "name" : "ClipColOffset" },
+        { "kind" : "IdRef",                     "name" : "ClipColSpan" }
       ],
       "capabilities" : [ "TensorAddressingNV" ],
       "version" : "None"
@@ -6670,8 +6670,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",                     "name" : "'TensorLayout'" },
-        { "kind" : "IdRef", "quantifier" : "*", "name" : "'BlockSize'" }
+        { "kind" : "IdRef",                     "name" : "TensorLayout" },
+        { "kind" : "IdRef", "quantifier" : "*", "name" : "BlockSize" }
 
       ],
       "capabilities" : [ "TensorAddressingNV" ],
@@ -6684,7 +6684,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Matrix'" }
+        { "kind" : "IdRef", "name" : "Matrix" }
       ],
       "capabilities" : [ "CooperativeMatrixConversionsNV" ],
       "version" : "None"
@@ -6696,7 +6696,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Operand'" }
+        { "kind" : "IdRef", "name" : "Operand" }
       ],
       "capabilities" : [ "BindlessTextureNV" ],
       "version" : "None"
@@ -6708,7 +6708,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Operand'" }
+        { "kind" : "IdRef", "name" : "Operand" }
       ],
       "capabilities" : [ "BindlessTextureNV" ],
       "version" : "None"
@@ -6720,7 +6720,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Operand'" }
+        { "kind" : "IdRef", "name" : "Operand" }
       ],
       "capabilities" : [ "BindlessTextureNV" ],
       "version" : "None"
@@ -6732,7 +6732,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Operand'" }
+        { "kind" : "IdRef", "name" : "Operand" }
       ],
       "capabilities" : [ "BindlessTextureNV" ],
       "version" : "None"
@@ -6744,7 +6744,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Operand'" }
+        { "kind" : "IdRef", "name" : "Operand" }
       ],
       "capabilities" : [ "BindlessTextureNV" ],
       "version" : "None"
@@ -6756,7 +6756,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Operand'" }
+        { "kind" : "IdRef", "name" : "Operand" }
       ],
       "capabilities" : [ "BindlessTextureNV" ],
       "version" : "None"
@@ -6766,7 +6766,7 @@
       "class"  : "Reserved",
       "opcode" : 5397,
       "operands" : [
-        { "kind" : "LiteralInteger", "name" : "'Bit Width'" }
+        { "kind" : "LiteralInteger", "name" : "Bit Width" }
       ],
       "capabilities" : [ "BindlessTextureNV" ],
       "version" : "None"
@@ -6778,10 +6778,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",          "name" : "'Base'" },
-        { "kind" : "IdRef",          "name" : "'Byte stride'" },
-        { "kind" : "IdRef",          "name" : "'Element index'" },
-        { "kind" : "IdRef",          "name" : "'Byte offset'" },
+        { "kind" : "IdRef",          "name" : "Base" },
+        { "kind" : "IdRef",          "name" : "Byte stride" },
+        { "kind" : "IdRef",          "name" : "Element index" },
+        { "kind" : "IdRef",          "name" : "Byte offset" },
         { "kind" : "RawAccessChainOperands", "quantifier" : "?" }
       ],
       "capabilities" : [
@@ -6798,11 +6798,11 @@
             { "kind" : "IdResult" },
             {
                 "kind" : "IdRef",
-                "name" : "'RayQuery'"
+                "name" : "RayQuery"
             },
             {
                 "kind" : "IdRef",
-                "name" : "'Intersection'"
+                "name" : "Intersection"
             }
         ],
         "capabilities" : [ "RayTracingSpheresGeometryNV" ],
@@ -6817,11 +6817,11 @@
             { "kind" : "IdResult" },
             {
                 "kind" : "IdRef",
-                "name" : "'RayQuery'"
+                "name" : "RayQuery"
             },
             {
                 "kind" : "IdRef",
-                "name" : "'Intersection'"
+                "name" : "Intersection"
             }
         ],
         "capabilities" : [ "RayTracingSpheresGeometryNV" ],
@@ -6836,11 +6836,11 @@
             { "kind" : "IdResult" },
             {
                 "kind" : "IdRef",
-                "name" : "'RayQuery'"
+                "name" : "RayQuery"
             },
             {
                 "kind" : "IdRef",
-                "name" : "'Intersection'"
+                "name" : "Intersection"
             }
         ],
         "capabilities" : [ "RayTracingLinearSweptSpheresGeometryNV" ],
@@ -6855,11 +6855,11 @@
             { "kind" : "IdResult" },
             {
                 "kind" : "IdRef",
-                "name" : "'RayQuery'"
+                "name" : "RayQuery"
             },
             {
                 "kind" : "IdRef",
-                "name" : "'Intersection'"
+                "name" : "Intersection"
             }
         ],
         "capabilities" : [ "RayTracingLinearSweptSpheresGeometryNV"],
@@ -6874,11 +6874,11 @@
             { "kind" : "IdResult" },
             {
                 "kind" : "IdRef",
-                "name" : "'RayQuery'"
+                "name" : "RayQuery"
             },
             {
                 "kind" : "IdRef",
-                "name" : "'Intersection'"
+                "name" : "Intersection"
             }
         ],
         "capabilities" : [ "RayTracingLinearSweptSpheresGeometryNV" ],
@@ -6891,7 +6891,7 @@
       "operands" : [
         { "kind" : "IdResultType"},
         { "kind" : "IdResult"},
-        { "kind" : "IdRef", "name" : "'Hit Object'" }
+        { "kind" : "IdRef", "name" : "Hit Object" }
       ],
       "capabilities" : [ "RayTracingSpheresGeometryNV" ],
       "version" : "None"
@@ -6903,7 +6903,7 @@
       "operands" : [
         { "kind" : "IdResultType"},
         { "kind" : "IdResult"},
-        { "kind" : "IdRef", "name" : "'Hit Object'" }
+        { "kind" : "IdRef", "name" : "Hit Object" }
       ],
       "capabilities" : [ "RayTracingSpheresGeometryNV" ],
       "version" : "None"
@@ -6915,7 +6915,7 @@
       "operands" : [
         { "kind" : "IdResultType"},
         { "kind" : "IdResult"},
-        { "kind" : "IdRef", "name" : "'Hit Object'" }
+        { "kind" : "IdRef", "name" : "Hit Object" }
       ],
       "capabilities" : [ "RayTracingLinearSweptSpheresGeometryNV" ],
       "version" : "None"
@@ -6927,7 +6927,7 @@
       "operands" : [
         { "kind" : "IdResultType"},
         { "kind" : "IdResult"},
-        { "kind" : "IdRef", "name" : "'Hit Object'" }
+        { "kind" : "IdRef", "name" : "Hit Object" }
       ],
       "capabilities" : [ "RayTracingLinearSweptSpheresGeometryNV" ],
       "version" : "None"
@@ -6939,7 +6939,7 @@
       "operands" : [
         { "kind" : "IdResultType"},
         { "kind" : "IdResult"},
-        { "kind" : "IdRef", "name" : "'Hit Object'" }
+        { "kind" : "IdRef", "name" : "Hit Object" }
       ],
       "capabilities" : [ "RayTracingSpheresGeometryNV" ],
       "version" : "None"
@@ -6951,7 +6951,7 @@
       "operands" : [
         { "kind" : "IdResultType"},
         { "kind" : "IdResult"},
-        { "kind" : "IdRef", "name" : "'Hit Object'" }
+        { "kind" : "IdRef", "name" : "Hit Object" }
       ],
       "capabilities" : [ "RayTracingLinearSweptSpheresGeometryNV" ],
       "version" : "None"
@@ -6965,11 +6965,11 @@
             { "kind" : "IdResult" },
             {
                 "kind" : "IdRef",
-                "name" : "'RayQuery'"
+                "name" : "RayQuery"
             },
             {
                 "kind" : "IdRef",
-                "name" : "'Intersection'"
+                "name" : "Intersection"
             }
         ],
         "capabilities" : [ "RayTracingSpheresGeometryNV" ],
@@ -6984,11 +6984,11 @@
             { "kind" : "IdResult" },
             {
                 "kind" : "IdRef",
-                "name" : "'RayQuery'"
+                "name" : "RayQuery"
             },
             {
                 "kind" : "IdRef",
-                "name" : "'Intersection'"
+                "name" : "Intersection"
             }
         ],
         "capabilities" : [ "RayTracingLinearSweptSpheresGeometryNV" ],
@@ -7001,8 +7001,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Data'" },
-        { "kind" : "IdRef", "name" : "'InvocationId'" }
+        { "kind" : "IdRef", "name" : "Data" },
+        { "kind" : "IdRef", "name" : "InvocationId" }
       ],
       "capabilities" : [ "SubgroupShuffleINTEL" ],
       "version" : "None"
@@ -7014,9 +7014,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Current'" },
-        { "kind" : "IdRef", "name" : "'Next'" },
-        { "kind" : "IdRef", "name" : "'Delta'" }
+        { "kind" : "IdRef", "name" : "Current" },
+        { "kind" : "IdRef", "name" : "Next" },
+        { "kind" : "IdRef", "name" : "Delta" }
       ],
       "capabilities" : [ "SubgroupShuffleINTEL" ],
       "version" : "None"
@@ -7028,9 +7028,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Previous'" },
-        { "kind" : "IdRef", "name" : "'Current'" },
-        { "kind" : "IdRef", "name" : "'Delta'" }
+        { "kind" : "IdRef", "name" : "Previous" },
+        { "kind" : "IdRef", "name" : "Current" },
+        { "kind" : "IdRef", "name" : "Delta" }
       ],
       "capabilities" : [ "SubgroupShuffleINTEL" ],
       "version" : "None"
@@ -7042,8 +7042,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Data'" },
-        { "kind" : "IdRef", "name" : "'Value'" }
+        { "kind" : "IdRef", "name" : "Data" },
+        { "kind" : "IdRef", "name" : "Value" }
       ],
       "capabilities" : [ "SubgroupShuffleINTEL" ],
       "version" : "None"
@@ -7055,7 +7055,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Ptr'" }
+        { "kind" : "IdRef", "name" : "Ptr" }
       ],
       "capabilities" : [ "SubgroupBufferBlockIOINTEL" ],
       "version" : "None"
@@ -7065,8 +7065,8 @@
       "class"  : "Group",
       "opcode" : 5576,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Ptr'" },
-        { "kind" : "IdRef", "name" : "'Data'" }
+        { "kind" : "IdRef", "name" : "Ptr" },
+        { "kind" : "IdRef", "name" : "Data" }
       ],
       "capabilities" : [ "SubgroupBufferBlockIOINTEL" ],
       "version" : "None"
@@ -7078,8 +7078,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Image'" },
-        { "kind" : "IdRef", "name" : "'Coordinate'" }
+        { "kind" : "IdRef", "name" : "Image" },
+        { "kind" : "IdRef", "name" : "Coordinate" }
       ],
       "capabilities" : [ "SubgroupImageBlockIOINTEL" ],
       "version" : "None"
@@ -7089,9 +7089,9 @@
       "class"  : "Group",
       "opcode" : 5578,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Image'" },
-        { "kind" : "IdRef", "name" : "'Coordinate'" },
-        { "kind" : "IdRef", "name" : "'Data'" }
+        { "kind" : "IdRef", "name" : "Image" },
+        { "kind" : "IdRef", "name" : "Coordinate" },
+        { "kind" : "IdRef", "name" : "Data" }
       ],
       "capabilities" : [ "SubgroupImageBlockIOINTEL" ],
       "version" : "None"
@@ -7103,10 +7103,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Image'" },
-        { "kind" : "IdRef", "name" : "'Coordinate'" },
-        { "kind" : "IdRef", "name" : "'Width'" },
-        { "kind" : "IdRef", "name" : "'Height'" }
+        { "kind" : "IdRef", "name" : "Image" },
+        { "kind" : "IdRef", "name" : "Coordinate" },
+        { "kind" : "IdRef", "name" : "Width" },
+        { "kind" : "IdRef", "name" : "Height" }
       ],
       "capabilities" : [ "SubgroupImageMediaBlockIOINTEL" ],
       "version" : "None"
@@ -7116,11 +7116,11 @@
       "class"  : "Group",
       "opcode" : 5581,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Image'" },
-        { "kind" : "IdRef", "name" : "'Coordinate'" },
-        { "kind" : "IdRef", "name" : "'Width'" },
-        { "kind" : "IdRef", "name" : "'Height'" },
-        { "kind" : "IdRef", "name" : "'Data'" }
+        { "kind" : "IdRef", "name" : "Image" },
+        { "kind" : "IdRef", "name" : "Coordinate" },
+        { "kind" : "IdRef", "name" : "Width" },
+        { "kind" : "IdRef", "name" : "Height" },
+        { "kind" : "IdRef", "name" : "Data" }
       ],
       "capabilities" : [ "SubgroupImageMediaBlockIOINTEL" ],
       "version" : "None"
@@ -7132,7 +7132,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand'" }
+        { "kind" : "IdRef",        "name" : "Operand" }
       ],
       "capabilities" : [ "IntegerFunctions2INTEL" ],
       "version" : "None"
@@ -7144,7 +7144,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand'" }
+        { "kind" : "IdRef",        "name" : "Operand" }
       ],
       "capabilities" : [ "IntegerFunctions2INTEL" ],
       "version" : "None"
@@ -7156,8 +7156,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "capabilities" : [ "IntegerFunctions2INTEL" ],
       "version" : "None"
@@ -7169,8 +7169,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "capabilities" : [ "IntegerFunctions2INTEL" ],
       "version" : "None"
@@ -7182,8 +7182,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "capabilities" : [ "IntegerFunctions2INTEL" ],
       "version" : "None"
@@ -7195,8 +7195,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "capabilities" : [ "IntegerFunctions2INTEL" ],
       "version" : "None"
@@ -7208,8 +7208,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "capabilities" : [ "IntegerFunctions2INTEL" ],
       "version" : "None"
@@ -7221,8 +7221,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "capabilities" : [ "IntegerFunctions2INTEL" ],
       "version" : "None"
@@ -7234,8 +7234,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "capabilities" : [ "IntegerFunctions2INTEL" ],
       "version" : "None"
@@ -7247,8 +7247,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "capabilities" : [ "IntegerFunctions2INTEL" ],
       "version" : "None"
@@ -7260,8 +7260,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "capabilities" : [ "IntegerFunctions2INTEL" ],
       "version" : "None"
@@ -7273,8 +7273,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "capabilities" : [ "IntegerFunctions2INTEL" ],
       "version" : "None"
@@ -7286,8 +7286,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "capabilities" : [ "IntegerFunctions2INTEL" ],
       "version" : "None"
@@ -7299,8 +7299,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Operand 1'" },
-        { "kind" : "IdRef",        "name" : "'Operand 2'" }
+        { "kind" : "IdRef",        "name" : "Operand 1" },
+        { "kind" : "IdRef",        "name" : "Operand 2" }
       ],
       "capabilities" : [ "IntegerFunctions2INTEL" ],
       "version" : "None"
@@ -7312,7 +7312,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Function'" }
+        { "kind" : "IdRef",        "name" : "Function" }
       ],
       "capabilities" : [ "FunctionPointersINTEL" ],
       "extensions" : [ "SPV_INTEL_function_pointers" ],
@@ -7325,7 +7325,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "quantifier" : "*", "name" : "'Operand 1'" }
+        { "kind" : "IdRef", "quantifier" : "*", "name" : "Operand 1" }
       ],
       "capabilities" : [ "FunctionPointersINTEL" ],
       "extensions" : [ "SPV_INTEL_function_pointers" ],
@@ -7337,7 +7337,7 @@
       "opcode" : 5609,
       "operands" : [
         { "kind" : "IdResult" },
-        { "kind" : "LiteralString", "name" : "'Asm target'" }
+        { "kind" : "LiteralString", "name" : "Asm target" }
       ],
       "capabilities" : [ "AsmINTEL" ],
       "version" : "None"
@@ -7349,10 +7349,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Asm type'" },
-        { "kind" : "IdRef", "name" : "'Target'" },
-        { "kind" : "LiteralString", "name" : "'Asm instructions'" },
-        { "kind" : "LiteralString", "name" : "'Constraints'" }
+        { "kind" : "IdRef", "name" : "Asm type" },
+        { "kind" : "IdRef", "name" : "Target" },
+        { "kind" : "LiteralString", "name" : "Asm instructions" },
+        { "kind" : "LiteralString", "name" : "Constraints" }
       ],
       "capabilities" : [ "AsmINTEL" ],
       "version" : "None"
@@ -7364,8 +7364,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Asm'" },
-        { "kind" : "IdRef", "quantifier" : "*", "name" : "'Argument 0'" }
+        { "kind" : "IdRef", "name" : "Asm" },
+        { "kind" : "IdRef", "quantifier" : "*", "name" : "Argument" }
       ],
       "capabilities" : [ "AsmINTEL" ],
       "version" : "None"
@@ -7377,10 +7377,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",             "name" : "'Pointer'" },
-        { "kind" : "IdScope",           "name" : "'Memory'" },
-        { "kind" : "IdMemorySemantics", "name" : "'Semantics'" },
-        { "kind" : "IdRef",             "name" : "'Value'" }
+        { "kind" : "IdRef",             "name" : "Pointer" },
+        { "kind" : "IdScope",           "name" : "Memory" },
+        { "kind" : "IdMemorySemantics", "name" : "Semantics" },
+        { "kind" : "IdRef",             "name" : "Value" }
       ],
       "capabilities" : [ "AtomicFloat16MinMaxEXT", "AtomicFloat32MinMaxEXT", "AtomicFloat64MinMaxEXT", "AtomicFloat16VectorNV" ],
       "version" : "None"
@@ -7392,10 +7392,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",             "name" : "'Pointer'" },
-        { "kind" : "IdScope",           "name" : "'Memory'" },
-        { "kind" : "IdMemorySemantics", "name" : "'Semantics'" },
-        { "kind" : "IdRef",             "name" : "'Value'" }
+        { "kind" : "IdRef",             "name" : "Pointer" },
+        { "kind" : "IdScope",           "name" : "Memory" },
+        { "kind" : "IdMemorySemantics", "name" : "Semantics" },
+        { "kind" : "IdRef",             "name" : "Value" }
       ],
       "capabilities" : [ "AtomicFloat16MinMaxEXT", "AtomicFloat32MinMaxEXT", "AtomicFloat64MinMaxEXT", "AtomicFloat16VectorNV" ],
       "version" : "None"
@@ -7405,7 +7405,7 @@
       "class"  : "Miscellaneous",
       "opcode" : 5630,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Condition'" }
+        { "kind" : "IdRef", "name" : "Condition" }
       ],
       "capabilities" : [ "ExpectAssumeKHR" ],
       "extensions" : [ "SPV_KHR_expect_assume" ],
@@ -7418,8 +7418,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Value'" },
-        { "kind" : "IdRef", "name" : "'ExpectedValue'" }
+        { "kind" : "IdRef", "name" : "Value" },
+        { "kind" : "IdRef", "name" : "ExpectedValue" }
       ],
       "capabilities" : [ "ExpectAssumeKHR" ],
       "extensions" : [ "SPV_KHR_expect_assume" ],
@@ -7431,7 +7431,7 @@
       "aliases" : ["OpDecorateStringGOOGLE"],
       "opcode" : 5632,
       "operands" : [
-        { "kind" : "IdRef",         "name" : "'Target'" },
+        { "kind" : "IdRef",         "name" : "Target" },
         { "kind" : "Decoration" }
       ],
       "extensions" : [ "SPV_GOOGLE_decorate_string", "SPV_GOOGLE_hlsl_functionality1" ],
@@ -7443,8 +7443,8 @@
       "aliases" : ["OpMemberDecorateStringGOOGLE"],
       "opcode" : 5633,
       "operands" : [
-        { "kind" : "IdRef",          "name" : "'Struct Type'" },
-        { "kind" : "LiteralInteger", "name" : "'Member'" },
+        { "kind" : "IdRef",          "name" : "Struct Type" },
+        { "kind" : "LiteralInteger", "name" : "Member" },
         { "kind" : "Decoration" }
       ],
       "extensions" : [ "SPV_GOOGLE_decorate_string", "SPV_GOOGLE_hlsl_functionality1" ],
@@ -7457,8 +7457,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Image Type'" },
-        { "kind" : "IdRef", "name" : "'Sampler'" }
+        { "kind" : "IdRef", "name" : "Image Type" },
+        { "kind" : "IdRef", "name" : "Sampler" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -7469,7 +7469,7 @@
       "opcode" : 5700,
       "operands" : [
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Image Type'" }
+        { "kind" : "IdRef", "name" : "Image Type" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -7601,8 +7601,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Slice Type'" },
-        { "kind" : "IdRef", "name" : "'Qp'" }
+        { "kind" : "IdRef", "name" : "Slice Type" },
+        { "kind" : "IdRef", "name" : "Qp" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -7614,8 +7614,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Reference Base Penalty'" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Reference Base Penalty" },
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -7627,8 +7627,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Slice Type'" },
-        { "kind" : "IdRef", "name" : "'Qp'" }
+        { "kind" : "IdRef", "name" : "Slice Type" },
+        { "kind" : "IdRef", "name" : "Qp" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -7640,8 +7640,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Packed Shape Penalty'" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Packed Shape Penalty" },
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -7653,8 +7653,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Slice Type'" },
-        { "kind" : "IdRef", "name" : "'Qp'" }
+        { "kind" : "IdRef", "name" : "Slice Type" },
+        { "kind" : "IdRef", "name" : "Qp" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -7666,8 +7666,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Direction Cost'" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Direction Cost" },
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -7679,8 +7679,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Slice Type'" },
-        { "kind" : "IdRef", "name" : "'Qp'" }
+        { "kind" : "IdRef", "name" : "Slice Type" },
+        { "kind" : "IdRef", "name" : "Qp" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL", "SubgroupAvcMotionEstimationIntraINTEL" ],
       "version" : "None"
@@ -7692,8 +7692,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Slice Type'" },
-        { "kind" : "IdRef", "name" : "'Qp'" }
+        { "kind" : "IdRef", "name" : "Slice Type" },
+        { "kind" : "IdRef", "name" : "Qp" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -7738,10 +7738,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Packed Cost Center Delta'" },
-        { "kind" : "IdRef", "name" : "'Packed Cost Table'" },
-        { "kind" : "IdRef", "name" : "'Cost Precision'" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Packed Cost Center Delta" },
+        { "kind" : "IdRef", "name" : "Packed Cost Table" },
+        { "kind" : "IdRef", "name" : "Cost Precision" },
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -7753,8 +7753,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Slice Type'" },
-        { "kind" : "IdRef", "name" : "'Qp'" }
+        { "kind" : "IdRef", "name" : "Slice Type" },
+        { "kind" : "IdRef", "name" : "Qp" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL", "SubgroupAvcMotionEstimationIntraINTEL" ],
       "version" : "None"
@@ -7788,7 +7788,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -7800,8 +7800,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Source Field Polarity'" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Source Field Polarity" },
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -7813,8 +7813,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Reference Field Polarity'" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Reference Field Polarity" },
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -7826,9 +7826,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Forward Reference Field Polarity'" },
-        { "kind" : "IdRef", "name" : "'Backward Reference Field Polarity'" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Forward Reference Field Polarity" },
+        { "kind" : "IdRef", "name" : "Backward Reference Field Polarity" },
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -7840,7 +7840,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -7852,7 +7852,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -7864,7 +7864,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -7876,7 +7876,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -7888,7 +7888,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -7900,7 +7900,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -7912,7 +7912,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -7924,7 +7924,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -7936,7 +7936,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -7948,7 +7948,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -7960,7 +7960,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -7972,7 +7972,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -7984,7 +7984,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -7996,7 +7996,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8008,9 +8008,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Packed Reference Ids'" },
-        { "kind" : "IdRef", "name" : "'Packed Reference Parameter Field Polarities'" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Packed Reference Ids" },
+        { "kind" : "IdRef", "name" : "Packed Reference Parameter Field Polarities" },
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8022,9 +8022,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Src Coord'" },
-        { "kind" : "IdRef", "name" : "'Partition Mask'" },
-        { "kind" : "IdRef", "name" : "'SAD Adjustment'" }
+        { "kind" : "IdRef", "name" : "Src Coord" },
+        { "kind" : "IdRef", "name" : "Partition Mask" },
+        { "kind" : "IdRef", "name" : "SAD Adjustment" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8036,9 +8036,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Ref Offset'" },
-        { "kind" : "IdRef", "name" : "'Search Window Config'" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Ref Offset" },
+        { "kind" : "IdRef", "name" : "Search Window Config" },
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8050,10 +8050,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Fwd Ref Offset'" },
-        { "kind" : "IdRef", "name" : "'Bwd Ref Offset'" },
-        { "kind" : "IdRef", "name" : "'id> Search Window Config'" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Fwd Ref Offset" },
+        { "kind" : "IdRef", "name" : "Bwd Ref Offset" },
+        { "kind" : "IdRef", "name" : "id> Search Window Config" },
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8065,8 +8065,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Search Window Config'" },
-        { "kind" : "IdRef", "name" : "'Dual Ref'" }
+        { "kind" : "IdRef", "name" : "Search Window Config" },
+        { "kind" : "IdRef", "name" : "Dual Ref" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8078,10 +8078,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Ref Offset'" },
-        { "kind" : "IdRef", "name" : "'Src Coord'" },
-        { "kind" : "IdRef", "name" : "'Ref Window Size'" },
-        { "kind" : "IdRef", "name" : "'Image Size'" }
+        { "kind" : "IdRef", "name" : "Ref Offset" },
+        { "kind" : "IdRef", "name" : "Src Coord" },
+        { "kind" : "IdRef", "name" : "Ref Window Size" },
+        { "kind" : "IdRef", "name" : "Image Size" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8093,7 +8093,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8105,8 +8105,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Max Motion Vector Count'" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Max Motion Vector Count" },
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8118,7 +8118,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8130,8 +8130,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Threshold'" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Threshold" },
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8143,8 +8143,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Packed Sad Weights'" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Packed Sad Weights" },
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8156,9 +8156,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Src Image'" },
-        { "kind" : "IdRef", "name" : "'Ref Image'" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Src Image" },
+        { "kind" : "IdRef", "name" : "Ref Image" },
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8170,10 +8170,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Src Image'" },
-        { "kind" : "IdRef", "name" : "'Fwd Ref Image'" },
-        { "kind" : "IdRef", "name" : "'Bwd Ref Image'" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Src Image" },
+        { "kind" : "IdRef", "name" : "Fwd Ref Image" },
+        { "kind" : "IdRef", "name" : "Bwd Ref Image" },
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8185,10 +8185,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Src Image'" },
-        { "kind" : "IdRef", "name" : "'Ref Image'" },
-        { "kind" : "IdRef", "name" : "'Payload'" },
-        { "kind" : "IdRef", "name" : "'Streamin Components'" }
+        { "kind" : "IdRef", "name" : "Src Image" },
+        { "kind" : "IdRef", "name" : "Ref Image" },
+        { "kind" : "IdRef", "name" : "Payload" },
+        { "kind" : "IdRef", "name" : "Streamin Components" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8200,11 +8200,11 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Src Image'" },
-        { "kind" : "IdRef", "name" : "'Fwd Ref Image'" },
-        { "kind" : "IdRef", "name" : "'Bwd Ref Image'" },
-        { "kind" : "IdRef", "name" : "'Payload'" },
-        { "kind" : "IdRef", "name" : "'Streamin Components'" }
+        { "kind" : "IdRef", "name" : "Src Image" },
+        { "kind" : "IdRef", "name" : "Fwd Ref Image" },
+        { "kind" : "IdRef", "name" : "Bwd Ref Image" },
+        { "kind" : "IdRef", "name" : "Payload" },
+        { "kind" : "IdRef", "name" : "Streamin Components" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8216,9 +8216,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Src Image'" },
-        { "kind" : "IdRef", "name" : "'Ref Image'" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Src Image" },
+        { "kind" : "IdRef", "name" : "Ref Image" },
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8230,10 +8230,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Src Image'" },
-        { "kind" : "IdRef", "name" : "'Fwd Ref Image'" },
-        { "kind" : "IdRef", "name" : "'Bwd Ref Image'" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Src Image" },
+        { "kind" : "IdRef", "name" : "Fwd Ref Image" },
+        { "kind" : "IdRef", "name" : "Bwd Ref Image" },
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8245,10 +8245,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Src Image'" },
-        { "kind" : "IdRef", "name" : "'Ref Image'" },
-        { "kind" : "IdRef", "name" : "'Payload'" },
-        { "kind" : "IdRef", "name" : "'Streamin Components'" }
+        { "kind" : "IdRef", "name" : "Src Image" },
+        { "kind" : "IdRef", "name" : "Ref Image" },
+        { "kind" : "IdRef", "name" : "Payload" },
+        { "kind" : "IdRef", "name" : "Streamin Components" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8260,11 +8260,11 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Src Image'" },
-        { "kind" : "IdRef", "name" : "'Fwd Ref Image'" },
-        { "kind" : "IdRef", "name" : "'Bwd Ref Image'" },
-        { "kind" : "IdRef", "name" : "'Payload'" },
-        { "kind" : "IdRef", "name" : "'Streamin Components'" }
+        { "kind" : "IdRef", "name" : "Src Image" },
+        { "kind" : "IdRef", "name" : "Fwd Ref Image" },
+        { "kind" : "IdRef", "name" : "Bwd Ref Image" },
+        { "kind" : "IdRef", "name" : "Payload" },
+        { "kind" : "IdRef", "name" : "Streamin Components" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8276,7 +8276,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8288,7 +8288,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8300,7 +8300,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8312,7 +8312,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8324,7 +8324,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8336,8 +8336,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Payload'" },
-        { "kind" : "IdRef", "name" : "'Major Shape'" }
+        { "kind" : "IdRef", "name" : "Payload" },
+        { "kind" : "IdRef", "name" : "Major Shape" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8349,8 +8349,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Payload'" },
-        { "kind" : "IdRef", "name" : "'Major Shape'" }
+        { "kind" : "IdRef", "name" : "Payload" },
+        { "kind" : "IdRef", "name" : "Major Shape" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8362,8 +8362,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Payload'" },
-        { "kind" : "IdRef", "name" : "'Major Shape'" }
+        { "kind" : "IdRef", "name" : "Payload" },
+        { "kind" : "IdRef", "name" : "Major Shape" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8375,9 +8375,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Payload'" },
-        { "kind" : "IdRef", "name" : "'Major Shape'" },
-        { "kind" : "IdRef", "name" : "'Direction'" }
+        { "kind" : "IdRef", "name" : "Payload" },
+        { "kind" : "IdRef", "name" : "Major Shape" },
+        { "kind" : "IdRef", "name" : "Direction" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8389,9 +8389,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Payload'" },
-        { "kind" : "IdRef", "name" : "'Major Shape'" },
-        { "kind" : "IdRef", "name" : "'Direction'" }
+        { "kind" : "IdRef", "name" : "Payload" },
+        { "kind" : "IdRef", "name" : "Major Shape" },
+        { "kind" : "IdRef", "name" : "Direction" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8403,9 +8403,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Payload'" },
-        { "kind" : "IdRef", "name" : "'Major Shape'" },
-        { "kind" : "IdRef", "name" : "'Direction'" }
+        { "kind" : "IdRef", "name" : "Payload" },
+        { "kind" : "IdRef", "name" : "Major Shape" },
+        { "kind" : "IdRef", "name" : "Direction" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8417,8 +8417,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Image Select'" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Image Select" },
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8430,7 +8430,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8442,7 +8442,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8454,7 +8454,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8466,7 +8466,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8478,13 +8478,13 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Src Coord'" },
-        { "kind" : "IdRef", "name" : "'Motion Vectors'" },
-        { "kind" : "IdRef", "name" : "'Major Shapes'" },
-        { "kind" : "IdRef", "name" : "'Minor Shapes'" },
-        { "kind" : "IdRef", "name" : "'Direction'" },
-        { "kind" : "IdRef", "name" : "'Pixel Resolution'" },
-        { "kind" : "IdRef", "name" : "'Sad Adjustment'" }
+        { "kind" : "IdRef", "name" : "Src Coord" },
+        { "kind" : "IdRef", "name" : "Motion Vectors" },
+        { "kind" : "IdRef", "name" : "Major Shapes" },
+        { "kind" : "IdRef", "name" : "Minor Shapes" },
+        { "kind" : "IdRef", "name" : "Direction" },
+        { "kind" : "IdRef", "name" : "Pixel Resolution" },
+        { "kind" : "IdRef", "name" : "Sad Adjustment" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8496,14 +8496,14 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Src Coord'" },
-        { "kind" : "IdRef", "name" : "'Motion Vectors'" },
-        { "kind" : "IdRef", "name" : "'Major Shapes'" },
-        { "kind" : "IdRef", "name" : "'Minor Shapes'" },
-        { "kind" : "IdRef", "name" : "'Direction'" },
-        { "kind" : "IdRef", "name" : "'Pixel Resolution'" },
-        { "kind" : "IdRef", "name" : "'Bidirectional Weight'" },
-        { "kind" : "IdRef", "name" : "'Sad Adjustment'" }
+        { "kind" : "IdRef", "name" : "Src Coord" },
+        { "kind" : "IdRef", "name" : "Motion Vectors" },
+        { "kind" : "IdRef", "name" : "Major Shapes" },
+        { "kind" : "IdRef", "name" : "Minor Shapes" },
+        { "kind" : "IdRef", "name" : "Direction" },
+        { "kind" : "IdRef", "name" : "Pixel Resolution" },
+        { "kind" : "IdRef", "name" : "Bidirectional Weight" },
+        { "kind" : "IdRef", "name" : "Sad Adjustment" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8515,7 +8515,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8527,7 +8527,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8539,7 +8539,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8551,9 +8551,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Src Image'" },
-        { "kind" : "IdRef", "name" : "'Ref Image'" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Src Image" },
+        { "kind" : "IdRef", "name" : "Ref Image" },
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8565,10 +8565,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Src Image'" },
-        { "kind" : "IdRef", "name" : "'Fwd Ref Image'" },
-        { "kind" : "IdRef", "name" : "'Bwd Ref Image'" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Src Image" },
+        { "kind" : "IdRef", "name" : "Fwd Ref Image" },
+        { "kind" : "IdRef", "name" : "Bwd Ref Image" },
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8580,9 +8580,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Src Image'" },
-        { "kind" : "IdRef", "name" : "'Packed Reference Ids'" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Src Image" },
+        { "kind" : "IdRef", "name" : "Packed Reference Ids" },
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8594,10 +8594,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Src Image'" },
-        { "kind" : "IdRef", "name" : "'Packed Reference Ids'" },
-        { "kind" : "IdRef", "name" : "'Packed Reference Field Polarities'" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Src Image" },
+        { "kind" : "IdRef", "name" : "Packed Reference Ids" },
+        { "kind" : "IdRef", "name" : "Packed Reference Field Polarities" },
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8609,7 +8609,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8621,7 +8621,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Src Coord'" }
+        { "kind" : "IdRef", "name" : "Src Coord" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8633,12 +8633,12 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Skip Block Partition Type'" },
-        { "kind" : "IdRef", "name" : "'Skip Motion Vector Mask'" },
-        { "kind" : "IdRef", "name" : "'Motion Vectors'" },
-        { "kind" : "IdRef", "name" : "'Bidirectional Weight'" },
-        { "kind" : "IdRef", "name" : "'Sad Adjustment'" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Skip Block Partition Type" },
+        { "kind" : "IdRef", "name" : "Skip Motion Vector Mask" },
+        { "kind" : "IdRef", "name" : "Motion Vectors" },
+        { "kind" : "IdRef", "name" : "Bidirectional Weight" },
+        { "kind" : "IdRef", "name" : "Sad Adjustment" },
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8650,14 +8650,14 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Luma Intra Partition Mask'" },
-        { "kind" : "IdRef", "name" : "'Intra Neighbour Availabilty'" },
-        { "kind" : "IdRef", "name" : "'Left Edge Luma Pixels'" },
-        { "kind" : "IdRef", "name" : "'Upper Left Corner Luma Pixel'" },
-        { "kind" : "IdRef", "name" : "'Upper Edge Luma Pixels'" },
-        { "kind" : "IdRef", "name" : "'Upper Right Edge Luma Pixels'" },
-        { "kind" : "IdRef", "name" : "'Sad Adjustment'" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Luma Intra Partition Mask" },
+        { "kind" : "IdRef", "name" : "Intra Neighbour Availabilty" },
+        { "kind" : "IdRef", "name" : "Left Edge Luma Pixels" },
+        { "kind" : "IdRef", "name" : "Upper Left Corner Luma Pixel" },
+        { "kind" : "IdRef", "name" : "Upper Edge Luma Pixels" },
+        { "kind" : "IdRef", "name" : "Upper Right Edge Luma Pixels" },
+        { "kind" : "IdRef", "name" : "Sad Adjustment" },
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL", "SubgroupAvcMotionEstimationIntraINTEL" ],
       "version" : "None"
@@ -8669,17 +8669,17 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Luma Intra Partition Mask'" },
-        { "kind" : "IdRef", "name" : "'Intra Neighbour Availabilty'" },
-        { "kind" : "IdRef", "name" : "'Left Edge Luma Pixels'" },
-        { "kind" : "IdRef", "name" : "'Upper Left Corner Luma Pixel'" },
-        { "kind" : "IdRef", "name" : "'Upper Edge Luma Pixels'" },
-        { "kind" : "IdRef", "name" : "'Upper Right Edge Luma Pixels'" },
-        { "kind" : "IdRef", "name" : "'Left Edge Chroma Pixels'" },
-        { "kind" : "IdRef", "name" : "'Upper Left Corner Chroma Pixel'" },
-        { "kind" : "IdRef", "name" : "'Upper Edge Chroma Pixels'" },
-        { "kind" : "IdRef", "name" : "'Sad Adjustment'" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Luma Intra Partition Mask" },
+        { "kind" : "IdRef", "name" : "Intra Neighbour Availabilty" },
+        { "kind" : "IdRef", "name" : "Left Edge Luma Pixels" },
+        { "kind" : "IdRef", "name" : "Upper Left Corner Luma Pixel" },
+        { "kind" : "IdRef", "name" : "Upper Edge Luma Pixels" },
+        { "kind" : "IdRef", "name" : "Upper Right Edge Luma Pixels" },
+        { "kind" : "IdRef", "name" : "Left Edge Chroma Pixels" },
+        { "kind" : "IdRef", "name" : "Upper Left Corner Chroma Pixel" },
+        { "kind" : "IdRef", "name" : "Upper Edge Chroma Pixels" },
+        { "kind" : "IdRef", "name" : "Sad Adjustment" },
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL", "SubgroupAvcMotionEstimationChromaINTEL" ],
       "version" : "None"
@@ -8691,8 +8691,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Skip Block Partition Type'" },
-        { "kind" : "IdRef", "name" : "'Direction'" }
+        { "kind" : "IdRef", "name" : "Skip Block Partition Type" },
+        { "kind" : "IdRef", "name" : "Direction" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8704,7 +8704,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8716,8 +8716,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Packed Shape Penalty'" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Packed Shape Penalty" },
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8729,10 +8729,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Luma Mode Penalty'" },
-        { "kind" : "IdRef", "name" : "'Luma Packed Neighbor Modes'" },
-        { "kind" : "IdRef", "name" : "'Luma Packed Non Dc Penalty'" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Luma Mode Penalty" },
+        { "kind" : "IdRef", "name" : "Luma Packed Neighbor Modes" },
+        { "kind" : "IdRef", "name" : "Luma Packed Non Dc Penalty" },
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL", "SubgroupAvcMotionEstimationIntraINTEL" ],
       "version" : "None"
@@ -8744,8 +8744,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Chroma Mode Base Penalty'" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Chroma Mode Base Penalty" },
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL", "SubgroupAvcMotionEstimationChromaINTEL" ],
       "version" : "None"
@@ -8757,7 +8757,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8769,8 +8769,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Packed Sad Coefficients'" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Packed Sad Coefficients" },
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8782,8 +8782,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Block Based Skip Type'" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Block Based Skip Type" },
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8795,8 +8795,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Src Image'" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Src Image" },
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL", "SubgroupAvcMotionEstimationIntraINTEL" ],
       "version" : "None"
@@ -8808,9 +8808,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Src Image'" },
-        { "kind" : "IdRef", "name" : "'Ref Image'" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Src Image" },
+        { "kind" : "IdRef", "name" : "Ref Image" },
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8822,10 +8822,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Src Image'" },
-        { "kind" : "IdRef", "name" : "'Fwd Ref Image'" },
-        { "kind" : "IdRef", "name" : "'Bwd Ref Image'" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Src Image" },
+        { "kind" : "IdRef", "name" : "Fwd Ref Image" },
+        { "kind" : "IdRef", "name" : "Bwd Ref Image" },
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8837,9 +8837,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Src Image'" },
-        { "kind" : "IdRef", "name" : "'Packed Reference Ids'" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Src Image" },
+        { "kind" : "IdRef", "name" : "Packed Reference Ids" },
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8851,10 +8851,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Src Image'" },
-        { "kind" : "IdRef", "name" : "'Packed Reference Ids'" },
-        { "kind" : "IdRef", "name" : "'Packed Reference Field Polarities'" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Src Image" },
+        { "kind" : "IdRef", "name" : "Packed Reference Ids" },
+        { "kind" : "IdRef", "name" : "Packed Reference Field Polarities" },
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8866,7 +8866,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8878,7 +8878,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL", "SubgroupAvcMotionEstimationIntraINTEL" ],
       "version" : "None"
@@ -8890,7 +8890,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL", "SubgroupAvcMotionEstimationIntraINTEL" ],
       "version" : "None"
@@ -8902,7 +8902,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8914,7 +8914,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL", "SubgroupAvcMotionEstimationIntraINTEL" ],
       "version" : "None"
@@ -8926,7 +8926,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL", "SubgroupAvcMotionEstimationChromaINTEL" ],
       "version" : "None"
@@ -8938,7 +8938,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL", "SubgroupAvcMotionEstimationIntraINTEL" ],
       "version" : "None"
@@ -8950,7 +8950,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL", "SubgroupAvcMotionEstimationIntraINTEL" ],
       "version" : "None"
@@ -8962,7 +8962,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Payload'" }
+        { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],
       "version" : "None"
@@ -8974,7 +8974,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Lenght'" }
+        { "kind" : "IdRef", "name" : "Lenght" }
       ],
       "capabilities" : [ "VariableLengthArrayINTEL" ],
       "version" : "None"
@@ -8995,7 +8995,7 @@
       "class"  : "@exclude",
       "opcode" : 5820,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Ptr'" }
+        { "kind" : "IdRef", "name" : "Ptr" }
       ],
       "capabilities" : [ "VariableLengthArrayINTEL" ],
       "version" : "None"
@@ -9007,12 +9007,12 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'A'" },
-        { "kind" : "LiteralInteger", "name" : "'Ma'" },
-        { "kind" : "LiteralInteger", "name" : "'MResult'" },
-        { "kind" : "LiteralInteger", "name" : "'Subnormal'" },
-        { "kind" : "LiteralInteger", "name" : "'Rounding'" },
-        { "kind" : "LiteralInteger", "name" : "'RoundingAccuracy'" }
+        { "kind" : "IdRef", "name" : "A" },
+        { "kind" : "LiteralInteger", "name" : "Ma" },
+        { "kind" : "LiteralInteger", "name" : "MResult" },
+        { "kind" : "LiteralInteger", "name" : "Subnormal" },
+        { "kind" : "LiteralInteger", "name" : "Rounding" },
+        { "kind" : "LiteralInteger", "name" : "RoundingAccuracy" }
       ],
       "capabilities" : [ "ArbitraryPrecisionFloatingPointINTEL" ],
       "version" : "None"
@@ -9024,12 +9024,12 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'A'" },
-        { "kind" : "LiteralInteger", "name" : "'Ma'" },
-        { "kind" : "LiteralInteger", "name" : "'Mresult'" },
-        { "kind" : "LiteralInteger", "name" : "'Subnormal'" },
-        { "kind" : "LiteralInteger", "name" : "'Rounding'" },
-        { "kind" : "LiteralInteger", "name" : "'Accuracy'" }
+        { "kind" : "IdRef", "name" : "A" },
+        { "kind" : "LiteralInteger", "name" : "Ma" },
+        { "kind" : "LiteralInteger", "name" : "Mresult" },
+        { "kind" : "LiteralInteger", "name" : "Subnormal" },
+        { "kind" : "LiteralInteger", "name" : "Rounding" },
+        { "kind" : "LiteralInteger", "name" : "Accuracy" }
       ],
       "capabilities" : [ "ArbitraryPrecisionFloatingPointINTEL" ],
       "version" : "None"
@@ -9041,12 +9041,12 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'A'" },
-        { "kind" : "LiteralInteger", "name" : "'Mresult'" },
-        { "kind" : "LiteralInteger", "name" : "'FromSign'" },
-        { "kind" : "LiteralInteger", "name" : "'Subnormal'" },
-        { "kind" : "LiteralInteger", "name" : "'Rounding'" },
-        { "kind" : "LiteralInteger", "name" : "'Accuracy'" }
+        { "kind" : "IdRef", "name" : "A" },
+        { "kind" : "LiteralInteger", "name" : "Mresult" },
+        { "kind" : "LiteralInteger", "name" : "FromSign" },
+        { "kind" : "LiteralInteger", "name" : "Subnormal" },
+        { "kind" : "LiteralInteger", "name" : "Rounding" },
+        { "kind" : "LiteralInteger", "name" : "Accuracy" }
       ],
       "capabilities" : [ "ArbitraryPrecisionFloatingPointINTEL" ],
       "version" : "None"
@@ -9058,12 +9058,12 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'A'" },
-        { "kind" : "LiteralInteger", "name" : "'Ma'" },
-        { "kind" : "LiteralInteger", "name" : "'ToSign'" },
-        { "kind" : "LiteralInteger", "name" : "'Subnormal'" },
-        { "kind" : "LiteralInteger", "name" : "'Rounding'" },
-        { "kind" : "LiteralInteger", "name" : "'Accuracy'" }
+        { "kind" : "IdRef", "name" : "A" },
+        { "kind" : "LiteralInteger", "name" : "Ma" },
+        { "kind" : "LiteralInteger", "name" : "ToSign" },
+        { "kind" : "LiteralInteger", "name" : "Subnormal" },
+        { "kind" : "LiteralInteger", "name" : "Rounding" },
+        { "kind" : "LiteralInteger", "name" : "Accuracy" }
       ],
       "capabilities" : [ "ArbitraryPrecisionFloatingPointINTEL" ],
       "version" : "None"
@@ -9075,14 +9075,14 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'A'" },
-        { "kind" : "LiteralInteger", "name" : "'Ma'" },
-        { "kind" : "IdRef", "name" : "'B'" },
-        { "kind" : "LiteralInteger", "name" : "'Mb'" },
-        { "kind" : "LiteralInteger", "name" : "'MResult'" },
-        { "kind" : "LiteralInteger", "name" : "'Subnormal'" },
-        { "kind" : "LiteralInteger", "name" : "'Rounding'" },
-        { "kind" : "LiteralInteger", "name" : "'Accuracy'" }
+        { "kind" : "IdRef", "name" : "A" },
+        { "kind" : "LiteralInteger", "name" : "Ma" },
+        { "kind" : "IdRef", "name" : "B" },
+        { "kind" : "LiteralInteger", "name" : "Mb" },
+        { "kind" : "LiteralInteger", "name" : "MResult" },
+        { "kind" : "LiteralInteger", "name" : "Subnormal" },
+        { "kind" : "LiteralInteger", "name" : "Rounding" },
+        { "kind" : "LiteralInteger", "name" : "Accuracy" }
       ],
       "capabilities" : [ "ArbitraryPrecisionFloatingPointINTEL" ],
       "version" : "None"
@@ -9094,14 +9094,14 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'A'" },
-        { "kind" : "LiteralInteger", "name" : "'Ma'" },
-        { "kind" : "IdRef", "name" : "'B'" },
-        { "kind" : "LiteralInteger", "name" : "'Mb'" },
-        { "kind" : "LiteralInteger", "name" : "'Mresult'" },
-        { "kind" : "LiteralInteger", "name" : "'Subnormal'" },
-        { "kind" : "LiteralInteger", "name" : "'Rounding'" },
-        { "kind" : "LiteralInteger", "name" : "'Accuracy'" }
+        { "kind" : "IdRef", "name" : "A" },
+        { "kind" : "LiteralInteger", "name" : "Ma" },
+        { "kind" : "IdRef", "name" : "B" },
+        { "kind" : "LiteralInteger", "name" : "Mb" },
+        { "kind" : "LiteralInteger", "name" : "Mresult" },
+        { "kind" : "LiteralInteger", "name" : "Subnormal" },
+        { "kind" : "LiteralInteger", "name" : "Rounding" },
+        { "kind" : "LiteralInteger", "name" : "Accuracy" }
       ],
       "capabilities" : [ "ArbitraryPrecisionFloatingPointINTEL" ],
       "version" : "None"
@@ -9113,14 +9113,14 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'A'" },
-        { "kind" : "LiteralInteger", "name" : "'Ma'" },
-        { "kind" : "IdRef", "name" : "'B'" },
-        { "kind" : "LiteralInteger", "name" : "'Mb'" },
-        { "kind" : "LiteralInteger", "name" : "'Mresult'" },
-        { "kind" : "LiteralInteger", "name" : "'Subnormal'" },
-        { "kind" : "LiteralInteger", "name" : "'Rounding'" },
-        { "kind" : "LiteralInteger", "name" : "'Accuracy'" }
+        { "kind" : "IdRef", "name" : "A" },
+        { "kind" : "LiteralInteger", "name" : "Ma" },
+        { "kind" : "IdRef", "name" : "B" },
+        { "kind" : "LiteralInteger", "name" : "Mb" },
+        { "kind" : "LiteralInteger", "name" : "Mresult" },
+        { "kind" : "LiteralInteger", "name" : "Subnormal" },
+        { "kind" : "LiteralInteger", "name" : "Rounding" },
+        { "kind" : "LiteralInteger", "name" : "Accuracy" }
       ],
       "capabilities" : [ "ArbitraryPrecisionFloatingPointINTEL" ],
       "version" : "None"
@@ -9132,14 +9132,14 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'A'" },
-        { "kind" : "LiteralInteger", "name" : "'Ma'" },
-        { "kind" : "IdRef", "name" : "'B'" },
-        { "kind" : "LiteralInteger", "name" : "'Mb'" },
-        { "kind" : "LiteralInteger", "name" : "'Mresult'" },
-        { "kind" : "LiteralInteger", "name" : "'Subnormal'" },
-        { "kind" : "LiteralInteger", "name" : "'Rounding'" },
-        { "kind" : "LiteralInteger", "name" : "'Accuracy'" }
+        { "kind" : "IdRef", "name" : "A" },
+        { "kind" : "LiteralInteger", "name" : "Ma" },
+        { "kind" : "IdRef", "name" : "B" },
+        { "kind" : "LiteralInteger", "name" : "Mb" },
+        { "kind" : "LiteralInteger", "name" : "Mresult" },
+        { "kind" : "LiteralInteger", "name" : "Subnormal" },
+        { "kind" : "LiteralInteger", "name" : "Rounding" },
+        { "kind" : "LiteralInteger", "name" : "Accuracy" }
       ],
       "capabilities" : [ "ArbitraryPrecisionFloatingPointINTEL" ],
       "version" : "None"
@@ -9151,10 +9151,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'A'" },
-        { "kind" : "LiteralInteger", "name" : "'Ma'" },
-        { "kind" : "IdRef", "name" : "'B'" },
-        { "kind" : "LiteralInteger", "name" : "'Mb'" }
+        { "kind" : "IdRef", "name" : "A" },
+        { "kind" : "LiteralInteger", "name" : "Ma" },
+        { "kind" : "IdRef", "name" : "B" },
+        { "kind" : "LiteralInteger", "name" : "Mb" }
       ],
       "capabilities" : [ "ArbitraryPrecisionFloatingPointINTEL" ],
       "version" : "None"
@@ -9166,10 +9166,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'A'" },
-        { "kind" : "LiteralInteger", "name" : "'Ma'" },
-        { "kind" : "IdRef", "name" : "'B'" },
-        { "kind" : "LiteralInteger", "name" : "'Mb'" }
+        { "kind" : "IdRef", "name" : "A" },
+        { "kind" : "LiteralInteger", "name" : "Ma" },
+        { "kind" : "IdRef", "name" : "B" },
+        { "kind" : "LiteralInteger", "name" : "Mb" }
       ],
       "capabilities" : [ "ArbitraryPrecisionFloatingPointINTEL" ],
       "version" : "None"
@@ -9181,10 +9181,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'A'" },
-        { "kind" : "LiteralInteger", "name" : "'Ma'" },
-        { "kind" : "IdRef", "name" : "'B'" },
-        { "kind" : "LiteralInteger", "name" : "'Mb'" }
+        { "kind" : "IdRef", "name" : "A" },
+        { "kind" : "LiteralInteger", "name" : "Ma" },
+        { "kind" : "IdRef", "name" : "B" },
+        { "kind" : "LiteralInteger", "name" : "Mb" }
       ],
       "capabilities" : [ "ArbitraryPrecisionFloatingPointINTEL" ],
       "version" : "None"
@@ -9196,10 +9196,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'A'" },
-        { "kind" : "LiteralInteger", "name" : "'Ma'" },
-        { "kind" : "IdRef", "name" : "'B'" },
-        { "kind" : "LiteralInteger", "name" : "'Mb'" }
+        { "kind" : "IdRef", "name" : "A" },
+        { "kind" : "LiteralInteger", "name" : "Ma" },
+        { "kind" : "IdRef", "name" : "B" },
+        { "kind" : "LiteralInteger", "name" : "Mb" }
       ],
       "capabilities" : [ "ArbitraryPrecisionFloatingPointINTEL" ],
       "version" : "None"
@@ -9211,10 +9211,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'A'" },
-        { "kind" : "LiteralInteger", "name" : "'Ma'" },
-        { "kind" : "IdRef", "name" : "'B'" },
-        { "kind" : "LiteralInteger", "name" : "'Mb'" }
+        { "kind" : "IdRef", "name" : "A" },
+        { "kind" : "LiteralInteger", "name" : "Ma" },
+        { "kind" : "IdRef", "name" : "B" },
+        { "kind" : "LiteralInteger", "name" : "Mb" }
       ],
       "capabilities" : [ "ArbitraryPrecisionFloatingPointINTEL" ],
       "version" : "None"
@@ -9226,12 +9226,12 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'A'" },
-        { "kind" : "LiteralInteger", "name" : "'Ma'" },
-        { "kind" : "LiteralInteger", "name" : "'Mresult'" },
-        { "kind" : "LiteralInteger", "name" : "'Subnormal'" },
-        { "kind" : "LiteralInteger", "name" : "'Rounding'" },
-        { "kind" : "LiteralInteger", "name" : "'Accuracy'" }
+        { "kind" : "IdRef", "name" : "A" },
+        { "kind" : "LiteralInteger", "name" : "Ma" },
+        { "kind" : "LiteralInteger", "name" : "Mresult" },
+        { "kind" : "LiteralInteger", "name" : "Subnormal" },
+        { "kind" : "LiteralInteger", "name" : "Rounding" },
+        { "kind" : "LiteralInteger", "name" : "Accuracy" }
       ],
       "capabilities" : [ "ArbitraryPrecisionFloatingPointINTEL" ],
       "version" : "None"
@@ -9243,12 +9243,12 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'A'" },
-        { "kind" : "LiteralInteger", "name" : "'Ma'" },
-        { "kind" : "LiteralInteger", "name" : "'Mresult'" },
-        { "kind" : "LiteralInteger", "name" : "'Subnormal'" },
-        { "kind" : "LiteralInteger", "name" : "'Rounding'" },
-        { "kind" : "LiteralInteger", "name" : "'Accuracy'" }
+        { "kind" : "IdRef", "name" : "A" },
+        { "kind" : "LiteralInteger", "name" : "Ma" },
+        { "kind" : "LiteralInteger", "name" : "Mresult" },
+        { "kind" : "LiteralInteger", "name" : "Subnormal" },
+        { "kind" : "LiteralInteger", "name" : "Rounding" },
+        { "kind" : "LiteralInteger", "name" : "Accuracy" }
       ],
       "capabilities" : [ "ArbitraryPrecisionFloatingPointINTEL" ],
       "version" : "None"
@@ -9260,12 +9260,12 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'A'" },
-        { "kind" : "LiteralInteger", "name" : "'Ma'" },
-        { "kind" : "LiteralInteger", "name" : "'Mresult'" },
-        { "kind" : "LiteralInteger", "name" : "'Subnormal'" },
-        { "kind" : "LiteralInteger", "name" : "'Rounding'" },
-        { "kind" : "LiteralInteger", "name" : "'Accuracy'" }
+        { "kind" : "IdRef", "name" : "A" },
+        { "kind" : "LiteralInteger", "name" : "Ma" },
+        { "kind" : "LiteralInteger", "name" : "Mresult" },
+        { "kind" : "LiteralInteger", "name" : "Subnormal" },
+        { "kind" : "LiteralInteger", "name" : "Rounding" },
+        { "kind" : "LiteralInteger", "name" : "Accuracy" }
       ],
       "capabilities" : [ "ArbitraryPrecisionFloatingPointINTEL" ],
       "version" : "None"
@@ -9277,14 +9277,14 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'A'" },
-        { "kind" : "LiteralInteger", "name" : "'Ma'" },
-        { "kind" : "IdRef", "name" : "'B'" },
-        { "kind" : "LiteralInteger", "name" : "'Mb'" },
-        { "kind" : "LiteralInteger", "name" : "'Mresult'" },
-        { "kind" : "LiteralInteger", "name" : "'Subnormal'" },
-        { "kind" : "LiteralInteger", "name" : "'Rounding'" },
-        { "kind" : "LiteralInteger", "name" : "'Accuracy'" }
+        { "kind" : "IdRef", "name" : "A" },
+        { "kind" : "LiteralInteger", "name" : "Ma" },
+        { "kind" : "IdRef", "name" : "B" },
+        { "kind" : "LiteralInteger", "name" : "Mb" },
+        { "kind" : "LiteralInteger", "name" : "Mresult" },
+        { "kind" : "LiteralInteger", "name" : "Subnormal" },
+        { "kind" : "LiteralInteger", "name" : "Rounding" },
+        { "kind" : "LiteralInteger", "name" : "Accuracy" }
       ],
       "capabilities" : [ "ArbitraryPrecisionFloatingPointINTEL" ],
       "version" : "None"
@@ -9296,12 +9296,12 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'A'" },
-        { "kind" : "LiteralInteger", "name" : "'Ma'" },
-        { "kind" : "LiteralInteger", "name" : "'Mresult'" },
-        { "kind" : "LiteralInteger", "name" : "'Subnormal'" },
-        { "kind" : "LiteralInteger", "name" : "'Rounding'" },
-        { "kind" : "LiteralInteger", "name" : "'Accuracy'" }
+        { "kind" : "IdRef", "name" : "A" },
+        { "kind" : "LiteralInteger", "name" : "Ma" },
+        { "kind" : "LiteralInteger", "name" : "Mresult" },
+        { "kind" : "LiteralInteger", "name" : "Subnormal" },
+        { "kind" : "LiteralInteger", "name" : "Rounding" },
+        { "kind" : "LiteralInteger", "name" : "Accuracy" }
       ],
       "capabilities" : [ "ArbitraryPrecisionFloatingPointINTEL" ],
       "version" : "None"
@@ -9313,12 +9313,12 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'A'" },
-        { "kind" : "LiteralInteger", "name" : "'Ma'" },
-        { "kind" : "LiteralInteger", "name" : "'Mresult'" },
-        { "kind" : "LiteralInteger", "name" : "'Subnormal'" },
-        { "kind" : "LiteralInteger", "name" : "'Rounding'" },
-        { "kind" : "LiteralInteger", "name" : "'Accuracy'" }
+        { "kind" : "IdRef", "name" : "A" },
+        { "kind" : "LiteralInteger", "name" : "Ma" },
+        { "kind" : "LiteralInteger", "name" : "Mresult" },
+        { "kind" : "LiteralInteger", "name" : "Subnormal" },
+        { "kind" : "LiteralInteger", "name" : "Rounding" },
+        { "kind" : "LiteralInteger", "name" : "Accuracy" }
       ],
       "capabilities" : [ "ArbitraryPrecisionFloatingPointINTEL" ],
       "version" : "None"
@@ -9330,12 +9330,12 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'A'" },
-        { "kind" : "LiteralInteger", "name" : "'Ma'" },
-        { "kind" : "LiteralInteger", "name" : "'Mresult'" },
-        { "kind" : "LiteralInteger", "name" : "'Subnormal'" },
-        { "kind" : "LiteralInteger", "name" : "'Rounding'" },
-        { "kind" : "LiteralInteger", "name" : "'Accuracy'" }
+        { "kind" : "IdRef", "name" : "A" },
+        { "kind" : "LiteralInteger", "name" : "Ma" },
+        { "kind" : "LiteralInteger", "name" : "Mresult" },
+        { "kind" : "LiteralInteger", "name" : "Subnormal" },
+        { "kind" : "LiteralInteger", "name" : "Rounding" },
+        { "kind" : "LiteralInteger", "name" : "Accuracy" }
       ],
       "capabilities" : [ "ArbitraryPrecisionFloatingPointINTEL" ],
       "version" : "None"
@@ -9347,12 +9347,12 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'A'" },
-        { "kind" : "LiteralInteger", "name" : "'Ma'" },
-        { "kind" : "LiteralInteger", "name" : "'Mresult'" },
-        { "kind" : "LiteralInteger", "name" : "'Subnormal'" },
-        { "kind" : "LiteralInteger", "name" : "'Rounding'" },
-        { "kind" : "LiteralInteger", "name" : "'Accuracy'" }
+        { "kind" : "IdRef", "name" : "A" },
+        { "kind" : "LiteralInteger", "name" : "Ma" },
+        { "kind" : "LiteralInteger", "name" : "Mresult" },
+        { "kind" : "LiteralInteger", "name" : "Subnormal" },
+        { "kind" : "LiteralInteger", "name" : "Rounding" },
+        { "kind" : "LiteralInteger", "name" : "Accuracy" }
       ],
       "capabilities" : [ "ArbitraryPrecisionFloatingPointINTEL" ],
       "version" : "None"
@@ -9364,12 +9364,12 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'A'" },
-        { "kind" : "LiteralInteger", "name" : "'Ma'" },
-        { "kind" : "LiteralInteger", "name" : "'Mresult'" },
-        { "kind" : "LiteralInteger", "name" : "'Subnormal'" },
-        { "kind" : "LiteralInteger", "name" : "'Rounding'" },
-        { "kind" : "LiteralInteger", "name" : "'Accuracy'" }
+        { "kind" : "IdRef", "name" : "A" },
+        { "kind" : "LiteralInteger", "name" : "Ma" },
+        { "kind" : "LiteralInteger", "name" : "Mresult" },
+        { "kind" : "LiteralInteger", "name" : "Subnormal" },
+        { "kind" : "LiteralInteger", "name" : "Rounding" },
+        { "kind" : "LiteralInteger", "name" : "Accuracy" }
       ],
       "capabilities" : [ "ArbitraryPrecisionFloatingPointINTEL" ],
       "version" : "None"
@@ -9381,12 +9381,12 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'A'" },
-        { "kind" : "LiteralInteger", "name" : "'Ma'" },
-        { "kind" : "LiteralInteger", "name" : "'Mresult'" },
-        { "kind" : "LiteralInteger", "name" : "'Subnormal'" },
-        { "kind" : "LiteralInteger", "name" : "'Rounding'" },
-        { "kind" : "LiteralInteger", "name" : "'Accuracy'" }
+        { "kind" : "IdRef", "name" : "A" },
+        { "kind" : "LiteralInteger", "name" : "Ma" },
+        { "kind" : "LiteralInteger", "name" : "Mresult" },
+        { "kind" : "LiteralInteger", "name" : "Subnormal" },
+        { "kind" : "LiteralInteger", "name" : "Rounding" },
+        { "kind" : "LiteralInteger", "name" : "Accuracy" }
       ],
       "capabilities" : [ "ArbitraryPrecisionFloatingPointINTEL" ],
       "version" : "None"
@@ -9398,12 +9398,12 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'A'" },
-        { "kind" : "LiteralInteger", "name" : "'Ma'" },
-        { "kind" : "LiteralInteger", "name" : "'Mresult'" },
-        { "kind" : "LiteralInteger", "name" : "'Subnormal'" },
-        { "kind" : "LiteralInteger", "name" : "'Rounding'" },
-        { "kind" : "LiteralInteger", "name" : "'Accuracy'" }
+        { "kind" : "IdRef", "name" : "A" },
+        { "kind" : "LiteralInteger", "name" : "Ma" },
+        { "kind" : "LiteralInteger", "name" : "Mresult" },
+        { "kind" : "LiteralInteger", "name" : "Subnormal" },
+        { "kind" : "LiteralInteger", "name" : "Rounding" },
+        { "kind" : "LiteralInteger", "name" : "Accuracy" }
       ],
       "capabilities" : [ "ArbitraryPrecisionFloatingPointINTEL" ],
       "version" : "None"
@@ -9415,12 +9415,12 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'A'" },
-        { "kind" : "LiteralInteger", "name" : "'Ma'" },
-        { "kind" : "LiteralInteger", "name" : "'Mresult'" },
-        { "kind" : "LiteralInteger", "name" : "'Subnormal'" },
-        { "kind" : "LiteralInteger", "name" : "'Rounding'" },
-        { "kind" : "LiteralInteger", "name" : "'Accuracy'" }
+        { "kind" : "IdRef", "name" : "A" },
+        { "kind" : "LiteralInteger", "name" : "Ma" },
+        { "kind" : "LiteralInteger", "name" : "Mresult" },
+        { "kind" : "LiteralInteger", "name" : "Subnormal" },
+        { "kind" : "LiteralInteger", "name" : "Rounding" },
+        { "kind" : "LiteralInteger", "name" : "Accuracy" }
       ],
       "capabilities" : [ "ArbitraryPrecisionFloatingPointINTEL" ],
       "version" : "None"
@@ -9432,12 +9432,12 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'A'" },
-        { "kind" : "LiteralInteger", "name" : "'Ma'" },
-        { "kind" : "LiteralInteger", "name" : "'Mresult'" },
-        { "kind" : "LiteralInteger", "name" : "'Subnormal'" },
-        { "kind" : "LiteralInteger", "name" : "'Rounding'" },
-        { "kind" : "LiteralInteger", "name" : "'Accuracy'" }
+        { "kind" : "IdRef", "name" : "A" },
+        { "kind" : "LiteralInteger", "name" : "Ma" },
+        { "kind" : "LiteralInteger", "name" : "Mresult" },
+        { "kind" : "LiteralInteger", "name" : "Subnormal" },
+        { "kind" : "LiteralInteger", "name" : "Rounding" },
+        { "kind" : "LiteralInteger", "name" : "Accuracy" }
       ],
       "capabilities" : [ "ArbitraryPrecisionFloatingPointINTEL" ],
       "version" : "None"
@@ -9449,12 +9449,12 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'A'" },
-        { "kind" : "LiteralInteger", "name" : "'Ma'" },
-        { "kind" : "LiteralInteger", "name" : "'Mresult'" },
-        { "kind" : "LiteralInteger", "name" : "'Subnormal'" },
-        { "kind" : "LiteralInteger", "name" : "'Rounding'" },
-        { "kind" : "LiteralInteger", "name" : "'Accuracy'" }
+        { "kind" : "IdRef", "name" : "A" },
+        { "kind" : "LiteralInteger", "name" : "Ma" },
+        { "kind" : "LiteralInteger", "name" : "Mresult" },
+        { "kind" : "LiteralInteger", "name" : "Subnormal" },
+        { "kind" : "LiteralInteger", "name" : "Rounding" },
+        { "kind" : "LiteralInteger", "name" : "Accuracy" }
       ],
       "capabilities" : [ "ArbitraryPrecisionFloatingPointINTEL" ],
       "version" : "None"
@@ -9466,12 +9466,12 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'A'" },
-        { "kind" : "LiteralInteger", "name" : "'Ma'" },
-        { "kind" : "LiteralInteger", "name" : "'Mresult'" },
-        { "kind" : "LiteralInteger", "name" : "'Subnormal'" },
-        { "kind" : "LiteralInteger", "name" : "'Rounding'" },
-        { "kind" : "LiteralInteger", "name" : "'Accuracy'" }
+        { "kind" : "IdRef", "name" : "A" },
+        { "kind" : "LiteralInteger", "name" : "Ma" },
+        { "kind" : "LiteralInteger", "name" : "Mresult" },
+        { "kind" : "LiteralInteger", "name" : "Subnormal" },
+        { "kind" : "LiteralInteger", "name" : "Rounding" },
+        { "kind" : "LiteralInteger", "name" : "Accuracy" }
       ],
       "capabilities" : [ "ArbitraryPrecisionFloatingPointINTEL" ],
       "version" : "None"
@@ -9483,12 +9483,12 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'A'" },
-        { "kind" : "LiteralInteger", "name" : "'Ma'" },
-        { "kind" : "LiteralInteger", "name" : "'Mresult'" },
-        { "kind" : "LiteralInteger", "name" : "'Subnormal'" },
-        { "kind" : "LiteralInteger", "name" : "'Rounding'" },
-        { "kind" : "LiteralInteger", "name" : "'Accuracy'" }
+        { "kind" : "IdRef", "name" : "A" },
+        { "kind" : "LiteralInteger", "name" : "Ma" },
+        { "kind" : "LiteralInteger", "name" : "Mresult" },
+        { "kind" : "LiteralInteger", "name" : "Subnormal" },
+        { "kind" : "LiteralInteger", "name" : "Rounding" },
+        { "kind" : "LiteralInteger", "name" : "Accuracy" }
       ],
       "capabilities" : [ "ArbitraryPrecisionFloatingPointINTEL" ],
       "version" : "None"
@@ -9500,12 +9500,12 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'A'" },
-        { "kind" : "LiteralInteger", "name" : "'Ma'" },
-        { "kind" : "LiteralInteger", "name" : "'Mresult'" },
-        { "kind" : "LiteralInteger", "name" : "'Subnormal'" },
-        { "kind" : "LiteralInteger", "name" : "'Rounding'" },
-        { "kind" : "LiteralInteger", "name" : "'Accuracy'" }
+        { "kind" : "IdRef", "name" : "A" },
+        { "kind" : "LiteralInteger", "name" : "Ma" },
+        { "kind" : "LiteralInteger", "name" : "Mresult" },
+        { "kind" : "LiteralInteger", "name" : "Subnormal" },
+        { "kind" : "LiteralInteger", "name" : "Rounding" },
+        { "kind" : "LiteralInteger", "name" : "Accuracy" }
       ],
       "capabilities" : [ "ArbitraryPrecisionFloatingPointINTEL" ],
       "version" : "None"
@@ -9517,12 +9517,12 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'A'" },
-        { "kind" : "LiteralInteger", "name" : "'Ma'" },
-        { "kind" : "LiteralInteger", "name" : "'Mresult'" },
-        { "kind" : "LiteralInteger", "name" : "'Subnormal'" },
-        { "kind" : "LiteralInteger", "name" : "'Rounding'" },
-        { "kind" : "LiteralInteger", "name" : "'Accuracy'" }
+        { "kind" : "IdRef", "name" : "A" },
+        { "kind" : "LiteralInteger", "name" : "Ma" },
+        { "kind" : "LiteralInteger", "name" : "Mresult" },
+        { "kind" : "LiteralInteger", "name" : "Subnormal" },
+        { "kind" : "LiteralInteger", "name" : "Rounding" },
+        { "kind" : "LiteralInteger", "name" : "Accuracy" }
       ],
       "capabilities" : [ "ArbitraryPrecisionFloatingPointINTEL" ],
       "version" : "None"
@@ -9534,12 +9534,12 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'A'" },
-        { "kind" : "LiteralInteger", "name" : "'Ma'" },
-        { "kind" : "LiteralInteger", "name" : "'Mresult'" },
-        { "kind" : "LiteralInteger", "name" : "'Subnormal'" },
-        { "kind" : "LiteralInteger", "name" : "'Rounding'" },
-        { "kind" : "LiteralInteger", "name" : "'Accuracy'" }
+        { "kind" : "IdRef", "name" : "A" },
+        { "kind" : "LiteralInteger", "name" : "Ma" },
+        { "kind" : "LiteralInteger", "name" : "Mresult" },
+        { "kind" : "LiteralInteger", "name" : "Subnormal" },
+        { "kind" : "LiteralInteger", "name" : "Rounding" },
+        { "kind" : "LiteralInteger", "name" : "Accuracy" }
       ],
       "capabilities" : [ "ArbitraryPrecisionFloatingPointINTEL" ],
       "version" : "None"
@@ -9551,12 +9551,12 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'A'" },
-        { "kind" : "LiteralInteger", "name" : "'Ma'" },
-        { "kind" : "LiteralInteger", "name" : "'Mresult'" },
-        { "kind" : "LiteralInteger", "name" : "'Subnormal'" },
-        { "kind" : "LiteralInteger", "name" : "'Rounding'" },
-        { "kind" : "LiteralInteger", "name" : "'Accuracy'" }
+        { "kind" : "IdRef", "name" : "A" },
+        { "kind" : "LiteralInteger", "name" : "Ma" },
+        { "kind" : "LiteralInteger", "name" : "Mresult" },
+        { "kind" : "LiteralInteger", "name" : "Subnormal" },
+        { "kind" : "LiteralInteger", "name" : "Rounding" },
+        { "kind" : "LiteralInteger", "name" : "Accuracy" }
       ],
       "capabilities" : [ "ArbitraryPrecisionFloatingPointINTEL" ],
       "version" : "None"
@@ -9568,12 +9568,12 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'A'" },
-        { "kind" : "LiteralInteger", "name" : "'M1'" },
-        { "kind" : "LiteralInteger", "name" : "'Mout'" },
-        { "kind" : "LiteralInteger", "name" : "'EnableSubnormals'" },
-        { "kind" : "LiteralInteger", "name" : "'RoundingMode'" },
-        { "kind" : "LiteralInteger", "name" : "'RoundingAccuracy'" }
+        { "kind" : "IdRef", "name" : "A" },
+        { "kind" : "LiteralInteger", "name" : "M1" },
+        { "kind" : "LiteralInteger", "name" : "Mout" },
+        { "kind" : "LiteralInteger", "name" : "EnableSubnormals" },
+        { "kind" : "LiteralInteger", "name" : "RoundingMode" },
+        { "kind" : "LiteralInteger", "name" : "RoundingAccuracy" }
       ],
       "capabilities" : [ "ArbitraryPrecisionFloatingPointINTEL" ],
       "version" : "None"
@@ -9585,12 +9585,12 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'A'" },
-        { "kind" : "LiteralInteger", "name" : "'Ma'" },
-        { "kind" : "LiteralInteger", "name" : "'Mresult'" },
-        { "kind" : "LiteralInteger", "name" : "'Subnormal'" },
-        { "kind" : "LiteralInteger", "name" : "'Rounding'" },
-        { "kind" : "LiteralInteger", "name" : "'Accuracy'" }
+        { "kind" : "IdRef", "name" : "A" },
+        { "kind" : "LiteralInteger", "name" : "Ma" },
+        { "kind" : "LiteralInteger", "name" : "Mresult" },
+        { "kind" : "LiteralInteger", "name" : "Subnormal" },
+        { "kind" : "LiteralInteger", "name" : "Rounding" },
+        { "kind" : "LiteralInteger", "name" : "Accuracy" }
       ],
       "capabilities" : [ "ArbitraryPrecisionFloatingPointINTEL" ],
       "version" : "None"
@@ -9602,12 +9602,12 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'A'" },
-        { "kind" : "LiteralInteger", "name" : "'Ma'" },
-        { "kind" : "LiteralInteger", "name" : "'Mresult'" },
-        { "kind" : "LiteralInteger", "name" : "'Subnormal'" },
-        { "kind" : "LiteralInteger", "name" : "'Rounding'" },
-        { "kind" : "LiteralInteger", "name" : "'Accuracy'" }
+        { "kind" : "IdRef", "name" : "A" },
+        { "kind" : "LiteralInteger", "name" : "Ma" },
+        { "kind" : "LiteralInteger", "name" : "Mresult" },
+        { "kind" : "LiteralInteger", "name" : "Subnormal" },
+        { "kind" : "LiteralInteger", "name" : "Rounding" },
+        { "kind" : "LiteralInteger", "name" : "Accuracy" }
       ],
       "capabilities" : [ "ArbitraryPrecisionFloatingPointINTEL" ],
       "version" : "None"
@@ -9619,12 +9619,12 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'A'" },
-        { "kind" : "LiteralInteger", "name" : "'Ma'" },
-        { "kind" : "LiteralInteger", "name" : "'Mresult'" },
-        { "kind" : "LiteralInteger", "name" : "'Subnormal'" },
-        { "kind" : "LiteralInteger", "name" : "'Rounding'" },
-        { "kind" : "LiteralInteger", "name" : "'Accuracy'" }
+        { "kind" : "IdRef", "name" : "A" },
+        { "kind" : "LiteralInteger", "name" : "Ma" },
+        { "kind" : "LiteralInteger", "name" : "Mresult" },
+        { "kind" : "LiteralInteger", "name" : "Subnormal" },
+        { "kind" : "LiteralInteger", "name" : "Rounding" },
+        { "kind" : "LiteralInteger", "name" : "Accuracy" }
       ],
       "capabilities" : [ "ArbitraryPrecisionFloatingPointINTEL" ],
       "version" : "None"
@@ -9636,14 +9636,14 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'A'" },
-        { "kind" : "LiteralInteger", "name" : "'Ma'" },
-        { "kind" : "IdRef", "name" : "'B'" },
-        { "kind" : "LiteralInteger", "name" : "'Mb'" },
-        { "kind" : "LiteralInteger", "name" : "'Mresult'" },
-        { "kind" : "LiteralInteger", "name" : "'Subnormal'" },
-        { "kind" : "LiteralInteger", "name" : "'Rounding'" },
-        { "kind" : "LiteralInteger", "name" : "'Accuracy'" }
+        { "kind" : "IdRef", "name" : "A" },
+        { "kind" : "LiteralInteger", "name" : "Ma" },
+        { "kind" : "IdRef", "name" : "B" },
+        { "kind" : "LiteralInteger", "name" : "Mb" },
+        { "kind" : "LiteralInteger", "name" : "Mresult" },
+        { "kind" : "LiteralInteger", "name" : "Subnormal" },
+        { "kind" : "LiteralInteger", "name" : "Rounding" },
+        { "kind" : "LiteralInteger", "name" : "Accuracy" }
       ],
       "capabilities" : [ "ArbitraryPrecisionFloatingPointINTEL" ],
       "version" : "None"
@@ -9655,14 +9655,14 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'A'" },
-        { "kind" : "LiteralInteger", "name" : "'Ma'" },
-        { "kind" : "IdRef", "name" : "'B'" },
-        { "kind" : "LiteralInteger", "name" : "'Mb'" },
-        { "kind" : "LiteralInteger", "name" : "'Mresult'" },
-        { "kind" : "LiteralInteger", "name" : "'Subnormal'" },
-        { "kind" : "LiteralInteger", "name" : "'Rounding'" },
-        { "kind" : "LiteralInteger", "name" : "'Accuracy'" }
+        { "kind" : "IdRef", "name" : "A" },
+        { "kind" : "LiteralInteger", "name" : "Ma" },
+        { "kind" : "IdRef", "name" : "B" },
+        { "kind" : "LiteralInteger", "name" : "Mb" },
+        { "kind" : "LiteralInteger", "name" : "Mresult" },
+        { "kind" : "LiteralInteger", "name" : "Subnormal" },
+        { "kind" : "LiteralInteger", "name" : "Rounding" },
+        { "kind" : "LiteralInteger", "name" : "Accuracy" }
       ],
       "capabilities" : [ "ArbitraryPrecisionFloatingPointINTEL" ],
       "version" : "None"
@@ -9674,14 +9674,14 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'A'" },
-        { "kind" : "LiteralInteger", "name" : "'Ma'" },
-        { "kind" : "IdRef", "name" : "'B'" },
-        { "kind" : "LiteralInteger", "name" : "'Mb'" },
-        { "kind" : "LiteralInteger", "name" : "'Mresult'" },
-        { "kind" : "LiteralInteger", "name" : "'Subnormal'" },
-        { "kind" : "LiteralInteger", "name" : "'Rounding'" },
-        { "kind" : "LiteralInteger", "name" : "'Accuracy'" }
+        { "kind" : "IdRef", "name" : "A" },
+        { "kind" : "LiteralInteger", "name" : "Ma" },
+        { "kind" : "IdRef", "name" : "B" },
+        { "kind" : "LiteralInteger", "name" : "Mb" },
+        { "kind" : "LiteralInteger", "name" : "Mresult" },
+        { "kind" : "LiteralInteger", "name" : "Subnormal" },
+        { "kind" : "LiteralInteger", "name" : "Rounding" },
+        { "kind" : "LiteralInteger", "name" : "Accuracy" }
       ],
       "capabilities" : [ "ArbitraryPrecisionFloatingPointINTEL" ],
       "version" : "None"
@@ -9693,14 +9693,14 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'A'" },
-        { "kind" : "LiteralInteger", "name" : "'Ma'" },
-        { "kind" : "IdRef", "name" : "'B'" },
-        { "kind" : "LiteralInteger", "name" : "'SignOfB'" },
-        { "kind" : "LiteralInteger", "name" : "'Mresult'" },
-        { "kind" : "LiteralInteger", "name" : "'Subnormal'" },
-        { "kind" : "LiteralInteger", "name" : "'Rounding'" },
-        { "kind" : "LiteralInteger", "name" : "'Accuracy'" }
+        { "kind" : "IdRef", "name" : "A" },
+        { "kind" : "LiteralInteger", "name" : "Ma" },
+        { "kind" : "IdRef", "name" : "B" },
+        { "kind" : "LiteralInteger", "name" : "SignOfB" },
+        { "kind" : "LiteralInteger", "name" : "Mresult" },
+        { "kind" : "LiteralInteger", "name" : "Subnormal" },
+        { "kind" : "LiteralInteger", "name" : "Rounding" },
+        { "kind" : "LiteralInteger", "name" : "Accuracy" }
       ],
       "capabilities" : [ "ArbitraryPrecisionFloatingPointINTEL" ],
       "version" : "None"
@@ -9710,7 +9710,7 @@
       "class"  : "Reserved",
       "opcode" : 5887,
       "operands" : [
-        { "kind" : "LiteralInteger", "quantifier" : "*", "name" : "'Loop Control Parameters'" }
+        { "kind" : "LiteralInteger", "quantifier" : "*", "name" : "Loop Control Parameters" }
       ],
       "capabilities" : [ "UnstructuredLoopControlsINTEL" ],
       "extensions" : [ "SPV_INTEL_unstructured_loop_controls" ],
@@ -9722,7 +9722,7 @@
       "opcode" : 5911,
       "operands" : [
         { "kind" : "IdResult"},
-        { "kind" : "IdRef", "quantifier" : "?", "name" : "'Name'" }
+        { "kind" : "IdRef", "quantifier" : "?", "name" : "Name" }
       ],
       "capabilities" : [ "MemoryAccessAliasingINTEL" ],
       "extensions" : [ "SPV_INTEL_memory_access_aliasing" ],
@@ -9734,8 +9734,8 @@
       "opcode" : 5912,
       "operands" : [
         { "kind" : "IdResult"},
-        { "kind" : "IdRef", "name" : "'Alias Domain'"},
-        { "kind" : "IdRef", "quantifier" : "?", "name" : "'Name'" }
+        { "kind" : "IdRef", "name" : "Alias Domain"},
+        { "kind" : "IdRef", "quantifier" : "?", "name" : "Name" }
       ],
       "capabilities" : [ "MemoryAccessAliasingINTEL" ],
       "extensions" : [ "SPV_INTEL_memory_access_aliasing" ],
@@ -9747,7 +9747,7 @@
       "opcode" : 5913,
       "operands" : [
         { "kind" : "IdResult"},
-        { "kind" : "IdRef", "quantifier" : "*", "name" : "'AliasScope1, AliasScope2, ...'" }
+        { "kind" : "IdRef", "quantifier" : "*", "name" : "AliasScope 1, AliasScope 2, ..." }
       ],
       "capabilities" : [ "MemoryAccessAliasingINTEL" ],
       "extensions" : [ "SPV_INTEL_memory_access_aliasing" ],
@@ -9760,12 +9760,12 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Input'" },
-        { "kind" : "LiteralInteger", "name" : "'S'" },
-        { "kind" : "LiteralInteger", "name" : "'I'" },
-        { "kind" : "LiteralInteger", "name" : "'rI'" },
-        { "kind" : "LiteralInteger", "name" : "'Q'" },
-        { "kind" : "LiteralInteger", "name" : "'O'" }
+        { "kind" : "IdRef", "name" : "Input" },
+        { "kind" : "LiteralInteger", "name" : "S" },
+        { "kind" : "LiteralInteger", "name" : "I" },
+        { "kind" : "LiteralInteger", "name" : "rI" },
+        { "kind" : "LiteralInteger", "name" : "Q" },
+        { "kind" : "LiteralInteger", "name" : "O" }
       ],
       "capabilities" : [ "ArbitraryPrecisionFixedPointINTEL" ],
       "version" : "None"
@@ -9777,12 +9777,12 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Input'" },
-        { "kind" : "LiteralInteger", "name" : "'S'" },
-        { "kind" : "LiteralInteger", "name" : "'I'" },
-        { "kind" : "LiteralInteger", "name" : "'rI'" },
-        { "kind" : "LiteralInteger", "name" : "'Q'" },
-        { "kind" : "LiteralInteger", "name" : "'O'" }
+        { "kind" : "IdRef", "name" : "Input" },
+        { "kind" : "LiteralInteger", "name" : "S" },
+        { "kind" : "LiteralInteger", "name" : "I" },
+        { "kind" : "LiteralInteger", "name" : "rI" },
+        { "kind" : "LiteralInteger", "name" : "Q" },
+        { "kind" : "LiteralInteger", "name" : "O" }
       ],
       "capabilities" : [ "ArbitraryPrecisionFixedPointINTEL" ],
       "version" : "None"
@@ -9794,12 +9794,12 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Input'" },
-        { "kind" : "LiteralInteger", "name" : "'S'" },
-        { "kind" : "LiteralInteger", "name" : "'I'" },
-        { "kind" : "LiteralInteger", "name" : "'rI'" },
-        { "kind" : "LiteralInteger", "name" : "'Q'" },
-        { "kind" : "LiteralInteger", "name" : "'O'" }
+        { "kind" : "IdRef", "name" : "Input" },
+        { "kind" : "LiteralInteger", "name" : "S" },
+        { "kind" : "LiteralInteger", "name" : "I" },
+        { "kind" : "LiteralInteger", "name" : "rI" },
+        { "kind" : "LiteralInteger", "name" : "Q" },
+        { "kind" : "LiteralInteger", "name" : "O" }
       ],
       "capabilities" : [ "ArbitraryPrecisionFixedPointINTEL" ],
       "version" : "None"
@@ -9811,12 +9811,12 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Input'" },
-        { "kind" : "LiteralInteger", "name" : "'S'" },
-        { "kind" : "LiteralInteger", "name" : "'I'" },
-        { "kind" : "LiteralInteger", "name" : "'rI'" },
-        { "kind" : "LiteralInteger", "name" : "'Q'" },
-        { "kind" : "LiteralInteger", "name" : "'O'" }
+        { "kind" : "IdRef", "name" : "Input" },
+        { "kind" : "LiteralInteger", "name" : "S" },
+        { "kind" : "LiteralInteger", "name" : "I" },
+        { "kind" : "LiteralInteger", "name" : "rI" },
+        { "kind" : "LiteralInteger", "name" : "Q" },
+        { "kind" : "LiteralInteger", "name" : "O" }
       ],
       "capabilities" : [ "ArbitraryPrecisionFixedPointINTEL" ],
       "version" : "None"
@@ -9828,12 +9828,12 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Input'" },
-        { "kind" : "LiteralInteger", "name" : "'S'" },
-        { "kind" : "LiteralInteger", "name" : "'I'" },
-        { "kind" : "LiteralInteger", "name" : "'rI'" },
-        { "kind" : "LiteralInteger", "name" : "'Q'" },
-        { "kind" : "LiteralInteger", "name" : "'O'" }
+        { "kind" : "IdRef", "name" : "Input" },
+        { "kind" : "LiteralInteger", "name" : "S" },
+        { "kind" : "LiteralInteger", "name" : "I" },
+        { "kind" : "LiteralInteger", "name" : "rI" },
+        { "kind" : "LiteralInteger", "name" : "Q" },
+        { "kind" : "LiteralInteger", "name" : "O" }
       ],
       "capabilities" : [ "ArbitraryPrecisionFixedPointINTEL" ],
       "version" : "None"
@@ -9845,12 +9845,12 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Input'" },
-        { "kind" : "LiteralInteger", "name" : "'S'" },
-        { "kind" : "LiteralInteger", "name" : "'I'" },
-        { "kind" : "LiteralInteger", "name" : "'rI'" },
-        { "kind" : "LiteralInteger", "name" : "'Q'" },
-        { "kind" : "LiteralInteger", "name" : "'O'" }
+        { "kind" : "IdRef", "name" : "Input" },
+        { "kind" : "LiteralInteger", "name" : "S" },
+        { "kind" : "LiteralInteger", "name" : "I" },
+        { "kind" : "LiteralInteger", "name" : "rI" },
+        { "kind" : "LiteralInteger", "name" : "Q" },
+        { "kind" : "LiteralInteger", "name" : "O" }
       ],
       "capabilities" : [ "ArbitraryPrecisionFixedPointINTEL" ],
       "version" : "None"
@@ -9862,12 +9862,12 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Input'" },
-        { "kind" : "LiteralInteger", "name" : "'S'" },
-        { "kind" : "LiteralInteger", "name" : "'I'" },
-        { "kind" : "LiteralInteger", "name" : "'rI'" },
-        { "kind" : "LiteralInteger", "name" : "'Q'" },
-        { "kind" : "LiteralInteger", "name" : "'O'" }
+        { "kind" : "IdRef", "name" : "Input" },
+        { "kind" : "LiteralInteger", "name" : "S" },
+        { "kind" : "LiteralInteger", "name" : "I" },
+        { "kind" : "LiteralInteger", "name" : "rI" },
+        { "kind" : "LiteralInteger", "name" : "Q" },
+        { "kind" : "LiteralInteger", "name" : "O" }
       ],
       "capabilities" : [ "ArbitraryPrecisionFixedPointINTEL" ],
       "version" : "None"
@@ -9879,12 +9879,12 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Input'" },
-        { "kind" : "LiteralInteger", "name" : "'S'" },
-        { "kind" : "LiteralInteger", "name" : "'I'" },
-        { "kind" : "LiteralInteger", "name" : "'rI'" },
-        { "kind" : "LiteralInteger", "name" : "'Q'" },
-        { "kind" : "LiteralInteger", "name" : "'O'" }
+        { "kind" : "IdRef", "name" : "Input" },
+        { "kind" : "LiteralInteger", "name" : "S" },
+        { "kind" : "LiteralInteger", "name" : "I" },
+        { "kind" : "LiteralInteger", "name" : "rI" },
+        { "kind" : "LiteralInteger", "name" : "Q" },
+        { "kind" : "LiteralInteger", "name" : "O" }
       ],
       "capabilities" : [ "ArbitraryPrecisionFixedPointINTEL" ],
       "version" : "None"
@@ -9896,12 +9896,12 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Input'" },
-        { "kind" : "LiteralInteger", "name" : "'S'" },
-        { "kind" : "LiteralInteger", "name" : "'I'" },
-        { "kind" : "LiteralInteger", "name" : "'rI'" },
-        { "kind" : "LiteralInteger", "name" : "'Q'" },
-        { "kind" : "LiteralInteger", "name" : "'O'" }
+        { "kind" : "IdRef", "name" : "Input" },
+        { "kind" : "LiteralInteger", "name" : "S" },
+        { "kind" : "LiteralInteger", "name" : "I" },
+        { "kind" : "LiteralInteger", "name" : "rI" },
+        { "kind" : "LiteralInteger", "name" : "Q" },
+        { "kind" : "LiteralInteger", "name" : "O" }
       ],
       "capabilities" : [ "ArbitraryPrecisionFixedPointINTEL" ],
       "version" : "None"
@@ -9913,12 +9913,12 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Input'" },
-        { "kind" : "LiteralInteger", "name" : "'S'" },
-        { "kind" : "LiteralInteger", "name" : "'I'" },
-        { "kind" : "LiteralInteger", "name" : "'rI'" },
-        { "kind" : "LiteralInteger", "name" : "'Q'" },
-        { "kind" : "LiteralInteger", "name" : "'O'" }
+        { "kind" : "IdRef", "name" : "Input" },
+        { "kind" : "LiteralInteger", "name" : "S" },
+        { "kind" : "LiteralInteger", "name" : "I" },
+        { "kind" : "LiteralInteger", "name" : "rI" },
+        { "kind" : "LiteralInteger", "name" : "Q" },
+        { "kind" : "LiteralInteger", "name" : "O" }
       ],
       "capabilities" : [ "ArbitraryPrecisionFixedPointINTEL" ],
       "version" : "None"
@@ -9930,12 +9930,12 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Input'" },
-        { "kind" : "LiteralInteger", "name" : "'S'" },
-        { "kind" : "LiteralInteger", "name" : "'I'" },
-        { "kind" : "LiteralInteger", "name" : "'rI'" },
-        { "kind" : "LiteralInteger", "name" : "'Q'" },
-        { "kind" : "LiteralInteger", "name" : "'O'" }
+        { "kind" : "IdRef", "name" : "Input" },
+        { "kind" : "LiteralInteger", "name" : "S" },
+        { "kind" : "LiteralInteger", "name" : "I" },
+        { "kind" : "LiteralInteger", "name" : "rI" },
+        { "kind" : "LiteralInteger", "name" : "Q" },
+        { "kind" : "LiteralInteger", "name" : "O" }
       ],
       "capabilities" : [ "ArbitraryPrecisionFixedPointINTEL" ],
       "version" : "None"
@@ -9947,7 +9947,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Pointer'" }
+        { "kind" : "IdRef", "name" : "Pointer" }
       ],
       "capabilities" : [ "USMStorageClassesINTEL" ],
       "version" : "None"
@@ -9959,7 +9959,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Pointer'" }
+        { "kind" : "IdRef", "name" : "Pointer" }
       ],
       "capabilities" : [ "USMStorageClassesINTEL" ],
       "version" : "None"
@@ -9971,8 +9971,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Packet Size'" },
-        { "kind" : "IdRef", "name" : "'Packet Alignment'" }
+        { "kind" : "IdRef", "name" : "Packet Size" },
+        { "kind" : "IdRef", "name" : "Packet Alignment" }
       ],
       "capabilities" : [ "BlockingPipesINTEL" ],
       "extensions" : [ "SPV_INTEL_blocking_pipes" ],
@@ -9985,8 +9985,8 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Packet Size'" },
-        { "kind" : "IdRef", "name" : "'Packet Alignment'" }
+        { "kind" : "IdRef", "name" : "Packet Size" },
+        { "kind" : "IdRef", "name" : "Packet Alignment" }
       ],
       "capabilities" : [ "BlockingPipesINTEL" ],
       "extensions" : [ "SPV_INTEL_blocking_pipes" ],
@@ -9999,7 +9999,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Input'" }
+        { "kind" : "IdRef", "name" : "Input" }
       ],
       "capabilities" : [ "FPGARegINTEL" ],
       "extensions" : [ "SPV_INTEL_fpga_reg" ],
@@ -10014,7 +10014,7 @@
             { "kind" : "IdResult" },
             {
                 "kind" : "IdRef",
-                "name" : "'RayQuery'"
+                "name" : "RayQuery"
             }
         ],
         "capabilities" : [ "RayQueryKHR" ],
@@ -10030,7 +10030,7 @@
             { "kind" : "IdResult" },
             {
                 "kind" : "IdRef",
-                "name" : "'RayQuery'"
+                "name" : "RayQuery"
             }
         ],
         "capabilities" : [ "RayQueryKHR" ],
@@ -10046,11 +10046,11 @@
             { "kind" : "IdResult" },
             {
                 "kind" : "IdRef",
-                "name" : "'RayQuery'"
+                "name" : "RayQuery"
             },
             {
                 "kind" : "IdRef",
-                "name" : "'Intersection'"
+                "name" : "Intersection"
             }
         ],
         "capabilities" : [ "RayQueryKHR" ],
@@ -10066,11 +10066,11 @@
             { "kind" : "IdResult" },
             {
                 "kind" : "IdRef",
-                "name" : "'RayQuery'"
+                "name" : "RayQuery"
             },
             {
                 "kind" : "IdRef",
-                "name" : "'Intersection'"
+                "name" : "Intersection"
             }
         ],
         "capabilities" : [ "RayQueryKHR" ],
@@ -10086,11 +10086,11 @@
             { "kind" : "IdResult" },
             {
                 "kind" : "IdRef",
-                "name" : "'RayQuery'"
+                "name" : "RayQuery"
             },
             {
                 "kind" : "IdRef",
-                "name" : "'Intersection'"
+                "name" : "Intersection"
             }
         ],
         "capabilities" : [ "RayQueryKHR" ],
@@ -10106,11 +10106,11 @@
             { "kind" : "IdResult" },
             {
                 "kind" : "IdRef",
-                "name" : "'RayQuery'"
+                "name" : "RayQuery"
             },
             {
                 "kind" : "IdRef",
-                "name" : "'Intersection'"
+                "name" : "Intersection"
             }
         ],
         "capabilities" : [ "RayQueryKHR" ],
@@ -10126,11 +10126,11 @@
             { "kind" : "IdResult" },
             {
                 "kind" : "IdRef",
-                "name" : "'RayQuery'"
+                "name" : "RayQuery"
             },
             {
                 "kind" : "IdRef",
-                "name" : "'Intersection'"
+                "name" : "Intersection"
             }
         ],
         "capabilities" : [ "RayQueryKHR" ],
@@ -10146,11 +10146,11 @@
             { "kind" : "IdResult" },
             {
                 "kind" : "IdRef",
-                "name" : "'RayQuery'"
+                "name" : "RayQuery"
             },
             {
                 "kind" : "IdRef",
-                "name" : "'Intersection'"
+                "name" : "Intersection"
             }
         ],
         "capabilities" : [ "RayQueryKHR" ],
@@ -10166,11 +10166,11 @@
             { "kind" : "IdResult" },
             {
                 "kind" : "IdRef",
-                "name" : "'RayQuery'"
+                "name" : "RayQuery"
             },
             {
                 "kind" : "IdRef",
-                "name" : "'Intersection'"
+                "name" : "Intersection"
             }
         ],
         "capabilities" : [ "RayQueryKHR" ],
@@ -10186,11 +10186,11 @@
             { "kind" : "IdResult" },
             {
                 "kind" : "IdRef",
-                "name" : "'RayQuery'"
+                "name" : "RayQuery"
             },
             {
                 "kind" : "IdRef",
-                "name" : "'Intersection'"
+                "name" : "Intersection"
             }
         ],
         "capabilities" : [ "RayQueryKHR" ],
@@ -10206,7 +10206,7 @@
             { "kind" : "IdResult" },
             {
                 "kind" : "IdRef",
-                "name" : "'RayQuery'"
+                "name" : "RayQuery"
             }
         ],
         "capabilities" : [ "RayQueryKHR" ],
@@ -10222,11 +10222,11 @@
             { "kind" : "IdResult" },
             {
                 "kind" : "IdRef",
-                "name" : "'RayQuery'"
+                "name" : "RayQuery"
             },
             {
                 "kind" : "IdRef",
-                "name" : "'Intersection'"
+                "name" : "Intersection"
             }
         ],
         "capabilities" : [ "RayQueryKHR" ],
@@ -10242,11 +10242,11 @@
             { "kind" : "IdResult" },
             {
                 "kind" : "IdRef",
-                "name" : "'RayQuery'"
+                "name" : "RayQuery"
             },
             {
                 "kind" : "IdRef",
-                "name" : "'Intersection'"
+                "name" : "Intersection"
             }
         ],
         "capabilities" : [ "RayQueryKHR" ],
@@ -10262,7 +10262,7 @@
             { "kind" : "IdResult" },
             {
                 "kind" : "IdRef",
-                "name" : "'RayQuery'"
+                "name" : "RayQuery"
             }
         ],
         "capabilities" : [ "RayQueryKHR" ],
@@ -10278,7 +10278,7 @@
             { "kind" : "IdResult" },
             {
                 "kind" : "IdRef",
-                "name" : "'RayQuery'"
+                "name" : "RayQuery"
             }
         ],
         "capabilities" : [ "RayQueryKHR" ],
@@ -10294,11 +10294,11 @@
             { "kind" : "IdResult" },
             {
                 "kind" : "IdRef",
-                "name" : "'RayQuery'"
+                "name" : "RayQuery"
             },
             {
                 "kind" : "IdRef",
-                "name" : "'Intersection'"
+                "name" : "Intersection"
             }
         ],
         "capabilities" : [ "RayQueryKHR" ],
@@ -10314,11 +10314,11 @@
             { "kind" : "IdResult" },
             {
                 "kind" : "IdRef",
-                "name" : "'RayQuery'"
+                "name" : "RayQuery"
             },
              {
                 "kind" : "IdRef",
-                "name" : "'Intersection'"
+                "name" : "Intersection"
             }
         ],
         "capabilities" : [ "RayQueryKHR" ],
@@ -10332,10 +10332,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",             "name" : "'Pointer'" },
-        { "kind" : "IdScope",           "name" : "'Memory'" },
-        { "kind" : "IdMemorySemantics", "name" : "'Semantics'" },
-        { "kind" : "IdRef",             "name" : "'Value'" }
+        { "kind" : "IdRef",             "name" : "Pointer" },
+        { "kind" : "IdScope",           "name" : "Memory" },
+        { "kind" : "IdMemorySemantics", "name" : "Semantics" },
+        { "kind" : "IdRef",             "name" : "Value" }
       ],
       "capabilities" : [ "AtomicFloat16AddEXT", "AtomicFloat32AddEXT", "AtomicFloat64AddEXT", "AtomicFloat16VectorNV" ],
       "extensions" : [ "SPV_EXT_shader_atomic_float_add" ],
@@ -10349,7 +10349,7 @@
         { "kind" : "IdResult" },
         {
           "kind" : "AccessQualifier",
-          "name" : "'AccessQualifier'"
+          "name" : "AccessQualifier"
         }
       ],
       "capabilities" : [ "VectorComputeINTEL" ],
@@ -10360,7 +10360,7 @@
       "class"  : "Type-Declaration",
       "opcode" : 6090,
       "operands" : [
-        { "kind" : "IdRef",    "quantifier" : "*", "name" : "'Member 0 type', +\n'member 1 type', +\n..." }
+        { "kind" : "IdRef",    "quantifier" : "*", "name" : "Member 0 type, member 1 type, ..." }
       ],
       "capabilities" : [ "LongCompositesINTEL" ],
       "version" : "None"
@@ -10370,7 +10370,7 @@
       "class"  : "Constant-Creation",
       "opcode" : 6091,
       "operands" : [
-        { "kind" : "IdRef",        "quantifier" : "*", "name" : "'Constituents'" }
+        { "kind" : "IdRef",        "quantifier" : "*", "name" : "Constituents" }
       ],
       "capabilities" : [ "LongCompositesINTEL" ],
       "version" : "None"
@@ -10380,7 +10380,7 @@
       "class"  : "Constant-Creation",
       "opcode" : 6092,
       "operands" : [
-        { "kind" : "IdRef",        "quantifier" : "*", "name" : "'Constituents'" }
+        { "kind" : "IdRef",        "quantifier" : "*", "name" : "Constituents" }
       ],
       "capabilities" : [ "LongCompositesINTEL" ],
       "version" : "None"
@@ -10392,7 +10392,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "quantifier" : "*", "name" : "'Constituents'" }
+        { "kind" : "IdRef",        "quantifier" : "*", "name" : "Constituents" }
       ],
       "capabilities" : [ "LongCompositesINTEL" ],
       "version": "None"
@@ -10404,7 +10404,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Float Value'" }
+        { "kind" : "IdRef",        "name" : "Float Value" }
       ],
       "capabilities" : [ "BFloat16ConversionINTEL" ],
       "version" : "None"
@@ -10416,7 +10416,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'BFloat16 Value'" }
+        { "kind" : "IdRef",        "name" : "BFloat16 Value" }
       ],
       "capabilities" : [ "BFloat16ConversionINTEL" ],
       "version" : "None"
@@ -10426,9 +10426,9 @@
       "class"  : "Barrier",
       "opcode" : 6142,
       "operands" : [
-        { "kind" : "IdScope",           "name" : "'Execution'" },
-        { "kind" : "IdScope",           "name" : "'Memory'" },
-        { "kind" : "IdMemorySemantics", "name" : "'Semantics'" }
+        { "kind" : "IdScope",           "name" : "Execution" },
+        { "kind" : "IdScope",           "name" : "Memory" },
+        { "kind" : "IdMemorySemantics", "name" : "Semantics" }
       ],
       "capabilities" : [ "SplitBarrierINTEL" ],
       "version" : "None"
@@ -10438,9 +10438,9 @@
       "class"  : "Barrier",
       "opcode" : 6143,
       "operands" : [
-        { "kind" : "IdScope",           "name" : "'Execution'" },
-        { "kind" : "IdScope",           "name" : "'Memory'" },
-        { "kind" : "IdMemorySemantics", "name" : "'Semantics'" }
+        { "kind" : "IdScope",           "name" : "Execution" },
+        { "kind" : "IdScope",           "name" : "Memory" },
+        { "kind" : "IdMemorySemantics", "name" : "Semantics" }
       ],
       "capabilities" : [ "SplitBarrierINTEL" ],
       "version" : "None"
@@ -10452,7 +10452,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",          "name" : "'Target'" }
+        { "kind" : "IdRef",          "name" : "Target" }
       ],
       "capabilities" : [ "ArithmeticFenceEXT" ],
       "version" : "None"
@@ -10464,11 +10464,11 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",          "name" : "'Function'" },
-        { "kind" : "LiteralInteger",  "name" : "'Pipelined'" },
-        { "kind" : "LiteralInteger",  "name" : "'UseStallEnableClusters'" },
-        { "kind" : "LiteralInteger",  "name" : "'GetCapacity'" },
-        { "kind" : "LiteralInteger",  "name" : "'AsyncCapacity'" }
+        { "kind" : "IdRef",          "name" : "Function" },
+        { "kind" : "LiteralInteger",  "name" : "Pipelined" },
+        { "kind" : "LiteralInteger",  "name" : "UseStallEnableClusters" },
+        { "kind" : "LiteralInteger",  "name" : "GetCapacity" },
+        { "kind" : "LiteralInteger",  "name" : "AsyncCapacity" }
       ],
       "capabilities" : [ "TaskSequenceINTEL" ],
       "version" : "None"
@@ -10478,8 +10478,8 @@
       "class"  : "Reserved",
       "opcode" : 6164,
       "operands" : [
-        { "kind" : "IdRef",          "name" : "'Sequence'" },
-        { "kind" : "IdRef", "quantifier" : "*",  "name" : "'Arguments'" }
+        { "kind" : "IdRef",          "name" : "Sequence" },
+        { "kind" : "IdRef", "quantifier" : "*",  "name" : "Arguments" }
       ],
       "capabilities" : [ "TaskSequenceINTEL" ],
       "version" : "None"
@@ -10491,7 +10491,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",          "name" : "'Sequence'" }
+        { "kind" : "IdRef",          "name" : "Sequence" }
       ],
       "capabilities" : [ "TaskSequenceINTEL" ],
       "version" : "None"
@@ -10501,7 +10501,7 @@
       "class"  : "Reserved",
       "opcode" : 6166,
       "operands" : [
-        { "kind" : "IdRef",          "name" : "'Sequence'" }
+        { "kind" : "IdRef",          "name" : "Sequence" }
       ],
       "capabilities" : [ "TaskSequenceINTEL" ],
       "version" : "None"
@@ -10521,8 +10521,8 @@
       "class"  : "Group",
       "opcode" : 6221,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Ptr'" },
-        { "kind" : "IdRef", "name" : "'NumBytes'" },
+        { "kind" : "IdRef", "name" : "Ptr" },
+        { "kind" : "IdRef", "name" : "NumBytes" },
         { "kind" : "MemoryAccess", "quantifier" : "?" }
       ],
       "capabilities" : [ "SubgroupBufferPrefetchINTEL" ],
@@ -10533,16 +10533,16 @@
       "class"  : "Group",
       "opcode" : 6231,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Element Size'" },
-        { "kind" : "IdRef", "name" : "'Block Width'" },
-        { "kind" : "IdRef", "name" : "'Block Height'" },
-        { "kind" : "IdRef", "name" : "'Block Count'" },
-        { "kind" : "IdRef", "name" : "'Src Base Pointer'" },
-        { "kind" : "IdRef", "name" : "'Memory Width'" },
-        { "kind" : "IdRef", "name" : "'Memory Height'" },
-        { "kind" : "IdRef", "name" : "'Memory Pitch'" },
-        { "kind" : "IdRef", "name" : "'Coordinate'" },
-        { "kind" : "IdRef", "name" : "'Dst Pointer'" }
+        { "kind" : "IdRef", "name" : "Element Size" },
+        { "kind" : "IdRef", "name" : "Block Width" },
+        { "kind" : "IdRef", "name" : "Block Height" },
+        { "kind" : "IdRef", "name" : "Block Count" },
+        { "kind" : "IdRef", "name" : "Src Base Pointer" },
+        { "kind" : "IdRef", "name" : "Memory Width" },
+        { "kind" : "IdRef", "name" : "Memory Height" },
+        { "kind" : "IdRef", "name" : "Memory Pitch" },
+        { "kind" : "IdRef", "name" : "Coordinate" },
+        { "kind" : "IdRef", "name" : "Dst Pointer" }
       ],
       "capabilities" : [ "Subgroup2DBlockIOINTEL" ],
       "version" : "None"
@@ -10552,16 +10552,16 @@
       "class"  : "Group",
       "opcode" : 6232,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Element Size'" },
-        { "kind" : "IdRef", "name" : "'Block Width'" },
-        { "kind" : "IdRef", "name" : "'Block Height'" },
-        { "kind" : "IdRef", "name" : "'Block Count'" },
-        { "kind" : "IdRef", "name" : "'Src Base Pointer'" },
-        { "kind" : "IdRef", "name" : "'Memory Width'" },
-        { "kind" : "IdRef", "name" : "'Memory Height'" },
-        { "kind" : "IdRef", "name" : "'Memory Pitch'" },
-        { "kind" : "IdRef", "name" : "'Coordinate'" },
-        { "kind" : "IdRef", "name" : "'Dst Pointer'" }
+        { "kind" : "IdRef", "name" : "Element Size" },
+        { "kind" : "IdRef", "name" : "Block Width" },
+        { "kind" : "IdRef", "name" : "Block Height" },
+        { "kind" : "IdRef", "name" : "Block Count" },
+        { "kind" : "IdRef", "name" : "Src Base Pointer" },
+        { "kind" : "IdRef", "name" : "Memory Width" },
+        { "kind" : "IdRef", "name" : "Memory Height" },
+        { "kind" : "IdRef", "name" : "Memory Pitch" },
+        { "kind" : "IdRef", "name" : "Coordinate" },
+        { "kind" : "IdRef", "name" : "Dst Pointer" }
       ],
       "capabilities" : [ "Subgroup2DBlockTransformINTEL" ],
       "version" : "None"
@@ -10571,16 +10571,16 @@
       "class"  : "Group",
       "opcode" : 6233,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Element Size'" },
-        { "kind" : "IdRef", "name" : "'Block Width'" },
-        { "kind" : "IdRef", "name" : "'Block Height'" },
-        { "kind" : "IdRef", "name" : "'Block Count'" },
-        { "kind" : "IdRef", "name" : "'Src Base Pointer'" },
-        { "kind" : "IdRef", "name" : "'Memory Width'" },
-        { "kind" : "IdRef", "name" : "'Memory Height'" },
-        { "kind" : "IdRef", "name" : "'Memory Pitch'" },
-        { "kind" : "IdRef", "name" : "'Coordinate'" },
-        { "kind" : "IdRef", "name" : "'Dst Pointer'" }
+        { "kind" : "IdRef", "name" : "Element Size" },
+        { "kind" : "IdRef", "name" : "Block Width" },
+        { "kind" : "IdRef", "name" : "Block Height" },
+        { "kind" : "IdRef", "name" : "Block Count" },
+        { "kind" : "IdRef", "name" : "Src Base Pointer" },
+        { "kind" : "IdRef", "name" : "Memory Width" },
+        { "kind" : "IdRef", "name" : "Memory Height" },
+        { "kind" : "IdRef", "name" : "Memory Pitch" },
+        { "kind" : "IdRef", "name" : "Coordinate" },
+        { "kind" : "IdRef", "name" : "Dst Pointer" }
       ],
       "capabilities" : [ "Subgroup2DBlockTransposeINTEL" ],
       "version" : "None"
@@ -10590,15 +10590,15 @@
       "class"  : "Group",
       "opcode" : 6234,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Element Size'" },
-        { "kind" : "IdRef", "name" : "'Block Width'" },
-        { "kind" : "IdRef", "name" : "'Block Height'" },
-        { "kind" : "IdRef", "name" : "'Block Count'" },
-        { "kind" : "IdRef", "name" : "'Src Base Pointer'" },
-        { "kind" : "IdRef", "name" : "'Memory Width'" },
-        { "kind" : "IdRef", "name" : "'Memory Height'" },
-        { "kind" : "IdRef", "name" : "'Memory Pitch'" },
-        { "kind" : "IdRef", "name" : "'Coordinate'" }
+        { "kind" : "IdRef", "name" : "Element Size" },
+        { "kind" : "IdRef", "name" : "Block Width" },
+        { "kind" : "IdRef", "name" : "Block Height" },
+        { "kind" : "IdRef", "name" : "Block Count" },
+        { "kind" : "IdRef", "name" : "Src Base Pointer" },
+        { "kind" : "IdRef", "name" : "Memory Width" },
+        { "kind" : "IdRef", "name" : "Memory Height" },
+        { "kind" : "IdRef", "name" : "Memory Pitch" },
+        { "kind" : "IdRef", "name" : "Coordinate" }
       ],
       "capabilities" : [ "Subgroup2DBlockIOINTEL" ],
       "version" : "None"
@@ -10608,16 +10608,16 @@
       "class"  : "Group",
       "opcode" : 6235,
       "operands" : [
-        { "kind" : "IdRef", "name" : "'Element Size'" },
-        { "kind" : "IdRef", "name" : "'Block Width'" },
-        { "kind" : "IdRef", "name" : "'Block Height'" },
-        { "kind" : "IdRef", "name" : "'Block Count'" },
-        { "kind" : "IdRef", "name" : "'Src Pointer'" },
-        { "kind" : "IdRef", "name" : "'Dst Base Pointer'" },
-        { "kind" : "IdRef", "name" : "'Memory Width'" },
-        { "kind" : "IdRef", "name" : "'Memory Height'" },
-        { "kind" : "IdRef", "name" : "'Memory Pitch'" },
-        { "kind" : "IdRef", "name" : "'Coordinate'" }
+        { "kind" : "IdRef", "name" : "Element Size" },
+        { "kind" : "IdRef", "name" : "Block Width" },
+        { "kind" : "IdRef", "name" : "Block Height" },
+        { "kind" : "IdRef", "name" : "Block Count" },
+        { "kind" : "IdRef", "name" : "Src Pointer" },
+        { "kind" : "IdRef", "name" : "Dst Base Pointer" },
+        { "kind" : "IdRef", "name" : "Memory Width" },
+        { "kind" : "IdRef", "name" : "Memory Height" },
+        { "kind" : "IdRef", "name" : "Memory Pitch" },
+        { "kind" : "IdRef", "name" : "Coordinate" }
       ],
       "capabilities" : [ "Subgroup2DBlockIOINTEL" ],
       "version" : "None"
@@ -10629,10 +10629,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'K Dim'" },
-        { "kind" : "IdRef", "name" : "'Matrix A'" },
-        { "kind" : "IdRef", "name" : "'Matrix B'" },
-        { "kind" : "IdRef", "name" : "'Matrix C'" },
+        { "kind" : "IdRef", "name" : "K Dim" },
+        { "kind" : "IdRef", "name" : "Matrix A" },
+        { "kind" : "IdRef", "name" : "Matrix B" },
+        { "kind" : "IdRef", "name" : "Matrix C" },
         { "kind" : "MatrixMultiplyAccumulateOperands", "quantifier" : "?" }
       ],
       "capabilities" : [ "SubgroupMatrixMultiplyAccumulateINTEL" ],
@@ -10645,10 +10645,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'A'" },
-        { "kind" : "IdRef", "name" : "'B'" },
-        { "kind" : "IdRef", "name" : "'C'" },
-        { "kind" : "IdRef", "name" : "'LUTIndex'" }
+        { "kind" : "IdRef", "name" : "A" },
+        { "kind" : "IdRef", "name" : "B" },
+        { "kind" : "IdRef", "name" : "C" },
+        { "kind" : "IdRef", "name" : "LUTIndex" }
       ],
       "capabilities" : [ "TernaryBitwiseFunctionINTEL" ],
       "version" : "None"
@@ -10660,9 +10660,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope",        "name" : "'Execution'" },
-        { "kind" : "GroupOperation", "name" : "'Operation'" },
-        { "kind" : "IdRef",          "name" : "'X'" }
+        { "kind" : "IdScope",        "name" : "Execution" },
+        { "kind" : "GroupOperation", "name" : "Operation" },
+        { "kind" : "IdRef",          "name" : "X" }
       ],
       "capabilities" : [ "GroupUniformArithmeticKHR" ],
       "version" : "None"
@@ -10674,9 +10674,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope",        "name" : "'Execution'" },
-        { "kind" : "GroupOperation", "name" : "'Operation'" },
-        { "kind" : "IdRef",          "name" : "'X'" }
+        { "kind" : "IdScope",        "name" : "Execution" },
+        { "kind" : "GroupOperation", "name" : "Operation" },
+        { "kind" : "IdRef",          "name" : "X" }
       ],
       "capabilities" : [ "GroupUniformArithmeticKHR" ],
       "version" : "None"
@@ -10688,9 +10688,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope",        "name" : "'Execution'" },
-        { "kind" : "GroupOperation", "name" : "'Operation'" },
-        { "kind" : "IdRef",          "name" : "'X'" }
+        { "kind" : "IdScope",        "name" : "Execution" },
+        { "kind" : "GroupOperation", "name" : "Operation" },
+        { "kind" : "IdRef",          "name" : "X" }
       ],
       "capabilities" : [ "GroupUniformArithmeticKHR" ],
       "version" : "None"
@@ -10702,9 +10702,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope",        "name" : "'Execution'" },
-        { "kind" : "GroupOperation", "name" : "'Operation'" },
-        { "kind" : "IdRef",          "name" : "'X'" }
+        { "kind" : "IdScope",        "name" : "Execution" },
+        { "kind" : "GroupOperation", "name" : "Operation" },
+        { "kind" : "IdRef",          "name" : "X" }
       ],
       "capabilities" : [ "GroupUniformArithmeticKHR" ],
       "version" : "None"
@@ -10716,9 +10716,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope",        "name" : "'Execution'" },
-        { "kind" : "GroupOperation", "name" : "'Operation'" },
-        { "kind" : "IdRef",          "name" : "'X'" }
+        { "kind" : "IdScope",        "name" : "Execution" },
+        { "kind" : "GroupOperation", "name" : "Operation" },
+        { "kind" : "IdRef",          "name" : "X" }
       ],
       "capabilities" : [ "GroupUniformArithmeticKHR" ],
       "version" : "None"
@@ -10730,9 +10730,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope",        "name" : "'Execution'" },
-        { "kind" : "GroupOperation", "name" : "'Operation'" },
-        { "kind" : "IdRef",          "name" : "'X'" }
+        { "kind" : "IdScope",        "name" : "Execution" },
+        { "kind" : "GroupOperation", "name" : "Operation" },
+        { "kind" : "IdRef",          "name" : "X" }
       ],
       "capabilities" : [ "GroupUniformArithmeticKHR" ],
       "version" : "None"
@@ -10744,9 +10744,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope",        "name" : "'Execution'" },
-        { "kind" : "GroupOperation", "name" : "'Operation'" },
-        { "kind" : "IdRef",          "name" : "'X'" }
+        { "kind" : "IdScope",        "name" : "Execution" },
+        { "kind" : "GroupOperation", "name" : "Operation" },
+        { "kind" : "IdRef",          "name" : "X" }
       ],
       "capabilities" : [ "GroupUniformArithmeticKHR" ],
       "version" : "None"
@@ -10758,9 +10758,9 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdScope",        "name" : "'Execution'" },
-        { "kind" : "GroupOperation", "name" : "'Operation'" },
-        { "kind" : "IdRef",          "name" : "'X'" }
+        { "kind" : "IdScope",        "name" : "Execution" },
+        { "kind" : "GroupOperation", "name" : "Operation" },
+        { "kind" : "IdRef",          "name" : "X" }
       ],
       "capabilities" : [ "GroupUniformArithmeticKHR" ],
       "version" : "None"
@@ -10772,7 +10772,7 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",        "name" : "'Float Value'" }
+        { "kind" : "IdRef",        "name" : "Float Value" }
       ],
       "capabilities" : [ "TensorFloat32RoundingINTEL" ],
       "version" : "None"
@@ -10784,10 +10784,10 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef",           "name" : "'PtrVector'" },
-        { "kind" : "LiteralInteger",  "name" : "'Alignment'" },
-        { "kind" : "IdRef",           "name" : "'Mask'" },
-        { "kind" : "IdRef",           "name" : "'FillEmpty'" }
+        { "kind" : "IdRef",           "name" : "PtrVector" },
+        { "kind" : "LiteralInteger",  "name" : "Alignment" },
+        { "kind" : "IdRef",           "name" : "Mask" },
+        { "kind" : "IdRef",           "name" : "FillEmpty" }
       ],
       "capabilities" : [ "MaskedGatherScatterINTEL" ],
       "version" : "None"
@@ -10797,10 +10797,10 @@
       "class"  : "Memory",
       "opcode" : 6429,
       "operands" : [
-        { "kind" : "IdRef",           "name" : "'InputVector'" },
-        { "kind" : "IdRef",           "name" : "'PtrVector'" },
-        { "kind" : "LiteralInteger",  "name" : "'Alignment'" },
-        { "kind" : "IdRef",           "name" : "'Mask'" }
+        { "kind" : "IdRef",           "name" : "InputVector" },
+        { "kind" : "IdRef",           "name" : "PtrVector" },
+        { "kind" : "LiteralInteger",  "name" : "Alignment" },
+        { "kind" : "IdRef",           "name" : "Mask" }
       ],
       "capabilities" : [ "MaskedGatherScatterINTEL" ],
       "version" : "None"
@@ -11807,7 +11807,7 @@
           "value" : 0,
           "capabilities" : [ "Geometry" ],
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'Number of <<Invocation,invocations>>'" }
+            { "kind" : "LiteralInteger", "name" : "Number of <<Invocation,invocations>>" }
           ],
           "version": "1.0"
         },
@@ -11905,9 +11905,9 @@
           "enumerant" : "LocalSize",
           "value" : 17,
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'x size'" },
-            { "kind" : "LiteralInteger", "name" : "'y size'" },
-            { "kind" : "LiteralInteger", "name" : "'z size'" }
+            { "kind" : "LiteralInteger", "name" : "x size" },
+            { "kind" : "LiteralInteger", "name" : "y size" },
+            { "kind" : "LiteralInteger", "name" : "z size" }
           ],
           "version": "1.0"
         },
@@ -11916,9 +11916,9 @@
           "value" : 18,
           "capabilities" : [ "Kernel" ],
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'x size'" },
-            { "kind" : "LiteralInteger", "name" : "'y size'" },
-            { "kind" : "LiteralInteger", "name" : "'z size'" }
+            { "kind" : "LiteralInteger", "name" : "x size" },
+            { "kind" : "LiteralInteger", "name" : "y size" },
+            { "kind" : "LiteralInteger", "name" : "z size" }
           ],
           "version": "1.0"
         },
@@ -11969,7 +11969,7 @@
           "value" : 26,
           "capabilities" : [ "Geometry", "Tessellation", "MeshShadingNV", "MeshShadingEXT" ],
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'Vertex count'" }
+            { "kind" : "LiteralInteger", "name" : "Vertex count" }
           ],
           "version": "1.0"
         },
@@ -11996,7 +11996,7 @@
           "value" : 30,
           "capabilities" : [ "Kernel" ],
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'Vector type'" }
+            { "kind" : "LiteralInteger", "name" : "Vector type" }
           ],
           "version": "1.0"
         },
@@ -12023,7 +12023,7 @@
           "value" : 35,
           "capabilities" : [ "SubgroupDispatch" ],
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'Subgroup Size'" }
+            { "kind" : "LiteralInteger", "name" : "Subgroup Size" }
           ],
           "version" : "1.1"
         },
@@ -12032,7 +12032,7 @@
           "value" : 36,
           "capabilities" : [ "SubgroupDispatch" ],
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'Subgroups Per Workgroup'" }
+            { "kind" : "LiteralInteger", "name" : "Subgroups Per Workgroup" }
           ],
           "version" : "1.1"
         },
@@ -12041,7 +12041,7 @@
           "value" : 37,
           "capabilities" : [ "SubgroupDispatch" ],
           "parameters" : [
-            { "kind" : "IdRef", "name" : "'Subgroups Per Workgroup'" }
+            { "kind" : "IdRef", "name" : "Subgroups Per Workgroup" }
           ],
           "version" : "1.2"
         },
@@ -12049,9 +12049,9 @@
           "enumerant" : "LocalSizeId",
           "value" : 38,
           "parameters" : [
-            { "kind" : "IdRef", "name" : "'x size'" },
-            { "kind" : "IdRef", "name" : "'y size'" },
-            { "kind" : "IdRef", "name" : "'z size'" }
+            { "kind" : "IdRef", "name" : "x size" },
+            { "kind" : "IdRef", "name" : "y size" },
+            { "kind" : "IdRef", "name" : "z size" }
           ],
           "version" : "1.2"
         },
@@ -12060,9 +12060,9 @@
           "value" : 39,
           "capabilities" : [ "Kernel" ],
           "parameters" : [
-            { "kind" : "IdRef", "name" : "'x size hint'" },
-            { "kind" : "IdRef", "name" : "'y size hint'" },
-            { "kind" : "IdRef", "name" : "'z size hint'" }
+            { "kind" : "IdRef", "name" : "x size hint" },
+            { "kind" : "IdRef", "name" : "y size hint" },
+            { "kind" : "IdRef", "name" : "z size hint" }
           ],
           "version" : "1.2"
         },
@@ -12104,7 +12104,7 @@
           "capabilities" : [ "DenormPreserve" ],
           "extensions" : [ "SPV_KHR_float_controls" ],
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'Target Width'" }
+            { "kind" : "LiteralInteger", "name" : "Target Width" }
           ],
           "version" : "1.4"
         },
@@ -12114,7 +12114,7 @@
           "capabilities" : [ "DenormFlushToZero" ],
           "extensions" : [ "SPV_KHR_float_controls" ],
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'Target Width'" }
+            { "kind" : "LiteralInteger", "name" : "Target Width" }
           ],
           "version" : "1.4"
         },
@@ -12124,7 +12124,7 @@
           "capabilities" : [ "SignedZeroInfNanPreserve" ],
           "extensions" : [ "SPV_KHR_float_controls" ],
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'Target Width'" }
+            { "kind" : "LiteralInteger", "name" : "Target Width" }
           ],
           "version" : "1.4"
         },
@@ -12134,7 +12134,7 @@
           "capabilities" : [ "RoundingModeRTE" ],
           "extensions" : [ "SPV_KHR_float_controls" ],
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'Target Width'" }
+            { "kind" : "LiteralInteger", "name" : "Target Width" }
           ],
           "version" : "1.4"
         },
@@ -12144,7 +12144,7 @@
           "capabilities" : [ "RoundingModeRTZ" ],
           "extensions" : [ "SPV_KHR_float_controls" ],
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'Target Width'" }
+            { "kind" : "LiteralInteger", "name" : "Target Width" }
           ],
           "version" : "1.4"
         },
@@ -12158,9 +12158,9 @@
           "enumerant" : "TileShadingRateQCOM",
           "value" : 4490,
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'x rate'" },
-            { "kind" : "LiteralInteger", "name" : "'y rate'" },
-            { "kind" : "LiteralInteger", "name" : "'z rate'" }
+            { "kind" : "LiteralInteger", "name" : "x rate" },
+            { "kind" : "LiteralInteger", "name" : "y rate" },
+            { "kind" : "LiteralInteger", "name" : "z rate" }
           ],
           "capabilities" : [ "TileShadingQCOM" ],
           "version": "None"
@@ -12191,7 +12191,7 @@
           "value" : 5070,
           "capabilities" : [ "ShaderEnqueueAMDX" ],
           "parameters" : [
-            { "kind" : "IdRef", "name" : "'Is Entry'" }
+            { "kind" : "IdRef", "name" : "Is Entry" }
           ],
           "provisional" : true,
           "version" : "None"
@@ -12201,7 +12201,7 @@
           "value" : 5071,
           "capabilities" : [ "ShaderEnqueueAMDX" ],
           "parameters" : [
-            { "kind" : "IdRef", "name" : "'Number of recursions'" }
+            { "kind" : "IdRef", "name" : "Number of recursions" }
           ],
           "provisional" : true,
           "version" : "None"
@@ -12211,9 +12211,9 @@
           "value" : 5072,
           "capabilities" : [ "ShaderEnqueueAMDX" ],
           "parameters" : [
-            { "kind" : "IdRef", "name" : "'x size'" },
-            { "kind" : "IdRef", "name" : "'y size'" },
-            { "kind" : "IdRef", "name" : "'z size'" }
+            { "kind" : "IdRef", "name" : "x size" },
+            { "kind" : "IdRef", "name" : "y size" },
+            { "kind" : "IdRef", "name" : "z size" }
           ],
           "provisional" : true,
           "version" : "None"
@@ -12223,7 +12223,7 @@
           "value" : 5073,
           "capabilities" : [ "ShaderEnqueueAMDX" ],
           "parameters" : [
-            { "kind" : "IdRef", "name" : "'Shader Index'" }
+            { "kind" : "IdRef", "name" : "Shader Index" }
           ],
           "provisional" : true,
           "version" : "None"
@@ -12233,9 +12233,9 @@
           "value" : 5077,
           "capabilities" : [ "ShaderEnqueueAMDX" ],
           "parameters" : [
-            { "kind" : "IdRef", "name" : "'x size'" },
-            { "kind" : "IdRef", "name" : "'y size'" },
-            { "kind" : "IdRef", "name" : "'z size'" }
+            { "kind" : "IdRef", "name" : "x size" },
+            { "kind" : "IdRef", "name" : "y size" },
+            { "kind" : "IdRef", "name" : "z size" }
           ],
           "provisional" : true,
           "version" : "None"
@@ -12299,8 +12299,8 @@
           "value" : 5102,
           "capabilities" : [ "ShaderEnqueueAMDX" ],
           "parameters" : [
-            { "kind" : "IdRef", "name" : "'Node Name'" },
-            { "kind" : "IdRef", "name" : "'Shader Index'" }
+            { "kind" : "IdRef", "name" : "Node Name" },
+            { "kind" : "IdRef", "name" : "Shader Index" }
           ],
           "provisional" : true,
           "version" : "None"
@@ -12319,7 +12319,7 @@
           "value" : 5270,
           "capabilities" : [ "MeshShadingNV", "MeshShadingEXT" ],
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'Primitive count'" }
+            { "kind" : "LiteralInteger", "name" : "Primitive count" }
           ],
           "extensions" : [ "SPV_NV_mesh_shader", "SPV_EXT_mesh_shader" ],
           "version" : "None"
@@ -12394,7 +12394,7 @@
           "enumerant" : "SharedLocalMemorySizeINTEL",
           "value" : 5618,
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'Size'" }
+            { "kind" : "LiteralInteger", "name" : "Size" }
           ],
           "capabilities" : [ "VectorComputeINTEL" ],
           "version" : "None"
@@ -12403,7 +12403,7 @@
           "enumerant" : "RoundingModeRTPINTEL",
           "value" : 5620,
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'Target Width'" }
+            { "kind" : "LiteralInteger", "name" : "Target Width" }
           ],
           "capabilities" : [ "RoundToInfinityINTEL" ],
           "version" : "None"
@@ -12412,7 +12412,7 @@
           "enumerant" : "RoundingModeRTNINTEL",
           "value" : 5621,
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'Target Width'" }
+            { "kind" : "LiteralInteger", "name" : "Target Width" }
           ],
           "capabilities" : [ "RoundToInfinityINTEL" ],
           "version" : "None"
@@ -12421,7 +12421,7 @@
           "enumerant" : "FloatingPointModeALTINTEL",
           "value" : 5622,
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'Target Width'" }
+            { "kind" : "LiteralInteger", "name" : "Target Width" }
           ],
           "capabilities" : [ "RoundToInfinityINTEL" ],
           "version" : "None"
@@ -12430,7 +12430,7 @@
           "enumerant" : "FloatingPointModeIEEEINTEL",
           "value" : 5623,
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'Target Width'" }
+            { "kind" : "LiteralInteger", "name" : "Target Width" }
           ],
           "capabilities" : [ "RoundToInfinityINTEL" ],
           "version" : "None"
@@ -12439,9 +12439,9 @@
           "enumerant" : "MaxWorkgroupSizeINTEL",
           "value" : 5893,
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'max_x_size'" },
-            { "kind" : "LiteralInteger", "name" : "'max_y_size'" },
-            { "kind" : "LiteralInteger", "name" : "'max_z_size'" }
+            { "kind" : "LiteralInteger", "name" : "max_x_size" },
+            { "kind" : "LiteralInteger", "name" : "max_y_size" },
+            { "kind" : "LiteralInteger", "name" : "max_z_size" }
           ],
           "capabilities" : [ "KernelAttributesINTEL" ],
           "extensions" : [ "SPV_INTEL_kernel_attributes" ],
@@ -12451,7 +12451,7 @@
           "enumerant" : "MaxWorkDimINTEL",
           "value" : 5894,
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'max_dimensions'" }
+            { "kind" : "LiteralInteger", "name" : "max_dimensions" }
           ],
           "capabilities" : [ "KernelAttributesINTEL" ],
           "extensions" : [ "SPV_INTEL_kernel_attributes" ],
@@ -12468,7 +12468,7 @@
           "enumerant" : "NumSIMDWorkitemsINTEL",
           "value" : 5896,
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'vector_width'" }
+            { "kind" : "LiteralInteger", "name" : "vector_width" }
           ],
           "capabilities" : [ "FPGAKernelAttributesINTEL" ],
           "extensions" : [ "SPV_INTEL_kernel_attributes" ],
@@ -12478,7 +12478,7 @@
           "enumerant" : "SchedulerTargetFmaxMhzINTEL",
           "value" : 5903,
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'target_fmax'" }
+            { "kind" : "LiteralInteger", "name" : "target_fmax" }
           ],
           "capabilities" : [ "FPGAKernelAttributesINTEL" ],
           "version" : "None"
@@ -12489,22 +12489,22 @@
           "capabilities" : [ "Shader" ],
           "extensions" : [ "SPV_KHR_maximal_reconvergence" ],
           "version" : "None"
-	},
-	{
+        },
+        {
           "enumerant" : "FPFastMathDefault",
           "value" : 6028,
           "parameters" : [
-            { "kind" : "IdRef", "name" : "'Target Type'" },
-            { "kind" : "IdRef", "name" : "'Fast-Math Mode'" }
-	        ],
+            { "kind" : "IdRef", "name" : "Target Type" },
+            { "kind" : "IdRef", "name" : "Fast-Math Mode" }
+                ],
           "capabilities" : [ "FloatControls2" ],
           "version" : "None"
-	},
-	{
+        },
+        {
           "enumerant" : "StreamingInterfaceINTEL",
           "value" : 6154,
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'StallFreeReturn'" }
+            { "kind" : "LiteralInteger", "name" : "StallFreeReturn" }
           ],
           "capabilities" : [ "FPGAKernelAttributesINTEL" ],
           "version" : "None"
@@ -12513,7 +12513,7 @@
           "enumerant" : "RegisterMapInterfaceINTEL",
           "value" : 6160,
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'WaitForDoneWrite'" }
+            { "kind" : "LiteralInteger", "name" : "WaitForDoneWrite" }
           ],
           "capabilities" : [ "FPGAKernelAttributesv2INTEL" ],
           "version" : "None"
@@ -12522,7 +12522,7 @@
           "enumerant" : "NamedBarrierCountINTEL",
           "value" : 6417,
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'Barrier Count'" }
+            { "kind" : "LiteralInteger", "name" : "Barrier Count" }
           ],
           "capabilities" : [ "VectorComputeINTEL" ],
           "version" : "None"
@@ -12531,7 +12531,7 @@
           "enumerant" : "MaximumRegistersINTEL",
           "value" : 6461,
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'Number of Registers'" }
+            { "kind" : "LiteralInteger", "name" : "Number of Registers" }
           ],
           "capabilities" : [ "RegisterLimitsINTEL" ],
           "version" : "None"
@@ -12540,7 +12540,7 @@
           "enumerant" : "MaximumRegistersIdINTEL",
           "value" : 6462,
           "parameters" : [
-            { "kind" : "IdRef", "name" : "'Number of Registers'" }
+            { "kind" : "IdRef", "name" : "Number of Registers" }
           ],
           "capabilities" : [ "RegisterLimitsINTEL" ],
           "version" : "None"
@@ -12549,7 +12549,7 @@
           "enumerant" : "NamedMaximumRegistersINTEL",
           "value" : 6463,
           "parameters" : [
-            { "kind" : "NamedMaximumNumberOfRegisters", "name" : "'Named Maximum Number of Registers'" }
+            { "kind" : "NamedMaximumNumberOfRegisters", "name" : "Named Maximum Number of Registers" }
           ],
           "capabilities" : [ "RegisterLimitsINTEL" ],
           "version" : "None"
@@ -13649,7 +13649,7 @@
           "value" : 1,
           "capabilities" : [ "Shader", "Kernel" ],
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'Specialization Constant ID'" }
+            { "kind" : "LiteralInteger", "name" : "Specialization Constant ID" }
           ],
           "version": "1.0"
         },
@@ -13683,7 +13683,7 @@
           "value" : 6,
           "capabilities" : [ "Shader" ],
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'Array Stride'" }
+            { "kind" : "LiteralInteger", "name" : "Array Stride" }
           ],
           "version": "1.0"
         },
@@ -13692,7 +13692,7 @@
           "value" : 7,
           "capabilities" : [ "Matrix" ],
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'Matrix Stride'" }
+            { "kind" : "LiteralInteger", "name" : "Matrix Stride" }
           ],
           "version": "1.0"
         },
@@ -13805,7 +13805,7 @@
           "value" : 27,
           "capabilities" : [ "Shader", "UniformDecoration" ],
           "parameters" : [
-            { "kind" : "IdScope",           "name" : "'Execution'" }
+            { "kind" : "IdScope",           "name" : "Execution" }
           ],
           "version" : "1.4"
         },
@@ -13820,7 +13820,7 @@
           "value" : 29,
           "capabilities" : [ "GeometryStreams" ],
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'Stream Number'" }
+            { "kind" : "LiteralInteger", "name" : "Stream Number" }
           ],
           "version": "1.0"
         },
@@ -13829,7 +13829,7 @@
           "value" : 30,
           "capabilities" : [ "Shader" ],
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'Location'" }
+            { "kind" : "LiteralInteger", "name" : "Location" }
           ],
           "version": "1.0"
         },
@@ -13838,7 +13838,7 @@
           "value" : 31,
           "capabilities" : [ "Shader" ],
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'Component'" }
+            { "kind" : "LiteralInteger", "name" : "Component" }
           ],
           "version": "1.0"
         },
@@ -13847,7 +13847,7 @@
           "value" : 32,
           "capabilities" : [ "Shader" ],
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'Index'" }
+            { "kind" : "LiteralInteger", "name" : "Index" }
           ],
           "version": "1.0"
         },
@@ -13856,7 +13856,7 @@
           "value" : 33,
           "capabilities" : [ "Shader" ],
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'Binding Point'" }
+            { "kind" : "LiteralInteger", "name" : "Binding Point" }
           ],
           "version": "1.0"
         },
@@ -13865,7 +13865,7 @@
           "value" : 34,
           "capabilities" : [ "Shader" ],
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'Descriptor Set'" }
+            { "kind" : "LiteralInteger", "name" : "Descriptor Set" }
           ],
           "version": "1.0"
         },
@@ -13874,7 +13874,7 @@
           "value" : 35,
           "capabilities" : [ "Shader" ],
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'Byte Offset'" }
+            { "kind" : "LiteralInteger", "name" : "Byte Offset" }
           ],
           "version": "1.0"
         },
@@ -13883,7 +13883,7 @@
           "value" : 36,
           "capabilities" : [ "TransformFeedback" ],
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'XFB Buffer Number'" }
+            { "kind" : "LiteralInteger", "name" : "XFB Buffer Number" }
           ],
           "version": "1.0"
         },
@@ -13892,7 +13892,7 @@
           "value" : 37,
           "capabilities" : [ "TransformFeedback" ],
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'XFB Stride'" }
+            { "kind" : "LiteralInteger", "name" : "XFB Stride" }
           ],
           "version": "1.0"
         },
@@ -13901,7 +13901,7 @@
           "value" : 38,
           "capabilities" : [ "Kernel" ],
           "parameters" : [
-            { "kind" : "FunctionParameterAttribute", "name" : "'Function Parameter Attribute'" }
+            { "kind" : "FunctionParameterAttribute", "name" : "Function Parameter Attribute" }
           ],
           "version": "1.0"
         },
@@ -13909,7 +13909,7 @@
           "enumerant" : "FPRoundingMode",
           "value" : 39,
           "parameters" : [
-            { "kind" : "FPRoundingMode", "name" : "'Floating-Point Rounding Mode'" }
+            { "kind" : "FPRoundingMode", "name" : "Floating-Point Rounding Mode" }
           ],
           "version": "1.0"
         },
@@ -13918,7 +13918,7 @@
           "value" : 40,
           "capabilities" : [ "Kernel", "FloatControls2" ],
           "parameters" : [
-            { "kind" : "FPFastMathMode", "name" : "'Fast-Math Mode'" }
+            { "kind" : "FPFastMathMode", "name" : "Fast-Math Mode" }
           ],
           "version": "1.0"
         },
@@ -13927,8 +13927,8 @@
           "value" : 41,
           "capabilities" : [ "Linkage" ],
           "parameters" : [
-            { "kind" : "LiteralString", "name" : "'Name'" },
-            { "kind" : "LinkageType",   "name" : "'Linkage Type'" }
+            { "kind" : "LiteralString", "name" : "Name" },
+            { "kind" : "LinkageType",   "name" : "Linkage Type" }
           ],
           "version": "1.0"
         },
@@ -13943,7 +13943,7 @@
           "value" : 43,
           "capabilities" : [ "InputAttachment" ],
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'Attachment Index'" }
+            { "kind" : "LiteralInteger", "name" : "Attachment Index" }
           ],
           "version": "1.0"
         },
@@ -13952,7 +13952,7 @@
           "value" : 44,
           "capabilities" : [ "Kernel" ],
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'Alignment'" }
+            { "kind" : "LiteralInteger", "name" : "Alignment" }
           ],
           "version": "1.0"
         },
@@ -13961,7 +13961,7 @@
           "value" : 45,
           "capabilities" : [ "Addresses" ],
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'Max Byte Offset'" }
+            { "kind" : "LiteralInteger", "name" : "Max Byte Offset" }
           ],
           "version" : "1.1"
         },
@@ -13970,7 +13970,7 @@
           "value" : 46,
           "capabilities" : [ "Kernel" ],
           "parameters" : [
-            { "kind" : "IdRef", "name" : "'Alignment'" }
+            { "kind" : "IdRef", "name" : "Alignment" }
           ],
           "version" : "1.2"
         },
@@ -13979,7 +13979,7 @@
           "value" : 47,
           "capabilities" : [ "Addresses" ],
           "parameters" : [
-            { "kind" : "IdRef", "name" : "'Max Byte Offset'" }
+            { "kind" : "IdRef", "name" : "Max Byte Offset" }
           ],
           "version" : "1.2"
         },
@@ -14024,7 +14024,7 @@
           "value" : 5019,
           "capabilities" : [ "ShaderEnqueueAMDX" ],
           "parameters" : [
-            { "kind" : "IdRef", "name" : "'Payload Type'" }
+            { "kind" : "IdRef", "name" : "Payload Type" }
           ],
           "provisional" : true,
           "version" : "None"
@@ -14034,7 +14034,7 @@
           "value" : 5020,
           "capabilities" : [ "ShaderEnqueueAMDX" ],
           "parameters" : [
-            { "kind" : "IdRef", "name" : "'Max number of payloads'" }
+            { "kind" : "IdRef", "name" : "Max number of payloads" }
           ],
           "provisional" : true,
           "version" : "None"
@@ -14051,7 +14051,7 @@
           "value" : 5091,
           "capabilities" : [ "ShaderEnqueueAMDX" ],
           "parameters" : [
-            { "kind" : "IdRef", "name" : "'Node Name'" }
+            { "kind" : "IdRef", "name" : "Node Name" }
           ],
           "provisional" : true,
           "version" : "None"
@@ -14061,7 +14061,7 @@
           "value" : 5098,
           "capabilities" : [ "ShaderEnqueueAMDX" ],
           "parameters" : [
-            { "kind" : "IdRef", "name" : "'Base Index'" }
+            { "kind" : "IdRef", "name" : "Base Index" }
           ],
           "provisional" : true,
           "version" : "None"
@@ -14078,7 +14078,7 @@
           "value" : 5100,
           "capabilities" : [ "ShaderEnqueueAMDX" ],
           "parameters" : [
-            { "kind" : "IdRef", "name" : "'Array Size'" }
+            { "kind" : "IdRef", "name" : "Array Size" }
           ],
           "provisional" : true,
           "version" : "None"
@@ -14117,7 +14117,7 @@
           "extensions" : [ "SPV_NV_stereo_view_rendering" ],
           "version" : "None",
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'Offset'" }
+            { "kind" : "LiteralInteger", "name" : "Offset" }
           ]
         },
         {
@@ -14208,7 +14208,7 @@
           "enumerant" : "SIMTCallINTEL",
           "value" : 5599,
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'N'" }
+            { "kind" : "LiteralInteger", "name" : "N" }
           ],
           "capabilities" : [ "VectorComputeINTEL" ],
           "version" : "None"
@@ -14224,7 +14224,7 @@
           "enumerant" : "ClobberINTEL",
           "value" : 5607,
           "parameters" : [
-            { "kind" : "LiteralString", "name" : "'Register'" }
+            { "kind" : "LiteralString", "name" : "Register" }
           ],
           "capabilities" : [ "AsmINTEL" ],
           "version" : "None"
@@ -14245,7 +14245,7 @@
           "enumerant" : "FuncParamIOKindINTEL",
           "value" : 5625,
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'Kind'" }
+            { "kind" : "LiteralInteger", "name" : "Kind" }
           ],
           "capabilities" : [ "VectorComputeINTEL" ],
           "version" : "None"
@@ -14266,7 +14266,7 @@
           "enumerant" : "GlobalVariableOffsetINTEL",
           "value" : 5628,
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'Offset'" }
+            { "kind" : "LiteralInteger", "name" : "Offset" }
           ],
           "capabilities" : [ "VectorComputeINTEL" ],
           "version" : "None"
@@ -14276,7 +14276,7 @@
           "aliases" : ["HlslCounterBufferGOOGLE"],
           "value" : 5634,
           "parameters" : [
-            { "kind" : "IdRef", "name" : "'Counter Buffer'" }
+            { "kind" : "IdRef", "name" : "Counter Buffer" }
           ],
           "extensions" : [ "SPV_GOOGLE_hlsl_functionality1" ],
           "version" : "1.4"
@@ -14286,7 +14286,7 @@
           "aliases" : ["HlslSemanticGOOGLE"],
           "value" : 5635,
           "parameters" : [
-            { "kind" : "LiteralString", "name" : "'Semantic'" }
+            { "kind" : "LiteralString", "name" : "Semantic" }
           ],
           "extensions" : [ "SPV_GOOGLE_hlsl_functionality1" ],
           "version" : "1.4"
@@ -14295,7 +14295,7 @@
           "enumerant" : "UserTypeGOOGLE",
           "value" : 5636,
           "parameters" : [
-            { "kind" : "LiteralString", "name" : "'User Type'" }
+            { "kind" : "LiteralString", "name" : "User Type" }
           ],
           "extensions" : [ "SPV_GOOGLE_user_type" ],
           "version" : "None"
@@ -14304,8 +14304,8 @@
           "enumerant" : "FunctionRoundingModeINTEL",
           "value" : 5822,
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'Target Width'" },
-            { "kind" : "FPRoundingMode", "name" : "'FP Rounding Mode'" }
+            { "kind" : "LiteralInteger", "name" : "Target Width" },
+            { "kind" : "FPRoundingMode", "name" : "FP Rounding Mode" }
           ],
           "capabilities" : [ "FunctionFloatControlINTEL" ],
           "version" : "None"
@@ -14314,8 +14314,8 @@
           "enumerant" : "FunctionDenormModeINTEL",
           "value" : 5823,
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'Target Width'" },
-            { "kind" : "FPDenormMode", "name" : "'FP Denorm Mode'" }
+            { "kind" : "LiteralInteger", "name" : "Target Width" },
+            { "kind" : "FPDenormMode", "name" : "FP Denorm Mode" }
           ],
           "capabilities" : [ "FunctionFloatControlINTEL" ],
           "version" : "None"
@@ -14331,7 +14331,7 @@
           "enumerant" : "MemoryINTEL",
           "value" : 5826,
           "parameters" : [
-            { "kind" : "LiteralString", "name" : "'Memory Type'" }
+            { "kind" : "LiteralString", "name" : "Memory Type" }
           ],
           "capabilities" : [ "FPGAMemoryAttributesINTEL" ],
           "extensions" : [ "SPV_INTEL_fpga_memory_attributes" ],
@@ -14341,7 +14341,7 @@
           "enumerant" : "NumbanksINTEL",
           "value" : 5827,
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'Banks'" }
+            { "kind" : "LiteralInteger", "name" : "Banks" }
           ],
           "capabilities" : [ "FPGAMemoryAttributesINTEL" ],
           "extensions" : [ "SPV_INTEL_fpga_memory_attributes" ],
@@ -14351,7 +14351,7 @@
           "enumerant" : "BankwidthINTEL",
           "value" : 5828,
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'Bank Width'" }
+            { "kind" : "LiteralInteger", "name" : "Bank Width" }
           ],
           "capabilities" : [ "FPGAMemoryAttributesINTEL" ],
           "extensions" : [ "SPV_INTEL_fpga_memory_attributes" ],
@@ -14361,7 +14361,7 @@
           "enumerant" : "MaxPrivateCopiesINTEL",
           "value" : 5829,
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'Maximum Copies'" }
+            { "kind" : "LiteralInteger", "name" : "Maximum Copies" }
           ],
           "capabilities" : [ "FPGAMemoryAttributesINTEL" ],
           "extensions" : [ "SPV_INTEL_fpga_memory_attributes" ],
@@ -14385,7 +14385,7 @@
           "enumerant" : "MaxReplicatesINTEL",
           "value" : 5832,
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'Maximum Replicates'" }
+            { "kind" : "LiteralInteger", "name" : "Maximum Replicates" }
           ],
           "capabilities" : [ "FPGAMemoryAttributesINTEL" ],
           "extensions" : [ "SPV_INTEL_fpga_memory_attributes" ],
@@ -14402,8 +14402,8 @@
           "enumerant" : "MergeINTEL",
           "value" : 5834,
           "parameters" : [
-            { "kind" : "LiteralString", "name" : "'Merge Key'" },
-            { "kind" : "LiteralString", "name" : "'Merge Type'" }
+            { "kind" : "LiteralString", "name" : "Merge Key" },
+            { "kind" : "LiteralString", "name" : "Merge Type" }
           ],
           "capabilities" : [ "FPGAMemoryAttributesINTEL" ],
           "extensions" : [ "SPV_INTEL_fpga_memory_attributes" ],
@@ -14413,7 +14413,7 @@
           "enumerant" : "BankBitsINTEL",
           "value" : 5835,
           "parameters" : [
-            { "kind" : "LiteralInteger", "quantifier" : "*", "name" : "'Bank Bits'" }
+            { "kind" : "LiteralInteger", "quantifier" : "*", "name" : "Bank Bits" }
           ],
           "capabilities" : [ "FPGAMemoryAttributesINTEL" ],
           "extensions" : [ "SPV_INTEL_fpga_memory_attributes" ],
@@ -14423,7 +14423,7 @@
           "enumerant" : "ForcePow2DepthINTEL",
           "value" : 5836,
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'Force Key'" }
+            { "kind" : "LiteralInteger", "name" : "Force Key" }
           ],
           "capabilities" : [ "FPGAMemoryAttributesINTEL" ],
           "extensions" : [ "SPV_INTEL_fpga_memory_attributes" ],
@@ -14433,7 +14433,7 @@
           "enumerant" : "StridesizeINTEL",
           "value" : 5883,
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'Stride Size'" }
+            { "kind" : "LiteralInteger", "name" : "Stride Size" }
           ],
           "capabilities" : [ "FPGAMemoryAttributesINTEL" ],
           "version" : "None"
@@ -14442,7 +14442,7 @@
           "enumerant" : "WordsizeINTEL",
           "value" : 5884,
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'Word Size'" }
+            { "kind" : "LiteralInteger", "name" : "Word Size" }
           ],
           "capabilities" : [ "FPGAMemoryAttributesINTEL" ],
           "version" : "None"
@@ -14463,7 +14463,7 @@
           "enumerant" : "CacheSizeINTEL",
           "value" : 5900,
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'Cache Size in bytes'" }
+            { "kind" : "LiteralInteger", "name" : "Cache Size in bytes" }
           ],
           "capabilities" : [ "FPGAMemoryAccessesINTEL" ],
           "version" : "None"
@@ -14478,7 +14478,7 @@
           "enumerant" : "PrefetchINTEL",
           "value" : 5902,
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'Prefetcher Size in bytes'" }
+            { "kind" : "LiteralInteger", "name" : "Prefetcher Size in bytes" }
           ],
           "capabilities" : [ "FPGAMemoryAccessesINTEL" ],
           "version" : "None"
@@ -14499,8 +14499,8 @@
           "enumerant" : "MathOpDSPModeINTEL",
           "value" : 5909,
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'Mode'" },
-            { "kind" : "LiteralInteger", "name" : "'Propagate'" }
+            { "kind" : "LiteralInteger", "name" : "Mode" },
+            { "kind" : "LiteralInteger", "name" : "Propagate" }
           ],
           "capabilities" : [ "FPGADSPControlINTEL" ],
           "version" : "None"
@@ -14509,7 +14509,7 @@
           "enumerant" : "AliasScopeINTEL",
           "value" : 5914,
           "parameters" : [
-            { "kind" : "IdRef", "name" : "'Aliasing Scopes List'" }
+            { "kind" : "IdRef", "name" : "Aliasing Scopes List" }
           ],
           "capabilities" : [ "MemoryAccessAliasingINTEL" ],
           "version" : "None"
@@ -14518,7 +14518,7 @@
           "enumerant" : "NoAliasINTEL",
           "value" : 5915,
           "parameters" : [
-            { "kind" : "IdRef", "name" : "'Aliasing Scopes List'" }
+            { "kind" : "IdRef", "name" : "Aliasing Scopes List" }
           ],
           "capabilities" : [ "MemoryAccessAliasingINTEL" ],
           "version" : "None"
@@ -14527,7 +14527,7 @@
           "enumerant" : "InitiationIntervalINTEL",
           "value" : 5917,
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'Cycles'" }
+            { "kind" : "LiteralInteger", "name" : "Cycles" }
           ],
           "capabilities" : [ "FPGAInvocationPipeliningAttributesINTEL" ],
           "version" : "None"
@@ -14536,7 +14536,7 @@
           "enumerant" : "MaxConcurrencyINTEL",
           "value" : 5918,
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'Invocations'" }
+            { "kind" : "LiteralInteger", "name" : "Invocations" }
           ],
           "capabilities" : [ "FPGAInvocationPipeliningAttributesINTEL" ],
           "version" : "None"
@@ -14545,7 +14545,7 @@
           "enumerant" : "PipelineEnableINTEL",
           "value" : 5919,
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'Enable'" }
+            { "kind" : "LiteralInteger", "name" : "Enable" }
           ],
           "capabilities" : [ "FPGAInvocationPipeliningAttributesINTEL" ],
           "version" : "None"
@@ -14554,7 +14554,7 @@
           "enumerant" : "BufferLocationINTEL",
           "value" : 5921,
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'Buffer Location ID'" }
+            { "kind" : "LiteralInteger", "name" : "Buffer Location ID" }
           ],
           "capabilities" : [ "FPGABufferLocationINTEL" ],
           "version" : "None"
@@ -14563,7 +14563,7 @@
           "enumerant" : "IOPipeStorageINTEL",
           "value" : 5944,
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'IO Pipe ID'" }
+            { "kind" : "LiteralInteger", "name" : "IO Pipe ID" }
           ],
           "capabilities" : [ "IOPipesINTEL" ],
           "version" : "None"
@@ -14572,8 +14572,8 @@
           "enumerant" : "FunctionFloatingPointModeINTEL",
           "value" : 6080,
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'Target Width'" },
-            { "kind" : "FPOperationMode", "name" : "'FP Operation Mode'" }
+            { "kind" : "LiteralInteger", "name" : "Target Width" },
+            { "kind" : "FPOperationMode", "name" : "FP Operation Mode" }
           ],
           "capabilities" : [ "FunctionFloatControlINTEL" ],
           "version" : "None"
@@ -14606,7 +14606,7 @@
           "enumerant" : "FPMaxErrorDecorationINTEL",
           "value" : 6170,
           "parameters" : [
-            { "kind" : "LiteralFloat", "name" : "'Max Error'" }
+            { "kind" : "LiteralFloat", "name" : "Max Error" }
           ],
           "capabilities" : [ "FPMaxErrorINTEL" ],
           "version" : "None"
@@ -14615,7 +14615,7 @@
           "enumerant" : "LatencyControlLabelINTEL",
           "value" : 6172,
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'Latency Label'" }
+            { "kind" : "LiteralInteger", "name" : "Latency Label" }
           ],
           "capabilities" : [ "FPGALatencyControlINTEL" ],
           "version" : "None"
@@ -14624,9 +14624,9 @@
           "enumerant" : "LatencyControlConstraintINTEL",
           "value" : 6173,
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'Relative To'" },
-            { "kind" : "LiteralInteger", "name" : "'Control Type'" },
-            { "kind" : "LiteralInteger", "name" : "'Relative Cycle'" }
+            { "kind" : "LiteralInteger", "name" : "Relative To" },
+            { "kind" : "LiteralInteger", "name" : "Control Type" },
+            { "kind" : "LiteralInteger", "name" : "Relative Cycle" }
           ],
           "capabilities" : [ "FPGALatencyControlINTEL" ],
           "version" : "None"
@@ -14648,7 +14648,7 @@
           "value" : 6177,
           "capabilities" : [ "FPGAArgumentInterfacesINTEL" ],
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'AddressWidth'" }
+            { "kind" : "LiteralInteger", "name" : "AddressWidth" }
           ],
           "version" : "None"
         },
@@ -14657,7 +14657,7 @@
           "value" : 6178,
           "capabilities" : [ "FPGAArgumentInterfacesINTEL" ],
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'DataWidth'" }
+            { "kind" : "LiteralInteger", "name" : "DataWidth" }
           ],
           "version" : "None"
         },
@@ -14666,7 +14666,7 @@
           "value" : 6179,
           "capabilities" : [ "FPGAArgumentInterfacesINTEL" ],
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'Latency'" }
+            { "kind" : "LiteralInteger", "name" : "Latency" }
           ],
           "version" : "None"
         },
@@ -14675,7 +14675,7 @@
           "value" : 6180,
           "capabilities" : [ "FPGAArgumentInterfacesINTEL" ],
           "parameters" : [
-            { "kind" : "AccessQualifier", "name" : "'ReadWriteMode'" }
+            { "kind" : "AccessQualifier", "name" : "ReadWriteMode" }
           ],
           "version" : "None"
         },
@@ -14684,7 +14684,7 @@
           "value" : 6181,
           "capabilities" : [ "FPGAArgumentInterfacesINTEL" ],
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'MaxBurstCount'" }
+            { "kind" : "LiteralInteger", "name" : "MaxBurstCount" }
           ],
           "version" : "None"
         },
@@ -14693,7 +14693,7 @@
           "value" : 6182,
           "capabilities" : [ "FPGAArgumentInterfacesINTEL" ],
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'Waitrequest'" }
+            { "kind" : "LiteralInteger", "name" : "Waitrequest" }
           ],
           "version" : "None"
         },
@@ -14707,8 +14707,8 @@
           "enumerant" : "HostAccessINTEL",
           "value" : 6188,
           "parameters": [
-            { "kind" : "HostAccessQualifier", "name" : "'Access'" },
-            { "kind" : "LiteralString", "name" : "'Name'" }
+            { "kind" : "HostAccessQualifier", "name" : "Access" },
+            { "kind" : "LiteralString", "name" : "Name" }
           ],
           "capabilities" : [ "GlobalVariableHostAccessINTEL" ],
           "version" : "None"
@@ -14717,7 +14717,7 @@
           "enumerant" : "InitModeINTEL",
           "value" : 6190,
           "parameters": [
-            { "kind" : "InitializationModeQualifier", "name" : "'Trigger'" }
+            { "kind" : "InitializationModeQualifier", "name" : "Trigger" }
           ],
           "capabilities" : [ "GlobalVariableFPGADecorationsINTEL" ],
           "version" : "None"
@@ -14736,8 +14736,8 @@
           "value" : 6442,
           "capabilities" : [ "CacheControlsINTEL" ],
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'Cache Level'" },
-            { "kind" : "LoadCacheControl", "name" : "'Cache Control'" }
+            { "kind" : "LiteralInteger", "name" : "Cache Level" },
+            { "kind" : "LoadCacheControl", "name" : "Cache Control" }
           ],
           "version" : "None"
         },
@@ -14746,8 +14746,8 @@
           "value" : 6443,
           "capabilities" : [ "CacheControlsINTEL" ],
           "parameters" : [
-            { "kind" : "LiteralInteger", "name" : "'Cache Level'" },
-            { "kind" : "StoreCacheControl", "name" : "'Cache Control'" }
+            { "kind" : "LiteralInteger", "name" : "Cache Level" },
+            { "kind" : "StoreCacheControl", "name" : "Cache Control" }
           ],
           "version" : "None"
         }

--- a/tools/buildHeaders/jsonToSpirv.h
+++ b/tools/buildHeaders/jsonToSpirv.h
@@ -147,6 +147,7 @@ public:
     void setOptional();
     OperandClass getClass(int op) const { return opClass[op]; }
     const char* getDesc(int op) const { return desc[op].c_str(); }
+    void setDesc(int op, const std::string& d) { desc[op] = d; }
     bool isOptional(int op) const { return optional[op]; }
     int getNum() const { return (int)opClass.size(); }
 


### PR DESCRIPTION
This is part of ongoing work to integrate the SPIR-V specs into the Vulkan Antora docs site build. While the internal spec tree builds from an internal (slightly laggy) mirror of this repo, @Naghasan recommended I submit the PR here instead. We might want to add a CI check for the old-style markup for a while, since that will be easy to overlook especially in currently open PRs. I can propose that here or separately (would not amount to more than grepping for

```
"'.*'"
```

in include/spirv/unified1/*.json, and failing the CI check if matched.

As far as I can tell, this makes no difference at all to the outputs when generating spec HTML from the default branch of the internal spec tree (as it should not).
