### PR TITLE
Add DisplacementMicromapNV to the capabilities enabling OpTypeAcceler…

### DIFF
--- a/include/spirv/unified1/spirv.core.grammar.json
+++ b/include/spirv/unified1/spirv.core.grammar.json
@@ -6300,8 +6300,8 @@
       "operands" : [
         { "kind" : "IdResult" }
       ],
-      "capabilities" : [ "RayTracingNV" , "RayTracingKHR", "RayQueryKHR" ],
-      "extensions" : [ "SPV_NV_ray_tracing" , "SPV_KHR_ray_tracing", "SPV_KHR_ray_query" ],
+      "capabilities" : [ "RayTracingNV" , "RayTracingKHR", "RayQueryKHR", "DisplacementMicromapNV" ],
+      "extensions" : [ "SPV_NV_ray_tracing" , "SPV_KHR_ray_tracing", "SPV_KHR_ray_query", "SPV_NV_displacement_micromap" ],
       "version" : "None"
     },
     {


### PR DESCRIPTION
…ationStructureKHR

Spirv modules declaring this capability should be able to use acceleration structures without validation errors.
Spec here: https://github.khronos.org/SPIRV-Registry/extensions/NV/SPV_NV_displacement_micromap.html