### PR TITLE
grammar: Use regular integers when the enumerant value is not hexadecimal

### DIFF
--- a/include/spirv/unified1/extinst.debuginfo.grammar.json
+++ b/include/spirv/unified1/extinst.debuginfo.grammar.json
@@ -432,35 +432,35 @@
       "enumerants" : [
         {
           "enumerant" : "Unspecified",
-          "value" : "0"
+          "value" : 0
         },
         {
           "enumerant" : "Address",
-          "value" : "1"
+          "value" : 1
         },
         {
           "enumerant" : "Boolean",
-          "value" : "2"
+          "value" : 2
         },
         {
           "enumerant" : "Float",
-          "value" : "4"
+          "value" : 4
         },
         {
           "enumerant" : "Signed",
-          "value" : "5"
+          "value" : 5
         },
         {
           "enumerant" : "SignedChar",
-          "value" : "6"
+          "value" : 6
         },
         {
           "enumerant" : "Unsigned",
-          "value" : "7"
+          "value" : 7
         },
         {
           "enumerant" : "UnsignedChar",
-          "value" : "8"
+          "value" : 8
         }
       ]
     },
@@ -470,15 +470,15 @@
       "enumerants" : [
         {
           "enumerant" : "Class",
-          "value" : "0"
+          "value" : 0
         },
         {
           "enumerant" : "Structure",
-          "value" : "1"
+          "value" : 1
         },
         {
           "enumerant" : "Union",
-          "value" : "2"
+          "value" : 2
         }
       ]
     },
@@ -488,15 +488,15 @@
       "enumerants" : [
         {
           "enumerant" : "ConstType",
-          "value" : "0"
+          "value" : 0
         },
         {
           "enumerant" : "VolatileType",
-          "value" : "1"
+          "value" : 1
         },
         {
           "enumerant" : "RestrictType",
-          "value" : "2"
+          "value" : 2
         }
       ]
     },
@@ -506,26 +506,26 @@
       "enumerants" : [
         {
           "enumerant" : "Deref",
-          "value" : "0"
+          "value" : 0
         },
         {
           "enumerant" : "Plus",
-          "value" : "1"
+          "value" : 1
         },
         {
           "enumerant" : "Minus",
-          "value" : "2"
+          "value" : 2
         },
         {
           "enumerant" : "PlusUconst",
-          "value" : "3",
+          "value" : 3,
           "parameters" : [
              { "kind" : "LiteralInteger" }
           ]
         },
         {
           "enumerant" : "BitPiece",
-          "value" : "4",
+          "value" : 4,
           "parameters" : [
              { "kind" : "LiteralInteger" },
              { "kind" : "LiteralInteger" }
@@ -533,19 +533,19 @@
         },
         {
           "enumerant" : "Swap",
-          "value" : "5"
+          "value" : 5
         },
         {
           "enumerant" : "Xderef",
-          "value" : "6"
+          "value" : 6
         },
         {
           "enumerant" : "StackValue",
-          "value" : "7"
+          "value" : 7
         },
         {
           "enumerant" : "Constu",
-          "value" : "8",
+          "value" : 8,
           "parameters" : [
              { "kind" : "LiteralInteger" }
           ]

--- a/include/spirv/unified1/extinst.nonsemantic.shader.debuginfo.100.grammar.json
+++ b/include/spirv/unified1/extinst.nonsemantic.shader.debuginfo.100.grammar.json
@@ -547,35 +547,35 @@
       "enumerants" : [
         {
           "enumerant" : "Unspecified",
-          "value" : "0"
+          "value" : 0
         },
         {
           "enumerant" : "Address",
-          "value" : "1"
+          "value" : 1
         },
         {
           "enumerant" : "Boolean",
-          "value" : "2"
+          "value" : 2
         },
         {
           "enumerant" : "Float",
-          "value" : "3"
+          "value" : 3
         },
         {
           "enumerant" : "Signed",
-          "value" : "4"
+          "value" : 4
         },
         {
           "enumerant" : "SignedChar",
-          "value" : "5"
+          "value" : 5
         },
         {
           "enumerant" : "Unsigned",
-          "value" : "6"
+          "value" : 6
         },
         {
           "enumerant" : "UnsignedChar",
-          "value" : "7"
+          "value" : 7
         }
       ]
     },
@@ -585,15 +585,15 @@
       "enumerants" : [
         {
           "enumerant" : "Class",
-          "value" : "0"
+          "value" : 0
         },
         {
           "enumerant" : "Structure",
-          "value" : "1"
+          "value" : 1
         },
         {
           "enumerant" : "Union",
-          "value" : "2"
+          "value" : 2
         }
       ]
     },
@@ -603,19 +603,19 @@
       "enumerants" : [
         {
           "enumerant" : "ConstType",
-          "value" : "0"
+          "value" : 0
         },
         {
           "enumerant" : "VolatileType",
-          "value" : "1"
+          "value" : 1
         },
         {
           "enumerant" : "RestrictType",
-          "value" : "2"
+          "value" : 2
         },
         {
           "enumerant" : "AtomicType",
-          "value" : "3"
+          "value" : 3
         }
       ]
     },
@@ -625,26 +625,26 @@
       "enumerants" : [
         {
           "enumerant" : "Deref",
-          "value" : "0"
+          "value" : 0
         },
         {
           "enumerant" : "Plus",
-          "value" : "1"
+          "value" : 1
         },
         {
           "enumerant" : "Minus",
-          "value" : "2"
+          "value" : 2
         },
         {
           "enumerant" : "PlusUconst",
-          "value" : "3",
+          "value" : 3,
           "parameters" : [
              { "kind" : "IdRef" }
           ]
         },
         {
           "enumerant" : "BitPiece",
-          "value" : "4",
+          "value" : 4,
           "parameters" : [
              { "kind" : "IdRef" },
              { "kind" : "IdRef" }
@@ -652,26 +652,26 @@
         },
         {
           "enumerant" : "Swap",
-          "value" : "5"
+          "value" : 5
         },
         {
           "enumerant" : "Xderef",
-          "value" : "6"
+          "value" : 6
         },
         {
           "enumerant" : "StackValue",
-          "value" : "7"
+          "value" : 7
         },
         {
           "enumerant" : "Constu",
-          "value" : "8",
+          "value" : 8,
           "parameters" : [
              { "kind" : "IdRef" }
           ]
         },
         {
           "enumerant" : "Fragment",
-          "value" : "9",
+          "value" : 9,
           "parameters" : [
              { "kind" : "IdRef" },
              { "kind" : "IdRef" }
@@ -685,11 +685,11 @@
       "enumerants" : [
         {
           "enumerant" : "ImportedModule",
-          "value" : "0"
+          "value" : 0
         },
         {
           "enumerant" : "ImportedDeclaration",
-          "value" : "1"
+          "value" : 1
         }
       ]
     }

--- a/include/spirv/unified1/extinst.opencl.debuginfo.100.grammar.json
+++ b/include/spirv/unified1/extinst.opencl.debuginfo.100.grammar.json
@@ -485,35 +485,35 @@
       "enumerants" : [
         {
           "enumerant" : "Unspecified",
-          "value" : "0"
+          "value" : 0
         },
         {
           "enumerant" : "Address",
-          "value" : "1"
+          "value" : 1
         },
         {
           "enumerant" : "Boolean",
-          "value" : "2"
+          "value" : 2
         },
         {
           "enumerant" : "Float",
-          "value" : "3"
+          "value" : 3
         },
         {
           "enumerant" : "Signed",
-          "value" : "4"
+          "value" : 4
         },
         {
           "enumerant" : "SignedChar",
-          "value" : "5"
+          "value" : 5
         },
         {
           "enumerant" : "Unsigned",
-          "value" : "6"
+          "value" : 6
         },
         {
           "enumerant" : "UnsignedChar",
-          "value" : "7"
+          "value" : 7
         }
       ]
     },
@@ -523,15 +523,15 @@
       "enumerants" : [
         {
           "enumerant" : "Class",
-          "value" : "0"
+          "value" : 0
         },
         {
           "enumerant" : "Structure",
-          "value" : "1"
+          "value" : 1
         },
         {
           "enumerant" : "Union",
-          "value" : "2"
+          "value" : 2
         }
       ]
     },
@@ -541,19 +541,19 @@
       "enumerants" : [
         {
           "enumerant" : "ConstType",
-          "value" : "0"
+          "value" : 0
         },
         {
           "enumerant" : "VolatileType",
-          "value" : "1"
+          "value" : 1
         },
         {
           "enumerant" : "RestrictType",
-          "value" : "2"
+          "value" : 2
         },
         {
           "enumerant" : "AtomicType",
-          "value" : "3"
+          "value" : 3
         }
       ]
     },
@@ -563,26 +563,26 @@
       "enumerants" : [
         {
           "enumerant" : "Deref",
-          "value" : "0"
+          "value" : 0
         },
         {
           "enumerant" : "Plus",
-          "value" : "1"
+          "value" : 1
         },
         {
           "enumerant" : "Minus",
-          "value" : "2"
+          "value" : 2
         },
         {
           "enumerant" : "PlusUconst",
-          "value" : "3",
+          "value" : 3,
           "parameters" : [
              { "kind" : "LiteralInteger" }
           ]
         },
         {
           "enumerant" : "BitPiece",
-          "value" : "4",
+          "value" : 4,
           "parameters" : [
              { "kind" : "LiteralInteger" },
              { "kind" : "LiteralInteger" }
@@ -590,26 +590,26 @@
         },
         {
           "enumerant" : "Swap",
-          "value" : "5"
+          "value" : 5
         },
         {
           "enumerant" : "Xderef",
-          "value" : "6"
+          "value" : 6
         },
         {
           "enumerant" : "StackValue",
-          "value" : "7"
+          "value" : 7
         },
         {
           "enumerant" : "Constu",
-          "value" : "8",
+          "value" : 8,
           "parameters" : [
              { "kind" : "LiteralInteger" }
           ]
         },
         {
           "enumerant" : "Fragment",
-          "value" : "9",
+          "value" : 9,
           "parameters" : [
              { "kind" : "LiteralInteger" },
              { "kind" : "LiteralInteger" }
@@ -623,11 +623,11 @@
       "enumerants" : [
         {
           "enumerant" : "ImportedModule",
-          "value" : "0"
+          "value" : 0
         },
         {
           "enumerant" : "ImportedDeclaration",
-          "value" : "1"
+          "value" : 1
 	}
       ]
     }


### PR DESCRIPTION
In [`rspirv`](https://github.com/gfx-rs/rspirv) we had some "flaky" logic that relied on the `"value"` for `"enumerants"` in `"operand_kinds"` to be hexadecimal when the type is a string, but this is not always the case now that we are parsing `extinst` grammar files.

While we should definitely fix our parser to more carefully look at the `0x` prefix, it is also preferred to use regular JSON numbers if no string is needed. All these were found with the regex `"value" : "\d+"` and manually replaced to be numbers.