### PR TITLE
remove extraneous operand from arbitrary precision fixed point instructions

### DIFF
--- a/include/spirv/unified1/spirv.core.grammar.json
+++ b/include/spirv/unified1/spirv.core.grammar.json
@@ -9759,7 +9759,6 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Input Type'" },
         { "kind" : "IdRef", "name" : "'Input'" },
         { "kind" : "LiteralInteger", "name" : "'S'" },
         { "kind" : "LiteralInteger", "name" : "'I'" },
@@ -9777,7 +9776,6 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Input Type'" },
         { "kind" : "IdRef", "name" : "'Input'" },
         { "kind" : "LiteralInteger", "name" : "'S'" },
         { "kind" : "LiteralInteger", "name" : "'I'" },
@@ -9795,7 +9793,6 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Input Type'" },
         { "kind" : "IdRef", "name" : "'Input'" },
         { "kind" : "LiteralInteger", "name" : "'S'" },
         { "kind" : "LiteralInteger", "name" : "'I'" },
@@ -9813,7 +9810,6 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Input Type'" },
         { "kind" : "IdRef", "name" : "'Input'" },
         { "kind" : "LiteralInteger", "name" : "'S'" },
         { "kind" : "LiteralInteger", "name" : "'I'" },
@@ -9831,7 +9827,6 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Input Type'" },
         { "kind" : "IdRef", "name" : "'Input'" },
         { "kind" : "LiteralInteger", "name" : "'S'" },
         { "kind" : "LiteralInteger", "name" : "'I'" },
@@ -9849,7 +9844,6 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Input Type'" },
         { "kind" : "IdRef", "name" : "'Input'" },
         { "kind" : "LiteralInteger", "name" : "'S'" },
         { "kind" : "LiteralInteger", "name" : "'I'" },
@@ -9867,7 +9861,6 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Input Type'" },
         { "kind" : "IdRef", "name" : "'Input'" },
         { "kind" : "LiteralInteger", "name" : "'S'" },
         { "kind" : "LiteralInteger", "name" : "'I'" },
@@ -9885,7 +9878,6 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Input Type'" },
         { "kind" : "IdRef", "name" : "'Input'" },
         { "kind" : "LiteralInteger", "name" : "'S'" },
         { "kind" : "LiteralInteger", "name" : "'I'" },
@@ -9903,7 +9895,6 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Input Type'" },
         { "kind" : "IdRef", "name" : "'Input'" },
         { "kind" : "LiteralInteger", "name" : "'S'" },
         { "kind" : "LiteralInteger", "name" : "'I'" },
@@ -9921,7 +9912,6 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Input Type'" },
         { "kind" : "IdRef", "name" : "'Input'" },
         { "kind" : "LiteralInteger", "name" : "'S'" },
         { "kind" : "LiteralInteger", "name" : "'I'" },
@@ -9939,7 +9929,6 @@
       "operands" : [
         { "kind" : "IdResultType" },
         { "kind" : "IdResult" },
-        { "kind" : "IdRef", "name" : "'Input Type'" },
         { "kind" : "IdRef", "name" : "'Input'" },
         { "kind" : "LiteralInteger", "name" : "'S'" },
         { "kind" : "LiteralInteger", "name" : "'I'" },


### PR DESCRIPTION
fixes #489 

Looks like the grammar file was based on an early version of the spec, which included an "input type" operand, which was not included in the final spec.