### PR TITLE
Fixed typo in operand name of OpSubgroupAvcImeSetDualReferenceINTEL

### DIFF
--- a/include/spirv/unified1/spirv.core.grammar.json
+++ b/include/spirv/unified1/spirv.core.grammar.json
@@ -8225,7 +8225,7 @@
         { "kind" : "IdResult" },
         { "kind" : "IdRef", "name" : "Fwd Ref Offset" },
         { "kind" : "IdRef", "name" : "Bwd Ref Offset" },
-        { "kind" : "IdRef", "name" : "id> Search Window Config" },
+        { "kind" : "IdRef", "name" : "Search Window Config" },
         { "kind" : "IdRef", "name" : "Payload" }
       ],
       "capabilities" : [ "SubgroupAvcMotionEstimationINTEL" ],


### PR DESCRIPTION
Was making some tooling and noticed OpSubgroupAvcImeSetDualReferenceINTEL seemed to accidently include id> in one of the operand names. Search Window Config is also the operand name for two other instructions both of which don't seem to include the id> prefix.