### PR TITLE
Rename OpRayQueryGetClusterIdNV to OpRayQueryGetIntersectionClusterIdNV

### DIFF
--- a/include/spirv/unified1/spirv.bf
+++ b/include/spirv/unified1/spirv.bf
@@ -2173,6 +2173,7 @@ namespace Spv
             OpTypeAccelerationStructureNV = 5341,
             OpExecuteCallableNV = 5344,
             OpRayQueryGetClusterIdNV = 5345,
+            OpRayQueryGetIntersectionClusterIdNV = 5345,
             OpHitObjectGetClusterIdNV = 5346,
             OpTypeCooperativeMatrixNV = 5358,
             OpCooperativeMatrixLoadNV = 5359,

--- a/include/spirv/unified1/spirv.core.grammar.json
+++ b/include/spirv/unified1/spirv.core.grammar.json
@@ -6504,8 +6504,9 @@
       "version" : "None"
     },
     {
-      "opname" : "OpRayQueryGetClusterIdNV",
+      "opname" : "OpRayQueryGetIntersectionClusterIdNV",
       "class" : "Reserved",
+      "aliases" : ["OpRayQueryGetClusterIdNV"],
       "opcode" : 5345,
       "operands" : [
           { "kind" : "IdResultType" },

--- a/include/spirv/unified1/spirv.cs
+++ b/include/spirv/unified1/spirv.cs
@@ -2172,6 +2172,7 @@ namespace Spv
             OpTypeAccelerationStructureNV = 5341,
             OpExecuteCallableNV = 5344,
             OpRayQueryGetClusterIdNV = 5345,
+            OpRayQueryGetIntersectionClusterIdNV = 5345,
             OpHitObjectGetClusterIdNV = 5346,
             OpTypeCooperativeMatrixNV = 5358,
             OpCooperativeMatrixLoadNV = 5359,

--- a/include/spirv/unified1/spirv.h
+++ b/include/spirv/unified1/spirv.h
@@ -2107,6 +2107,7 @@ typedef enum SpvOp_ {
     SpvOpTypeAccelerationStructureNV = 5341,
     SpvOpExecuteCallableNV = 5344,
     SpvOpRayQueryGetClusterIdNV = 5345,
+    SpvOpRayQueryGetIntersectionClusterIdNV = 5345,
     SpvOpHitObjectGetClusterIdNV = 5346,
     SpvOpTypeCooperativeMatrixNV = 5358,
     SpvOpCooperativeMatrixLoadNV = 5359,
@@ -2941,7 +2942,7 @@ inline void SpvHasResultAndType(SpvOp opcode, bool *hasResult, bool *hasResultTy
     case SpvOpRayQueryGetIntersectionTriangleVertexPositionsKHR: *hasResult = true; *hasResultType = true; break;
     case SpvOpTypeAccelerationStructureKHR: *hasResult = true; *hasResultType = false; break;
     case SpvOpExecuteCallableNV: *hasResult = false; *hasResultType = false; break;
-    case SpvOpRayQueryGetClusterIdNV: *hasResult = true; *hasResultType = true; break;
+    case SpvOpRayQueryGetIntersectionClusterIdNV: *hasResult = true; *hasResultType = true; break;
     case SpvOpHitObjectGetClusterIdNV: *hasResult = true; *hasResultType = true; break;
     case SpvOpTypeCooperativeMatrixNV: *hasResult = true; *hasResultType = false; break;
     case SpvOpCooperativeMatrixLoadNV: *hasResult = true; *hasResultType = true; break;

--- a/include/spirv/unified1/spirv.hpp
+++ b/include/spirv/unified1/spirv.hpp
@@ -2103,6 +2103,7 @@ enum Op {
     OpTypeAccelerationStructureNV = 5341,
     OpExecuteCallableNV = 5344,
     OpRayQueryGetClusterIdNV = 5345,
+    OpRayQueryGetIntersectionClusterIdNV = 5345,
     OpHitObjectGetClusterIdNV = 5346,
     OpTypeCooperativeMatrixNV = 5358,
     OpCooperativeMatrixLoadNV = 5359,
@@ -2937,7 +2938,7 @@ inline void HasResultAndType(Op opcode, bool *hasResult, bool *hasResultType) {
     case OpRayQueryGetIntersectionTriangleVertexPositionsKHR: *hasResult = true; *hasResultType = true; break;
     case OpTypeAccelerationStructureKHR: *hasResult = true; *hasResultType = false; break;
     case OpExecuteCallableNV: *hasResult = false; *hasResultType = false; break;
-    case OpRayQueryGetClusterIdNV: *hasResult = true; *hasResultType = true; break;
+    case OpRayQueryGetIntersectionClusterIdNV: *hasResult = true; *hasResultType = true; break;
     case OpHitObjectGetClusterIdNV: *hasResult = true; *hasResultType = true; break;
     case OpTypeCooperativeMatrixNV: *hasResult = true; *hasResultType = false; break;
     case OpCooperativeMatrixLoadNV: *hasResult = true; *hasResultType = true; break;

--- a/include/spirv/unified1/spirv.hpp11
+++ b/include/spirv/unified1/spirv.hpp11
@@ -2103,6 +2103,7 @@ enum class Op : unsigned {
     OpTypeAccelerationStructureNV = 5341,
     OpExecuteCallableNV = 5344,
     OpRayQueryGetClusterIdNV = 5345,
+    OpRayQueryGetIntersectionClusterIdNV = 5345,
     OpHitObjectGetClusterIdNV = 5346,
     OpTypeCooperativeMatrixNV = 5358,
     OpCooperativeMatrixLoadNV = 5359,
@@ -2937,7 +2938,7 @@ inline void HasResultAndType(Op opcode, bool *hasResult, bool *hasResultType) {
     case Op::OpRayQueryGetIntersectionTriangleVertexPositionsKHR: *hasResult = true; *hasResultType = true; break;
     case Op::OpTypeAccelerationStructureKHR: *hasResult = true; *hasResultType = false; break;
     case Op::OpExecuteCallableNV: *hasResult = false; *hasResultType = false; break;
-    case Op::OpRayQueryGetClusterIdNV: *hasResult = true; *hasResultType = true; break;
+    case Op::OpRayQueryGetIntersectionClusterIdNV: *hasResult = true; *hasResultType = true; break;
     case Op::OpHitObjectGetClusterIdNV: *hasResult = true; *hasResultType = true; break;
     case Op::OpTypeCooperativeMatrixNV: *hasResult = true; *hasResultType = false; break;
     case Op::OpCooperativeMatrixLoadNV: *hasResult = true; *hasResultType = true; break;

--- a/include/spirv/unified1/spirv.json
+++ b/include/spirv/unified1/spirv.json
@@ -2084,6 +2084,7 @@
                     "OpTypeAccelerationStructureNV": 5341,
                     "OpExecuteCallableNV": 5344,
                     "OpRayQueryGetClusterIdNV": 5345,
+                    "OpRayQueryGetIntersectionClusterIdNV": 5345,
                     "OpHitObjectGetClusterIdNV": 5346,
                     "OpTypeCooperativeMatrixNV": 5358,
                     "OpCooperativeMatrixLoadNV": 5359,

--- a/include/spirv/unified1/spirv.lua
+++ b/include/spirv/unified1/spirv.lua
@@ -2094,6 +2094,7 @@ spv = {
         OpTypeAccelerationStructureNV = 5341,
         OpExecuteCallableNV = 5344,
         OpRayQueryGetClusterIdNV = 5345,
+        OpRayQueryGetIntersectionClusterIdNV = 5345,
         OpHitObjectGetClusterIdNV = 5346,
         OpTypeCooperativeMatrixNV = 5358,
         OpCooperativeMatrixLoadNV = 5359,

--- a/include/spirv/unified1/spirv.py
+++ b/include/spirv/unified1/spirv.py
@@ -2037,6 +2037,7 @@ spv = {
         'OpTypeAccelerationStructureNV' : 5341,
         'OpExecuteCallableNV' : 5344,
         'OpRayQueryGetClusterIdNV' : 5345,
+        'OpRayQueryGetIntersectionClusterIdNV' : 5345,
         'OpHitObjectGetClusterIdNV' : 5346,
         'OpTypeCooperativeMatrixNV' : 5358,
         'OpCooperativeMatrixLoadNV' : 5359,

--- a/include/spirv/unified1/spv.d
+++ b/include/spirv/unified1/spv.d
@@ -2175,6 +2175,7 @@ enum Op : uint
     OpTypeAccelerationStructureNV = 5341,
     OpExecuteCallableNV = 5344,
     OpRayQueryGetClusterIdNV = 5345,
+    OpRayQueryGetIntersectionClusterIdNV = 5345,
     OpHitObjectGetClusterIdNV = 5346,
     OpTypeCooperativeMatrixNV = 5358,
     OpCooperativeMatrixLoadNV = 5359,


### PR DESCRIPTION
As discussed in https://github.com/KhronosGroup/SPIRV-Registry/pull/354, the instruction `OpRayQueryGetClusterIdNV` is really named `OpRayQueryGetIntersectionClusterIdNV`.

I've added an alias to the old name for backward compatibility.