### PR TITLE
Add definitions for TOSA.001000.1 extended instruction set

### DIFF
--- a/include/spirv/unified1/TOSA.001000.1.h
+++ b/include/spirv/unified1/TOSA.001000.1.h
@@ -1,0 +1,94 @@
+// (c) 2022-2025 Arm Ltd.
+
+#ifndef SPIRV_UNIFIED1_TOSA_001000_1_H_
+#define SPIRV_UNIFIED1_TOSA_001000_1_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum {
+    TOSAVersion = 1000000,
+    TOSAVersion_BitWidthPadding = 0x7fffffff
+};
+enum {
+    TOSARevision = 1,
+    TOSARevision_BitWidthPadding = 0x7fffffff
+};
+
+enum TOSAInstructions {
+    TOSAARGMAX = 0,
+    TOSAAVG_POOL2D = 1,
+    TOSACONV2D = 2,
+    TOSACONV3D = 3,
+    TOSADEPTHWISE_CONV2D = 4,
+    TOSAFFT2D = 5,
+    TOSAMATMUL = 6,
+    TOSAMAX_POOL2D = 7,
+    TOSARFFT2D = 8,
+    TOSATRANSPOSE_CONV2D = 9,
+    TOSACLAMP = 10,
+    TOSAERF = 11,
+    TOSASIGMOID = 12,
+    TOSATANH = 13,
+    TOSAADD = 14,
+    TOSAARITHMETIC_RIGHT_SHIFT = 15,
+    TOSABITWISE_AND = 16,
+    TOSABITWISE_OR = 17,
+    TOSABITWISE_XOR = 18,
+    TOSAINTDIV = 19,
+    TOSALOGICAL_AND = 20,
+    TOSALOGICAL_LEFT_SHIFT = 21,
+    TOSALOGICAL_RIGHT_SHIFT = 22,
+    TOSALOGICAL_OR = 23,
+    TOSALOGICAL_XOR = 24,
+    TOSAMAXIMUM = 25,
+    TOSAMINIMUM = 26,
+    TOSAMUL = 27,
+    TOSAPOW = 28,
+    TOSASUB = 29,
+    TOSATABLE = 30,
+    TOSAABS = 31,
+    TOSABITWISE_NOT = 32,
+    TOSACEIL = 33,
+    TOSACLZ = 34,
+    TOSACOS = 35,
+    TOSAEXP = 36,
+    TOSAFLOOR = 37,
+    TOSALOG = 38,
+    TOSALOGICAL_NOT = 39,
+    TOSANEGATE = 40,
+    TOSARECIPROCAL = 41,
+    TOSARSQRT = 42,
+    TOSASIN = 43,
+    TOSASELECT = 44,
+    TOSAEQUAL = 45,
+    TOSAGREATER = 46,
+    TOSAGREATER_EQUAL = 47,
+    TOSAREDUCE_ALL = 48,
+    TOSAREDUCE_ANY = 49,
+    TOSAREDUCE_MAX = 50,
+    TOSAREDUCE_MIN = 51,
+    TOSAREDUCE_PRODUCT = 52,
+    TOSAREDUCE_SUM = 53,
+    TOSACONCAT = 54,
+    TOSAPAD = 55,
+    TOSARESHAPE = 56,
+    TOSAREVERSE = 57,
+    TOSASLICE = 58,
+    TOSATILE = 59,
+    TOSATRANSPOSE = 60,
+    TOSAGATHER = 61,
+    TOSASCATTER = 62,
+    TOSARESIZE = 63,
+    TOSACAST = 64,
+    TOSARESCALE = 65,
+    TOSAInstructionsMax = 0x7fffffff
+};
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // SPIRV_UNIFIED1_TOSA_001000_1_H_

--- a/include/spirv/unified1/extinst.tosa.001000.1.grammar.json
+++ b/include/spirv/unified1/extinst.tosa.001000.1.grammar.json
@@ -1,0 +1,1143 @@
+{
+  "copyright": [
+    "(c) 2022-2025 Arm Ltd."
+  ],
+  "version": 1000000,
+  "revision": 1,
+  "instructions": [
+    {
+      "opname": "ARGMAX",
+      "opcode": 0,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "axis"
+        },
+        {
+          "kind": "IdRef",
+          "name": "nan_mode"
+        },
+        {
+          "kind": "IdRef",
+          "name": "input"
+        }
+      ]
+    },
+    {
+      "opname": "AVG_POOL2D",
+      "opcode": 1,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "kernel"
+        },
+        {
+          "kind": "IdRef",
+          "name": "stride"
+        },
+        {
+          "kind": "IdRef",
+          "name": "pad"
+        },
+        {
+          "kind": "IdRef",
+          "name": "acc_type"
+        },
+        {
+          "kind": "IdRef",
+          "name": "input"
+        },
+        {
+          "kind": "IdRef",
+          "name": "input_zp"
+        },
+        {
+          "kind": "IdRef",
+          "name": "output_zp"
+        }
+      ]
+    },
+    {
+      "opname": "CONV2D",
+      "opcode": 2,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "pad"
+        },
+        {
+          "kind": "IdRef",
+          "name": "stride"
+        },
+        {
+          "kind": "IdRef",
+          "name": "dilation"
+        },
+        {
+          "kind": "IdRef",
+          "name": "acc_type"
+        },
+        {
+          "kind": "IdRef",
+          "name": "local_bound"
+        },
+        {
+          "kind": "IdRef",
+          "name": "input"
+        },
+        {
+          "kind": "IdRef",
+          "name": "weight"
+        },
+        {
+          "kind": "IdRef",
+          "name": "bias"
+        },
+        {
+          "kind": "IdRef",
+          "name": "input_zp"
+        },
+        {
+          "kind": "IdRef",
+          "name": "weight_zp"
+        }
+      ]
+    },
+    {
+      "opname": "CONV3D",
+      "opcode": 3,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "pad"
+        },
+        {
+          "kind": "IdRef",
+          "name": "stride"
+        },
+        {
+          "kind": "IdRef",
+          "name": "dilation"
+        },
+        {
+          "kind": "IdRef",
+          "name": "acc_type"
+        },
+        {
+          "kind": "IdRef",
+          "name": "local_bound"
+        },
+        {
+          "kind": "IdRef",
+          "name": "input"
+        },
+        {
+          "kind": "IdRef",
+          "name": "weight"
+        },
+        {
+          "kind": "IdRef",
+          "name": "bias"
+        },
+        {
+          "kind": "IdRef",
+          "name": "input_zp"
+        },
+        {
+          "kind": "IdRef",
+          "name": "weight_zp"
+        }
+      ]
+    },
+    {
+      "opname": "DEPTHWISE_CONV2D",
+      "opcode": 4,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "pad"
+        },
+        {
+          "kind": "IdRef",
+          "name": "stride"
+        },
+        {
+          "kind": "IdRef",
+          "name": "dilation"
+        },
+        {
+          "kind": "IdRef",
+          "name": "acc_type"
+        },
+        {
+          "kind": "IdRef",
+          "name": "local_bound"
+        },
+        {
+          "kind": "IdRef",
+          "name": "input"
+        },
+        {
+          "kind": "IdRef",
+          "name": "weight"
+        },
+        {
+          "kind": "IdRef",
+          "name": "bias"
+        },
+        {
+          "kind": "IdRef",
+          "name": "input_zp"
+        },
+        {
+          "kind": "IdRef",
+          "name": "weight_zp"
+        }
+      ]
+    },
+    {
+      "opname": "FFT2D",
+      "opcode": 5,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "inverse"
+        },
+        {
+          "kind": "IdRef",
+          "name": "local_bound"
+        },
+        {
+          "kind": "IdRef",
+          "name": "input_real"
+        },
+        {
+          "kind": "IdRef",
+          "name": "input_imag"
+        }
+      ]
+    },
+    {
+      "opname": "MATMUL",
+      "opcode": 6,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "A"
+        },
+        {
+          "kind": "IdRef",
+          "name": "B"
+        },
+        {
+          "kind": "IdRef",
+          "name": "A_zp"
+        },
+        {
+          "kind": "IdRef",
+          "name": "B_zp"
+        }
+      ]
+    },
+    {
+      "opname": "MAX_POOL2D",
+      "opcode": 7,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "kernel"
+        },
+        {
+          "kind": "IdRef",
+          "name": "stride"
+        },
+        {
+          "kind": "IdRef",
+          "name": "pad"
+        },
+        {
+          "kind": "IdRef",
+          "name": "nan_mode"
+        },
+        {
+          "kind": "IdRef",
+          "name": "input"
+        }
+      ]
+    },
+    {
+      "opname": "RFFT2D",
+      "opcode": 8,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "local_bound"
+        },
+        {
+          "kind": "IdRef",
+          "name": "input_real"
+        }
+      ]
+    },
+    {
+      "opname": "TRANSPOSE_CONV2D",
+      "opcode": 9,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "out_pad"
+        },
+        {
+          "kind": "IdRef",
+          "name": "stride"
+        },
+        {
+          "kind": "IdRef",
+          "name": "acc_type"
+        },
+        {
+          "kind": "IdRef",
+          "name": "local_bound"
+        },
+        {
+          "kind": "IdRef",
+          "name": "input"
+        },
+        {
+          "kind": "IdRef",
+          "name": "weight"
+        },
+        {
+          "kind": "IdRef",
+          "name": "bias"
+        },
+        {
+          "kind": "IdRef",
+          "name": "input_zp"
+        },
+        {
+          "kind": "IdRef",
+          "name": "weight_zp"
+        }
+      ]
+    },
+    {
+      "opname": "CLAMP",
+      "opcode": 10,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "min_val"
+        },
+        {
+          "kind": "IdRef",
+          "name": "max_val"
+        },
+        {
+          "kind": "IdRef",
+          "name": "nan_mode"
+        },
+        {
+          "kind": "IdRef",
+          "name": "input"
+        }
+      ]
+    },
+    {
+      "opname": "ERF",
+      "opcode": 11,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "input"
+        }
+      ]
+    },
+    {
+      "opname": "SIGMOID",
+      "opcode": 12,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "input"
+        }
+      ]
+    },
+    {
+      "opname": "TANH",
+      "opcode": 13,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "input"
+        }
+      ]
+    },
+    {
+      "opname": "ADD",
+      "opcode": 14,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "input1"
+        },
+        {
+          "kind": "IdRef",
+          "name": "input2"
+        }
+      ]
+    },
+    {
+      "opname": "ARITHMETIC_RIGHT_SHIFT",
+      "opcode": 15,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "round"
+        },
+        {
+          "kind": "IdRef",
+          "name": "input1"
+        },
+        {
+          "kind": "IdRef",
+          "name": "input2"
+        }
+      ]
+    },
+    {
+      "opname": "BITWISE_AND",
+      "opcode": 16,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "input1"
+        },
+        {
+          "kind": "IdRef",
+          "name": "input2"
+        }
+      ]
+    },
+    {
+      "opname": "BITWISE_OR",
+      "opcode": 17,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "input1"
+        },
+        {
+          "kind": "IdRef",
+          "name": "input2"
+        }
+      ]
+    },
+    {
+      "opname": "BITWISE_XOR",
+      "opcode": 18,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "input1"
+        },
+        {
+          "kind": "IdRef",
+          "name": "input2"
+        }
+      ]
+    },
+    {
+      "opname": "INTDIV",
+      "opcode": 19,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "input1"
+        },
+        {
+          "kind": "IdRef",
+          "name": "input2"
+        }
+      ]
+    },
+    {
+      "opname": "LOGICAL_AND",
+      "opcode": 20,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "input1"
+        },
+        {
+          "kind": "IdRef",
+          "name": "input2"
+        }
+      ]
+    },
+    {
+      "opname": "LOGICAL_LEFT_SHIFT",
+      "opcode": 21,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "input1"
+        },
+        {
+          "kind": "IdRef",
+          "name": "input2"
+        }
+      ]
+    },
+    {
+      "opname": "LOGICAL_RIGHT_SHIFT",
+      "opcode": 22,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "input1"
+        },
+        {
+          "kind": "IdRef",
+          "name": "input2"
+        }
+      ]
+    },
+    {
+      "opname": "LOGICAL_OR",
+      "opcode": 23,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "input1"
+        },
+        {
+          "kind": "IdRef",
+          "name": "input2"
+        }
+      ]
+    },
+    {
+      "opname": "LOGICAL_XOR",
+      "opcode": 24,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "input1"
+        },
+        {
+          "kind": "IdRef",
+          "name": "input2"
+        }
+      ]
+    },
+    {
+      "opname": "MAXIMUM",
+      "opcode": 25,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "nan_mode"
+        },
+        {
+          "kind": "IdRef",
+          "name": "input1"
+        },
+        {
+          "kind": "IdRef",
+          "name": "input2"
+        }
+      ]
+    },
+    {
+      "opname": "MINIMUM",
+      "opcode": 26,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "nan_mode"
+        },
+        {
+          "kind": "IdRef",
+          "name": "input1"
+        },
+        {
+          "kind": "IdRef",
+          "name": "input2"
+        }
+      ]
+    },
+    {
+      "opname": "MUL",
+      "opcode": 27,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "input1"
+        },
+        {
+          "kind": "IdRef",
+          "name": "input2"
+        },
+        {
+          "kind": "IdRef",
+          "name": "shift"
+        }
+      ]
+    },
+    {
+      "opname": "POW",
+      "opcode": 28,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "input1"
+        },
+        {
+          "kind": "IdRef",
+          "name": "input2"
+        }
+      ]
+    },
+    {
+      "opname": "SUB",
+      "opcode": 29,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "input1"
+        },
+        {
+          "kind": "IdRef",
+          "name": "input2"
+        }
+      ]
+    },
+    {
+      "opname": "TABLE",
+      "opcode": 30,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "input1"
+        },
+        {
+          "kind": "IdRef",
+          "name": "table"
+        }
+      ]
+    },
+    {
+      "opname": "ABS",
+      "opcode": 31,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "input1"
+        }
+      ]
+    },
+    {
+      "opname": "BITWISE_NOT",
+      "opcode": 32,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "input1"
+        }
+      ]
+    },
+    {
+      "opname": "CEIL",
+      "opcode": 33,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "input1"
+        }
+      ]
+    },
+    {
+      "opname": "CLZ",
+      "opcode": 34,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "input1"
+        }
+      ]
+    },
+    {
+      "opname": "COS",
+      "opcode": 35,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "input1"
+        }
+      ]
+    },
+    {
+      "opname": "EXP",
+      "opcode": 36,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "input1"
+        }
+      ]
+    },
+    {
+      "opname": "FLOOR",
+      "opcode": 37,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "input1"
+        }
+      ]
+    },
+    {
+      "opname": "LOG",
+      "opcode": 38,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "input1"
+        }
+      ]
+    },
+    {
+      "opname": "LOGICAL_NOT",
+      "opcode": 39,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "input1"
+        }
+      ]
+    },
+    {
+      "opname": "NEGATE",
+      "opcode": 40,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "input1"
+        },
+        {
+          "kind": "IdRef",
+          "name": "input1_zp"
+        },
+        {
+          "kind": "IdRef",
+          "name": "output_zp"
+        }
+      ]
+    },
+    {
+      "opname": "RECIPROCAL",
+      "opcode": 41,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "input1"
+        }
+      ]
+    },
+    {
+      "opname": "RSQRT",
+      "opcode": 42,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "input1"
+        }
+      ]
+    },
+    {
+      "opname": "SIN",
+      "opcode": 43,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "input1"
+        }
+      ]
+    },
+    {
+      "opname": "SELECT",
+      "opcode": 44,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "input1"
+        },
+        {
+          "kind": "IdRef",
+          "name": "input2"
+        },
+        {
+          "kind": "IdRef",
+          "name": "input3"
+        }
+      ]
+    },
+    {
+      "opname": "EQUAL",
+      "opcode": 45,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "input1"
+        },
+        {
+          "kind": "IdRef",
+          "name": "input2"
+        }
+      ]
+    },
+    {
+      "opname": "GREATER",
+      "opcode": 46,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "input1"
+        },
+        {
+          "kind": "IdRef",
+          "name": "input2"
+        }
+      ]
+    },
+    {
+      "opname": "GREATER_EQUAL",
+      "opcode": 47,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "input1"
+        },
+        {
+          "kind": "IdRef",
+          "name": "input2"
+        }
+      ]
+    },
+    {
+      "opname": "REDUCE_ALL",
+      "opcode": 48,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "axis"
+        },
+        {
+          "kind": "IdRef",
+          "name": "input"
+        }
+      ]
+    },
+    {
+      "opname": "REDUCE_ANY",
+      "opcode": 49,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "axis"
+        },
+        {
+          "kind": "IdRef",
+          "name": "input"
+        }
+      ]
+    },
+    {
+      "opname": "REDUCE_MAX",
+      "opcode": 50,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "axis"
+        },
+        {
+          "kind": "IdRef",
+          "name": "nan_mode"
+        },
+        {
+          "kind": "IdRef",
+          "name": "input"
+        }
+      ]
+    },
+    {
+      "opname": "REDUCE_MIN",
+      "opcode": 51,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "axis"
+        },
+        {
+          "kind": "IdRef",
+          "name": "nan_mode"
+        },
+        {
+          "kind": "IdRef",
+          "name": "input"
+        }
+      ]
+    },
+    {
+      "opname": "REDUCE_PRODUCT",
+      "opcode": 52,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "axis"
+        },
+        {
+          "kind": "IdRef",
+          "name": "input"
+        }
+      ]
+    },
+    {
+      "opname": "REDUCE_SUM",
+      "opcode": 53,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "axis"
+        },
+        {
+          "kind": "IdRef",
+          "name": "input"
+        }
+      ]
+    },
+    {
+      "opname": "CONCAT",
+      "opcode": 54,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "axis"
+        },
+        {
+          "kind": "IdRef",
+          "name": "input1",
+          "quantifier": "*"
+        }
+      ]
+    },
+    {
+      "opname": "PAD",
+      "opcode": 55,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "input1"
+        },
+        {
+          "kind": "IdRef",
+          "name": "padding"
+        },
+        {
+          "kind": "IdRef",
+          "name": "pad_const"
+        }
+      ]
+    },
+    {
+      "opname": "RESHAPE",
+      "opcode": 56,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "input1"
+        },
+        {
+          "kind": "IdRef",
+          "name": "shape"
+        }
+      ]
+    },
+    {
+      "opname": "REVERSE",
+      "opcode": 57,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "axis"
+        },
+        {
+          "kind": "IdRef",
+          "name": "input1"
+        }
+      ]
+    },
+    {
+      "opname": "SLICE",
+      "opcode": 58,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "input1"
+        },
+        {
+          "kind": "IdRef",
+          "name": "start"
+        },
+        {
+          "kind": "IdRef",
+          "name": "size"
+        }
+      ]
+    },
+    {
+      "opname": "TILE",
+      "opcode": 59,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "input1"
+        },
+        {
+          "kind": "IdRef",
+          "name": "multiples"
+        }
+      ]
+    },
+    {
+      "opname": "TRANSPOSE",
+      "opcode": 60,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "perms"
+        },
+        {
+          "kind": "IdRef",
+          "name": "input1"
+        }
+      ]
+    },
+    {
+      "opname": "GATHER",
+      "opcode": 61,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "values"
+        },
+        {
+          "kind": "IdRef",
+          "name": "indices"
+        }
+      ]
+    },
+    {
+      "opname": "SCATTER",
+      "opcode": 62,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "values_in"
+        },
+        {
+          "kind": "IdRef",
+          "name": "indices"
+        },
+        {
+          "kind": "IdRef",
+          "name": "input"
+        }
+      ]
+    },
+    {
+      "opname": "RESIZE",
+      "opcode": 63,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "mode"
+        },
+        {
+          "kind": "IdRef",
+          "name": "input"
+        },
+        {
+          "kind": "IdRef",
+          "name": "scale"
+        },
+        {
+          "kind": "IdRef",
+          "name": "offset"
+        },
+        {
+          "kind": "IdRef",
+          "name": "border"
+        }
+      ]
+    },
+    {
+      "opname": "CAST",
+      "opcode": 64,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "input"
+        }
+      ]
+    },
+    {
+      "opname": "RESCALE",
+      "opcode": 65,
+      "operands": [
+        {
+          "kind": "IdRef",
+          "name": "scale32"
+        },
+        {
+          "kind": "IdRef",
+          "name": "rounding_mode"
+        },
+        {
+          "kind": "IdRef",
+          "name": "per_channel"
+        },
+        {
+          "kind": "IdRef",
+          "name": "input_unsigned"
+        },
+        {
+          "kind": "IdRef",
+          "name": "output_unsigned"
+        },
+        {
+          "kind": "IdRef",
+          "name": "input"
+        },
+        {
+          "kind": "IdRef",
+          "name": "multiplier"
+        },
+        {
+          "kind": "IdRef",
+          "name": "shift"
+        },
+        {
+          "kind": "IdRef",
+          "name": "input_zp"
+        },
+        {
+          "kind": "IdRef",
+          "name": "output_zp"
+        }
+      ]
+    }
+  ],
+  "operand_kinds": []
+}

--- a/tools/buildHeaders/bin/generate_language_headers.py
+++ b/tools/buildHeaders/bin/generate_language_headers.py
@@ -43,8 +43,9 @@ def make_path_to_file(f):
 class ExtInstGrammar:
     """The grammar for an extended instruction set"""
 
-    def __init__(self, name, copyright, instructions, operand_kinds, version = None, revision = None):
+    def __init__(self, name, guard_name, copyright, instructions, operand_kinds, version = None, revision = None):
        self.name = name
+       self.guard_name = guard_name
        self.copyright = copyright
        self.instructions = instructions
        self.operand_kinds = operand_kinds
@@ -90,7 +91,7 @@ class LangGenerator:
             parts.extend(["{}{}".format(self.comment_prefix(), f) for f in grammar.copyright])
         parts.append('')
 
-        guard = 'SPIRV_UNIFIED1_{}_H_'.format(grammar.name)
+        guard = 'SPIRV_UNIFIED1_{}_H_'.format(grammar.guard_name)
         if self.uses_guards:
             parts.append('#ifndef {}'.format(guard))
             parts.append('#define {}'.format(guard))
@@ -192,7 +193,10 @@ def main():
         else:
           operand_kinds = []
 
+        sanitized_guard_name = args.extinst_output_base.replace('.', '_')
+
         grammar = ExtInstGrammar(name = args.extinst_name,
+                                 guard_name = sanitized_guard_name,
                                  copyright = copyright,
                                  instructions = grammar_json['instructions'],
                                  operand_kinds = operand_kinds,

--- a/tools/buildHeaders/bin/makeExtinstHeaders.py
+++ b/tools/buildHeaders/bin/makeExtinstHeaders.py
@@ -7,15 +7,16 @@ import os
 # Assume we are running from the tools/buildHeaders directory
 os.chdir('../../include/spirv/unified1')
 
-def mk_extinst(name, grammar_file):
+def mk_extinst(name, grammar_file, header_basename=None):
   """Generate one C header from a grammar"""
   script = '../../../tools/buildHeaders/bin/generate_language_headers.py'
+  header_basename = header_basename if header_basename else name
   subprocess.check_call(['python3',
                          script,
                          '--extinst-name=' + name,
                          '--extinst-grammar=' + grammar_file,
-                         '--extinst-output-base=' + name])
-  subprocess.check_call(['dos2unix', name + '.h'])
+                         '--extinst-output-base=' + header_basename])
+  subprocess.check_call(['dos2unix', header_basename + '.h'])
 
 
 mk_extinst('DebugInfo', 'extinst.debuginfo.grammar.json')
@@ -28,3 +29,4 @@ mk_extinst('NonSemanticDebugPrintf', 'extinst.nonsemantic.debugprintf.grammar.js
 mk_extinst('NonSemanticClspvReflection', 'extinst.nonsemantic.clspvreflection.grammar.json')
 mk_extinst('NonSemanticDebugBreak', 'extinst.nonsemantic.debugbreak.grammar.json')
 mk_extinst('NonSemanticVkspReflection', 'extinst.nonsemantic.vkspreflection.grammar.json')
+mk_extinst('TOSA', 'extinst.tosa.001000.1.grammar.json', 'TOSA.001000.1')


### PR DESCRIPTION
Also support custom header file names and header guard names in generated headers. This is useful when multiple extended instruction sets share a prefix. In the case of TOSA SPIR-V, multiple versions exist but we want all definitions to be prefixed with "TOSA" but have their own header and a different header guard such that it is possible to use the definitions in code that deals with multiple versions of the instruction set.

Change-Id: I7c18b72fd229e586da7cb1070d24cfcd69826827