### PR TITLE
ClspvReflection non-sematic: Add WorkgroupVariableSize

### DIFF
--- a/include/spirv/unified1/NonSemanticClspvReflection.h
+++ b/include/spirv/unified1/NonSemanticClspvReflection.h
@@ -33,7 +33,7 @@ extern "C" {
 #endif
 
 enum {
-    NonSemanticClspvReflectionRevision = 6,
+    NonSemanticClspvReflectionRevision = 7,
     NonSemanticClspvReflectionRevision_BitWidthPadding = 0x7fffffff
 };
 
@@ -79,6 +79,7 @@ enum NonSemanticClspvReflectionInstructions {
     NonSemanticClspvReflectionPrintfBufferStorageBuffer = 39,
     NonSemanticClspvReflectionPrintfBufferPointerPushConstant = 40,
     NonSemanticClspvReflectionNormalizedSamplerMaskPushConstant = 41,
+    NonSemanticClspvReflectionWorkgroupVariableSize = 42,
     NonSemanticClspvReflectionInstructionsMax = 0x7fffffff
 };
 

--- a/include/spirv/unified1/extinst.nonsemantic.clspvreflection.grammar.json
+++ b/include/spirv/unified1/extinst.nonsemantic.clspvreflection.grammar.json
@@ -1,5 +1,5 @@
 {
-  "revision" : 6,
+  "revision" : 7,
   "instructions" : [
     {
       "opname" : "Kernel",
@@ -403,6 +403,14 @@
       { "kind" : "IdRef", "name" : "Kernel" },
       { "kind" : "IdRef", "name" : "Ordinal" },
       { "kind" : "IdRef", "name" : "Offset" },
+      { "kind" : "IdRef", "name" : "Size" }
+      ]
+    },
+    {
+    "opname" : "WorkgroupVariableSize",
+    "opcode" : 42,
+    "operands" : [
+      { "kind" : "IdRef", "name" : "Variable" },
       { "kind" : "IdRef", "name" : "Size" }
       ]
     }


### PR DESCRIPTION
This is needed to be able to report the local memory size required by a kernel.