### PR TITLE
Change enum StorageClass underlying type to unsigned

### DIFF
--- a/include/spirv/unified1/spirv.hpp
+++ b/include/spirv/unified1/spirv.hpp
@@ -212,7 +212,7 @@ enum ExecutionMode {
     ExecutionModeMax = 0x7fffffff,
 };
 
-enum StorageClass {
+enum StorageClass : unsigned {
     StorageClassUniformConstant = 0,
     StorageClassInput = 1,
     StorageClassUniform = 2,


### PR DESCRIPTION
Since https://github.com/llvm/llvm-project/commit/38f82534, SmallDenseMap requires key enum type to have a fixed underlying type.

StorageClass is used as key type of llvm::SmallDenseMap at https://github.com/KhronosGroup/SPIRV-LLVM-Translator/blob/43a5855e/lib/SPIRV/libSPIRV/SPIRVModule.cpp#L640 This PR fixes build of SPIRV-LLVM-Translator with latest llvm-project.