### PR TITLE
updates IntegerFunctions2INTEL to remove Shader capability dependency

### DIFF
--- a/include/spirv/unified1/spirv.core.grammar.json
+++ b/include/spirv/unified1/spirv.core.grammar.json
@@ -16315,7 +16315,6 @@
         {
           "enumerant" : "IntegerFunctions2INTEL",
           "value" : 5584,
-          "capabilities" : [ "Shader" ],
           "extensions" : [ "SPV_INTEL_shader_integer_functions2" ],
           "version" : "None"
         },


### PR DESCRIPTION
fixes #480 

Updates the IntegerFunctions2INTEL capability to remove the Shader capability dependency, because no dependency is described in the SPV_INTEL_shader_integer_functions2 [spec](https://github.khronos.org/SPIRV-Registry/extensions/INTEL/SPV_INTEL_shader_integer_functions2.html).