### PR TITLE
updates AtomicStorageOps to depend on the AtomicStorage capability

### DIFF
--- a/include/spirv/unified1/spirv.core.grammar.json
+++ b/include/spirv/unified1/spirv.core.grammar.json
@@ -15712,6 +15712,7 @@
         {
           "enumerant" : "AtomicStorageOps",
           "value" : 4445,
+          "capabilities" : [ "AtomicStorage" ],
           "extensions" : [ "SPV_KHR_shader_atomic_counter_ops" ],
           "version" : "None"
         },


### PR DESCRIPTION
fixes #473 

Updates AtomicStorageOps to depend on / implicitly declare the AtomicStorage capability, fixing an inconsistency between the [spec](https://github.com/KhronosGroup/SPIRV-Registry/blob/main/extensions/KHR/SPV_KHR_shader_atomic_counter_ops.asciidoc#modifications-to-the-spir-v-specification-version-11) and the SPIR-V grammar.