### PR TITLE
Add Bazel bzlmod support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 build
 out
 .DS_Store
+bazel-*
+MODULE.bazel.lock

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(
     default_visibility = ["//visibility:public"],
 )
@@ -175,4 +177,3 @@ cc_library(
     includes = ["include"],
     deps = [":spirv_common_headers"],
 )
-

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,8 @@
+"""SPIRV-Headers"""
+
+module(
+    name = "spirv_headers",
+    version = "0.0.0",
+)
+
+bazel_dep(name = "rules_cc", version = "0.1.1")


### PR DESCRIPTION
This change adds Bazel bzlmod support so this repository can be added to the [Bazel Central Registry](https://registry.bazel.build/)