### PR TITLE
bump the required CMake version to 3.14

### DIFF
--- a/tests/find_package/CMakeLists.txt
+++ b/tests/find_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.14)
 
 project(TEST_FIND_PACKAGE LANGUAGES CXX)
 

--- a/tools/buildHeaders/CMakeLists.txt
+++ b/tools/buildHeaders/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.14)
 
 set(CMAKE_INSTALL_PREFIX "install" CACHE STRING "prefix" FORCE)
 


### PR DESCRIPTION
Several projects in this repo still required a minimum CMake version of 3.0, but this is no longer supported by CMake 4.0.  Update these minimum CMake versions to 3.14 to align with the rest of the repo.

This is needed for the latest CI pipelines.