### PR TITLE
Add version-unified grammar and header for NonSemantic.Shader.DebugInfo

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -104,6 +104,11 @@ filegroup(
 )
 
 filegroup(
+    name = "spirv_ext_inst_nonsemantic_shader_debuginfo_grammar_unified1",
+    srcs = ["include/spirv/unified1/extinst.nonsemantic.shader.debuginfo.grammar.json"],
+)
+
+filegroup(
     name = "spirv_ext_inst_spv_amd_gcn_shader_grammar_unified1",
     srcs = ["include/spirv/unified1/extinst.spv-amd-gcn-shader.grammar.json"],
 )
@@ -147,6 +152,7 @@ cc_library(
         "include/spirv/unified1/NonSemanticClspvReflection.h",
         "include/spirv/unified1/NonSemanticDebugBreak.h",
         "include/spirv/unified1/NonSemanticDebugPrintf.h",
+        "include/spirv/unified1/NonSemanticShaderDebugInfo.h",
         "include/spirv/unified1/NonSemanticShaderDebugInfo100.h",
         "include/spirv/unified1/NonSemanticVkspReflection.h",
         "include/spirv/unified1/OpenCL.std.h",

--- a/include/spirv/unified1/NonSemanticShaderDebugInfo.h
+++ b/include/spirv/unified1/NonSemanticShaderDebugInfo.h
@@ -1,0 +1,155 @@
+// SPDX-FileCopyrightText: 2018-2026 The Khronos Group Inc.
+// SPDX-License-Identifier: MIT
+//
+// MODIFICATIONS TO THIS FILE MAY MEAN IT NO LONGER ACCURATELY REFLECTS
+// KHRONOS STANDARDS. THE UNMODIFIED, NORMATIVE VERSIONS OF KHRONOS
+// SPECIFICATIONS AND HEADER INFORMATION ARE LOCATED AT
+//    https://www.khronos.org/registry/
+
+#ifndef SPIRV_UNIFIED1_NonSemanticShaderDebugInfo_H_
+#define SPIRV_UNIFIED1_NonSemanticShaderDebugInfo_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum {
+    NonSemanticShaderDebugInfoVersion = 100,
+    NonSemanticShaderDebugInfoVersion_BitWidthPadding = 0x7fffffff
+};
+enum {
+    NonSemanticShaderDebugInfoRevision = 6,
+    NonSemanticShaderDebugInfoRevision_BitWidthPadding = 0x7fffffff
+};
+
+enum NonSemanticShaderDebugInfoInstructions {
+    NonSemanticShaderDebugInfoDebugInfoNone = 0,
+    NonSemanticShaderDebugInfoDebugCompilationUnit = 1,
+    NonSemanticShaderDebugInfoDebugTypeBasic = 2,
+    NonSemanticShaderDebugInfoDebugTypePointer = 3,
+    NonSemanticShaderDebugInfoDebugTypeQualifier = 4,
+    NonSemanticShaderDebugInfoDebugTypeArray = 5,
+    NonSemanticShaderDebugInfoDebugTypeVector = 6,
+    NonSemanticShaderDebugInfoDebugTypedef = 7,
+    NonSemanticShaderDebugInfoDebugTypeFunction = 8,
+    NonSemanticShaderDebugInfoDebugTypeEnum = 9,
+    NonSemanticShaderDebugInfoDebugTypeComposite = 10,
+    NonSemanticShaderDebugInfoDebugTypeMember = 11,
+    NonSemanticShaderDebugInfoDebugTypeInheritance = 12,
+    NonSemanticShaderDebugInfoDebugTypePtrToMember = 13,
+    NonSemanticShaderDebugInfoDebugTypeTemplate = 14,
+    NonSemanticShaderDebugInfoDebugTypeTemplateParameter = 15,
+    NonSemanticShaderDebugInfoDebugTypeTemplateTemplateParameter = 16,
+    NonSemanticShaderDebugInfoDebugTypeTemplateParameterPack = 17,
+    NonSemanticShaderDebugInfoDebugGlobalVariable = 18,
+    NonSemanticShaderDebugInfoDebugFunctionDeclaration = 19,
+    NonSemanticShaderDebugInfoDebugFunction = 20,
+    NonSemanticShaderDebugInfoDebugLexicalBlock = 21,
+    NonSemanticShaderDebugInfoDebugLexicalBlockDiscriminator = 22,
+    NonSemanticShaderDebugInfoDebugScope = 23,
+    NonSemanticShaderDebugInfoDebugNoScope = 24,
+    NonSemanticShaderDebugInfoDebugInlinedAt = 25,
+    NonSemanticShaderDebugInfoDebugLocalVariable = 26,
+    NonSemanticShaderDebugInfoDebugInlinedVariable = 27,
+    NonSemanticShaderDebugInfoDebugDeclare = 28,
+    NonSemanticShaderDebugInfoDebugValue = 29,
+    NonSemanticShaderDebugInfoDebugOperation = 30,
+    NonSemanticShaderDebugInfoDebugExpression = 31,
+    NonSemanticShaderDebugInfoDebugMacroDef = 32,
+    NonSemanticShaderDebugInfoDebugMacroUndef = 33,
+    NonSemanticShaderDebugInfoDebugImportedEntity = 34,
+    NonSemanticShaderDebugInfoDebugSource = 35,
+    NonSemanticShaderDebugInfoDebugFunctionDefinition = 101,
+    NonSemanticShaderDebugInfoDebugSourceContinued = 102,
+    NonSemanticShaderDebugInfoDebugLine = 103,
+    NonSemanticShaderDebugInfoDebugNoLine = 104,
+    NonSemanticShaderDebugInfoDebugBuildIdentifier = 105,
+    NonSemanticShaderDebugInfoDebugStoragePath = 106,
+    NonSemanticShaderDebugInfoDebugEntryPoint = 107,
+    NonSemanticShaderDebugInfoDebugTypeMatrix = 108,
+    NonSemanticShaderDebugInfoInstructionsMax = 0x7fffffff
+};
+
+
+enum NonSemanticShaderDebugInfoDebugInfoFlags {
+    NonSemanticShaderDebugInfoNone = 0x0000,
+    NonSemanticShaderDebugInfoFlagIsProtected = 0x01,
+    NonSemanticShaderDebugInfoFlagIsPrivate = 0x02,
+    NonSemanticShaderDebugInfoFlagIsPublic = 0x03,
+    NonSemanticShaderDebugInfoFlagIsLocal = 0x04,
+    NonSemanticShaderDebugInfoFlagIsDefinition = 0x08,
+    NonSemanticShaderDebugInfoFlagFwdDecl = 0x10,
+    NonSemanticShaderDebugInfoFlagArtificial = 0x20,
+    NonSemanticShaderDebugInfoFlagExplicit = 0x40,
+    NonSemanticShaderDebugInfoFlagPrototyped = 0x80,
+    NonSemanticShaderDebugInfoFlagObjectPointer = 0x100,
+    NonSemanticShaderDebugInfoFlagStaticMember = 0x200,
+    NonSemanticShaderDebugInfoFlagIndirectVariable = 0x400,
+    NonSemanticShaderDebugInfoFlagLValueReference = 0x800,
+    NonSemanticShaderDebugInfoFlagRValueReference = 0x1000,
+    NonSemanticShaderDebugInfoFlagIsOptimized = 0x2000,
+    NonSemanticShaderDebugInfoFlagIsEnumClass = 0x4000,
+    NonSemanticShaderDebugInfoFlagTypePassByValue = 0x8000,
+    NonSemanticShaderDebugInfoFlagTypePassByReference = 0x10000,
+    NonSemanticShaderDebugInfoFlagUnknownPhysicalLayout = 0x20000,
+    NonSemanticShaderDebugInfoDebugInfoFlagsMax = 0x7fffffff
+};
+
+enum NonSemanticShaderDebugInfoBuildIdentifierFlags {
+    NonSemanticShaderDebugInfoIdentifierPossibleDuplicates = 0x01,
+    NonSemanticShaderDebugInfoBuildIdentifierFlagsMax = 0x7fffffff
+};
+
+enum NonSemanticShaderDebugInfoDebugBaseTypeAttributeEncoding {
+    NonSemanticShaderDebugInfoUnspecified = 0,
+    NonSemanticShaderDebugInfoAddress = 1,
+    NonSemanticShaderDebugInfoBoolean = 2,
+    NonSemanticShaderDebugInfoFloat = 3,
+    NonSemanticShaderDebugInfoSigned = 4,
+    NonSemanticShaderDebugInfoSignedChar = 5,
+    NonSemanticShaderDebugInfoUnsigned = 6,
+    NonSemanticShaderDebugInfoUnsignedChar = 7,
+    NonSemanticShaderDebugInfoDebugBaseTypeAttributeEncodingMax = 0x7fffffff
+};
+
+enum NonSemanticShaderDebugInfoDebugCompositeType {
+    NonSemanticShaderDebugInfoClass = 0,
+    NonSemanticShaderDebugInfoStructure = 1,
+    NonSemanticShaderDebugInfoUnion = 2,
+    NonSemanticShaderDebugInfoDebugCompositeTypeMax = 0x7fffffff
+};
+
+enum NonSemanticShaderDebugInfoDebugTypeQualifier {
+    NonSemanticShaderDebugInfoConstType = 0,
+    NonSemanticShaderDebugInfoVolatileType = 1,
+    NonSemanticShaderDebugInfoRestrictType = 2,
+    NonSemanticShaderDebugInfoAtomicType = 3,
+    NonSemanticShaderDebugInfoDebugTypeQualifierMax = 0x7fffffff
+};
+
+enum NonSemanticShaderDebugInfoDebugOperation {
+    NonSemanticShaderDebugInfoDeref = 0,
+    NonSemanticShaderDebugInfoPlus = 1,
+    NonSemanticShaderDebugInfoMinus = 2,
+    NonSemanticShaderDebugInfoPlusUconst = 3,
+    NonSemanticShaderDebugInfoBitPiece = 4,
+    NonSemanticShaderDebugInfoSwap = 5,
+    NonSemanticShaderDebugInfoXderef = 6,
+    NonSemanticShaderDebugInfoStackValue = 7,
+    NonSemanticShaderDebugInfoConstu = 8,
+    NonSemanticShaderDebugInfoFragment = 9,
+    NonSemanticShaderDebugInfoDebugOperationMax = 0x7fffffff
+};
+
+enum NonSemanticShaderDebugInfoDebugImportedEntity {
+    NonSemanticShaderDebugInfoImportedModule = 0,
+    NonSemanticShaderDebugInfoImportedDeclaration = 1,
+    NonSemanticShaderDebugInfoDebugImportedEntityMax = 0x7fffffff
+};
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // SPIRV_UNIFIED1_NonSemanticShaderDebugInfo_H_

--- a/include/spirv/unified1/NonSemanticShaderDebugInfo100.h
+++ b/include/spirv/unified1/NonSemanticShaderDebugInfo100.h
@@ -1,10 +1,14 @@
 // SPDX-FileCopyrightText: 2018-2024 The Khronos Group Inc.
 // SPDX-License-Identifier: MIT
-// 
+//
 // MODIFICATIONS TO THIS FILE MAY MEAN IT NO LONGER ACCURATELY REFLECTS
 // KHRONOS STANDARDS. THE UNMODIFIED, NORMATIVE VERSIONS OF KHRONOS
 // SPECIFICATIONS AND HEADER INFORMATION ARE LOCATED AT
 //    https://www.khronos.org/registry/
+//
+// This file is a frozen snapshot of the NonSemantic.Shader.DebugInfo version
+// 100 instruction set. It will not be updated with new instructions. New code
+// should include NonSemanticShaderDebugInfo.h, which covers all versions.
 
 #ifndef SPIRV_UNIFIED1_NonSemanticShaderDebugInfo100_H_
 #define SPIRV_UNIFIED1_NonSemanticShaderDebugInfo100_H_

--- a/include/spirv/unified1/extinst.nonsemantic.shader.debuginfo.grammar.json
+++ b/include/spirv/unified1/extinst.nonsemantic.shader.debuginfo.grammar.json
@@ -1,0 +1,697 @@
+{
+  "copyright" : [
+    "Copyright: 2018-2024 The Khronos Group Inc.",
+    "License: MIT",
+    "",
+    "MODIFICATIONS TO THIS FILE MAY MEAN IT NO LONGER ACCURATELY REFLECTS KHRONOS",
+    "STANDARDS. THE UNMODIFIED, NORMATIVE VERSIONS OF KHRONOS SPECIFICATIONS AND",
+    "HEADER INFORMATION ARE LOCATED AT https://www.khronos.org/registry/ ",
+    ""
+  ],
+  "version" : 100,
+  "revision" : 6,
+  "instructions" : [
+    {
+      "opname" : "DebugInfoNone",
+      "opcode" : 0
+    },
+    {
+      "opname" : "DebugCompilationUnit",
+      "opcode" : 1,
+      "operands" : [
+        { "kind" : "IdRef", "name" : "Version" },
+        { "kind" : "IdRef", "name" : "DWARF Version" },
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "IdRef", "name" : "Language" }
+      ]
+    },
+    {
+      "opname" : "DebugTypeBasic",
+      "opcode" : 2,
+      "operands" : [
+        { "kind" : "IdRef", "name" : "Name" },
+        { "kind" : "IdRef", "name" : "Size" },
+        { "kind" : "IdRef", "name" : "Encoding" },
+        { "kind" : "IdRef", "name" : "Flags" }
+      ]
+    },
+    {
+      "opname" : "DebugTypePointer",
+      "opcode" : 3,
+      "operands" : [
+        { "kind" : "IdRef", "name" : "Base Type" },
+        { "kind" : "IdRef", "name" : "Storage Class" },
+        { "kind" : "IdRef", "name" : "Flags" }
+      ]
+    },
+    {
+      "opname" : "DebugTypeQualifier",
+      "opcode" : 4,
+      "operands" : [
+        { "kind" : "IdRef", "name" : "Base Type" },
+        { "kind" : "IdRef", "name" : "Type Qualifier" }
+      ]
+    },
+    {
+      "opname" : "DebugTypeArray",
+      "opcode" : 5,
+      "operands" : [
+        { "kind" : "IdRef", "name" : "Base Type" },
+        { "kind" : "IdRef", "name" : "Component Counts", "quantifier" : "*" }
+      ]
+    },
+    {
+      "opname" : "DebugTypeVector",
+      "opcode" : 6,
+      "operands" : [
+        { "kind" : "IdRef", "name" : "Base Type" },
+        { "kind" : "IdRef", "name" : "Component Count" }
+      ]
+    },
+    {
+      "opname" : "DebugTypedef",
+      "opcode" : 7,
+      "operands" : [
+        { "kind" : "IdRef", "name" : "Name" },
+        { "kind" : "IdRef", "name" : "Base Type" },
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "IdRef", "name" : "Line" },
+        { "kind" : "IdRef", "name" : "Column" },
+        { "kind" : "IdRef", "name" : "Parent" }
+      ]
+    },
+    {
+      "opname" : "DebugTypeFunction",
+      "opcode" : 8,
+      "operands" : [
+        { "kind" : "IdRef", "name" : "Flags" },
+        { "kind" : "IdRef", "name" : "Return Type" },
+        { "kind" : "IdRef", "name" : "Parameter Types", "quantifier" : "*" }
+      ]
+    },
+    {
+      "opname" : "DebugTypeEnum",
+      "opcode" : 9,
+      "operands" : [
+        { "kind" : "IdRef", "name" : "Name" },
+        { "kind" : "IdRef", "name" : "Underlying Type" },
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "IdRef", "name" : "Line" },
+        { "kind" : "IdRef", "name" : "Column" },
+        { "kind" : "IdRef", "name" : "Parent" },
+        { "kind" : "IdRef", "name" : "Size" },
+        { "kind" : "IdRef", "name" : "Flags" },
+        { "kind" : "PairIdRefIdRef", "name" : "Value, Name, Value, Name, ...", "quantifier" : "*" }
+      ]
+    },
+    {
+      "opname" : "DebugTypeComposite",
+      "opcode" : 10,
+      "operands" : [
+        { "kind" : "IdRef", "name" : "Name" },
+        { "kind" : "IdRef", "name" : "Tag" },
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "IdRef", "name" : "Line" },
+        { "kind" : "IdRef", "name" : "Column" },
+        { "kind" : "IdRef", "name" : "Parent" },
+        { "kind" : "IdRef", "name" : "Linkage Name" },
+        { "kind" : "IdRef", "name" : "Size" },
+        { "kind" : "IdRef", "name" : "Flags" },
+        { "kind" : "IdRef", "name" : "Members", "quantifier" : "*" }
+      ]
+    },
+    {
+      "opname" : "DebugTypeMember",
+      "opcode" : 11,
+      "operands" : [
+        { "kind" : "IdRef", "name" : "Name" },
+        { "kind" : "IdRef", "name" : "Type" },
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "IdRef", "name" : "Line" },
+        { "kind" : "IdRef", "name" : "Column" },
+        { "kind" : "IdRef", "name" : "Offset" },
+        { "kind" : "IdRef", "name" : "Size" },
+        { "kind" : "IdRef", "name" : "Flags" },
+        { "kind" : "IdRef", "name" : "Value", "quantifier" : "?" }
+      ]
+    },
+    {
+      "opname" : "DebugTypeInheritance",
+      "opcode" : 12,
+      "operands" : [
+        { "kind" : "IdRef", "name" : "Parent" },
+        { "kind" : "IdRef", "name" : "Offset" },
+        { "kind" : "IdRef", "name" : "Size" },
+        { "kind" : "IdRef", "name" : "Flags" }
+      ]
+    },
+    {
+      "opname" : "DebugTypePtrToMember",
+      "opcode" : 13,
+      "operands" : [
+        { "kind" : "IdRef", "name" : "Member Type" },
+        { "kind" : "IdRef", "name" : "Parent" }
+      ]
+    },
+    {
+      "opname" : "DebugTypeTemplate",
+      "opcode" : 14,
+      "operands" : [
+        { "kind" : "IdRef", "name" : "Target" },
+        { "kind" : "IdRef", "name" : "Parameters", "quantifier" : "*" }
+      ]
+    },
+    {
+      "opname" : "DebugTypeTemplateParameter",
+      "opcode" : 15,
+      "operands" : [
+        { "kind" : "IdRef", "name" : "Name" },
+        { "kind" : "IdRef", "name" : "Actual Type" },
+        { "kind" : "IdRef", "name" : "Value" },
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "IdRef", "name" : "Line" },
+        { "kind" : "IdRef", "name" : "Column" }
+      ]
+    },
+    {
+      "opname" : "DebugTypeTemplateTemplateParameter",
+      "opcode" : 16,
+      "operands" : [
+        { "kind" : "IdRef", "name" : "Name" },
+        { "kind" : "IdRef", "name" : "Template Name" },
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "IdRef", "name" : "Line" },
+        { "kind" : "IdRef", "name" : "Column" }
+      ]
+    },
+    {
+      "opname" : "DebugTypeTemplateParameterPack",
+      "opcode" : 17,
+      "operands" : [
+        { "kind" : "IdRef", "name" : "Name" },
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "IdRef", "name" : "Line" },
+        { "kind" : "IdRef", "name" : "Column" },
+        { "kind" : "IdRef", "name" : "Template Parameters", "quantifier" : "*" }
+      ]
+    },
+    {
+      "opname" : "DebugGlobalVariable",
+      "opcode" : 18,
+      "operands" : [
+        { "kind" : "IdRef", "name" : "Name" },
+        { "kind" : "IdRef", "name" : "Type" },
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "IdRef", "name" : "Line" },
+        { "kind" : "IdRef", "name" : "Column" },
+        { "kind" : "IdRef", "name" : "Parent" },
+        { "kind" : "IdRef", "name" : "Linkage Name" },
+        { "kind" : "IdRef", "name" : "Variable" },
+        { "kind" : "IdRef", "name" : "Flags" },
+        { "kind" : "IdRef", "name" : "Static Member Declaration", "quantifier" : "?" }
+      ]
+    },
+    {
+      "opname" : "DebugFunctionDeclaration",
+      "opcode" : 19,
+      "operands" : [
+        { "kind" : "IdRef", "name" : "Name" },
+        { "kind" : "IdRef", "name" : "Type" },
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "IdRef", "name" : "Line" },
+        { "kind" : "IdRef", "name" : "Column" },
+        { "kind" : "IdRef", "name" : "Parent" },
+        { "kind" : "IdRef", "name" : "Linkage Name" },
+        { "kind" : "IdRef", "name" : "Flags" }
+      ]
+    },
+    {
+      "opname" : "DebugFunction",
+      "opcode" : 20,
+      "operands" : [
+        { "kind" : "IdRef", "name" : "Name" },
+        { "kind" : "IdRef", "name" : "Type" },
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "IdRef", "name" : "Line" },
+        { "kind" : "IdRef", "name" : "Column" },
+        { "kind" : "IdRef", "name" : "Parent" },
+        { "kind" : "IdRef", "name" : "Linkage Name" },
+        { "kind" : "IdRef", "name" : "Flags" },
+        { "kind" : "IdRef", "name" : "Scope Line" },
+        { "kind" : "IdRef", "name" : "Declaration", "quantifier" : "?" }
+      ]
+    },
+    {
+      "opname" : "DebugLexicalBlock",
+      "opcode" : 21,
+      "operands" : [
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "IdRef", "name" : "Line" },
+        { "kind" : "IdRef", "name" : "Column" },
+        { "kind" : "IdRef", "name" : "Parent" },
+        { "kind" : "IdRef", "name" : "Name", "quantifier" : "?" }
+      ]
+    },
+    {
+      "opname" : "DebugLexicalBlockDiscriminator",
+      "opcode" : 22,
+      "operands" : [
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "IdRef", "name" : "Discriminator" },
+        { "kind" : "IdRef", "name" : "Parent" }
+      ]
+    },
+    {
+      "opname" : "DebugScope",
+      "opcode" : 23,
+      "operands" : [
+        { "kind" : "IdRef", "name" : "Scope" },
+        { "kind" : "IdRef", "name" : "Inlined At", "quantifier" : "?" }
+      ]
+    },
+    {
+      "opname" : "DebugNoScope",
+      "opcode" : 24
+    },
+    {
+      "opname" : "DebugInlinedAt",
+      "opcode" : 25,
+      "operands" : [
+        { "kind" : "IdRef", "name" : "Line" },
+        { "kind" : "IdRef", "name" : "Scope" },
+        { "kind" : "IdRef", "name" : "Inlined", "quantifier" : "?" }
+      ]
+    },
+    {
+      "opname" : "DebugLocalVariable",
+      "opcode" : 26,
+      "operands" : [
+        { "kind" : "IdRef", "name" : "Name" },
+        { "kind" : "IdRef", "name" : "Type" },
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "IdRef", "name" : "Line" },
+        { "kind" : "IdRef", "name" : "Column" },
+        { "kind" : "IdRef", "name" : "Parent" },
+        { "kind" : "IdRef", "name" : "Flags" },
+        { "kind" : "IdRef", "name" : "Arg Number", "quantifier" : "?" }
+      ]
+    },
+    {
+      "opname" : "DebugInlinedVariable",
+      "opcode" : 27,
+      "operands" : [
+        { "kind" : "IdRef", "name" : "Variable" },
+        { "kind" : "IdRef", "name" : "Inlined" }
+      ]
+    },
+    {
+      "opname" : "DebugDeclare",
+      "opcode" : 28,
+      "operands" : [
+        { "kind" : "IdRef", "name" : "Local Variable" },
+        { "kind" : "IdRef", "name" : "Variable" },
+        { "kind" : "IdRef", "name" : "Expression" },
+        { "kind" : "IdRef", "name" : "Indexes", "quantifier" : "*" }
+      ]
+    },
+    {
+      "opname" : "DebugValue",
+      "opcode" : 29,
+      "operands" : [
+        { "kind" : "IdRef", "name" : "Local Variable" },
+        { "kind" : "IdRef", "name" : "Value" },
+        { "kind" : "IdRef", "name" : "Expression" },
+        { "kind" : "IdRef", "name" : "Indexes", "quantifier" : "*" }
+      ]
+    },
+    {
+      "opname" : "DebugOperation",
+      "opcode" : 30,
+      "operands" : [
+        { "kind" : "IdRef", "name" : "OpCode" },
+        { "kind" : "IdRef", "name" : "Operands ...", "quantifier" : "*" }
+      ]
+    },
+    {
+      "opname" : "DebugExpression",
+      "opcode" : 31,
+      "operands" : [
+        { "kind" : "IdRef", "name" : "Operands ...", "quantifier" : "*" }
+      ]
+    },
+    {
+      "opname" : "DebugMacroDef",
+      "opcode" : 32,
+      "operands" : [
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "IdRef", "name" : "Line" },
+        { "kind" : "IdRef", "name" : "Name" },
+        { "kind" : "IdRef", "name" : "Value", "quantifier" : "?" }
+      ]
+    },
+    {
+      "opname" : "DebugMacroUndef",
+      "opcode" : 33,
+      "operands" : [
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "IdRef", "name" : "Line" },
+        { "kind" : "IdRef", "name" : "Macro" }
+      ]
+    },
+    {
+      "opname" : "DebugImportedEntity",
+      "opcode" : 34,
+      "operands" : [
+        { "kind" : "IdRef", "name" : "Name" },
+        { "kind" : "IdRef", "name" : "Tag" },
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "IdRef", "name" : "Entity" },
+        { "kind" : "IdRef", "name" : "Line" },
+        { "kind" : "IdRef", "name" : "Column" },
+        { "kind" : "IdRef", "name" : "Parent" }
+      ]
+    },
+    {
+      "opname" : "DebugSource",
+      "opcode" : 35,
+      "operands" : [
+        { "kind" : "IdRef", "name" : "File" },
+        { "kind" : "IdRef", "name" : "Text", "quantifier" : "?" }
+      ]
+    },
+    {
+      "opname" : "DebugFunctionDefinition",
+      "opcode" : 101,
+      "operands" : [
+        { "kind" : "IdRef", "name" : "Function" },
+        { "kind" : "IdRef", "name" : "Definition" }
+      ]
+    },
+    {
+      "opname" : "DebugSourceContinued",
+      "opcode" : 102,
+      "operands" : [
+        { "kind" : "IdRef", "name" : "Text" }
+      ]
+    },
+    {
+      "opname" : "DebugLine",
+      "opcode" : 103,
+      "operands" : [
+        { "kind" : "IdRef", "name" : "Source" },
+        { "kind" : "IdRef", "name" : "Line Start" },
+        { "kind" : "IdRef", "name" : "Line End" },
+        { "kind" : "IdRef", "name" : "Column Start" },
+        { "kind" : "IdRef", "name" : "Column End" }
+      ]
+    },
+    {
+      "opname" : "DebugNoLine",
+      "opcode" : 104
+    },
+    {
+      "opname" : "DebugBuildIdentifier",
+      "opcode" : 105,
+      "operands" : [
+        { "kind" : "IdRef", "name" : "Identifier" },
+        { "kind" : "IdRef", "name" : "Flags" }
+      ]
+    },
+    {
+      "opname" : "DebugStoragePath",
+      "opcode" : 106,
+      "operands" : [
+        { "kind" : "IdRef", "name" : "Path" }
+      ]
+    },
+    {
+      "opname" : "DebugEntryPoint",
+      "opcode" : 107,
+      "operands" : [
+        { "kind" : "IdRef", "name" : "Entry Point" },
+        { "kind" : "IdRef", "name" : "Compilation Unit" },
+        { "kind" : "IdRef", "name" : "Compiler Signature" },
+        { "kind" : "IdRef", "name" : "Command-line Arguments" }
+      ]
+    },
+    {
+      "opname" : "DebugTypeMatrix",
+      "opcode" : 108,
+      "operands" : [
+        { "kind" : "IdRef", "name" : "Vector Type" },
+        { "kind" : "IdRef", "name" : "Vector Count" },
+        { "kind" : "IdRef", "name" : "Column Major" }
+      ]
+    }
+  ],
+  "operand_kinds" : [
+    {
+      "category" : "BitEnum",
+      "kind" : "DebugInfoFlags",
+      "enumerants" : [
+        {
+          "enumerant" : "None",
+          "value" : "0x0000"
+        },
+        {
+          "enumerant" : "FlagIsProtected",
+          "value" : "0x01"
+        },
+        {
+          "enumerant" : "FlagIsPrivate",
+          "value" : "0x02"
+        },
+        {
+          "enumerant" : "FlagIsPublic",
+          "value" : "0x03"
+        },
+        {
+          "enumerant" : "FlagIsLocal",
+          "value" : "0x04"
+        },
+        {
+          "enumerant" : "FlagIsDefinition",
+          "value" : "0x08"
+        },
+        {
+          "enumerant" : "FlagFwdDecl",
+          "value" : "0x10"
+        },
+        {
+          "enumerant" : "FlagArtificial",
+          "value" : "0x20"
+        },
+        {
+          "enumerant" : "FlagExplicit",
+          "value" : "0x40"
+        },
+        {
+          "enumerant" : "FlagPrototyped",
+          "value" : "0x80"
+        },
+        {
+          "enumerant" : "FlagObjectPointer",
+          "value" : "0x100"
+        },
+        {
+          "enumerant" : "FlagStaticMember",
+          "value" : "0x200"
+        },
+        {
+          "enumerant" : "FlagIndirectVariable",
+          "value" : "0x400"
+        },
+        {
+          "enumerant" : "FlagLValueReference",
+          "value" : "0x800"
+        },
+        {
+          "enumerant" : "FlagRValueReference",
+          "value" : "0x1000"
+        },
+        {
+          "enumerant" : "FlagIsOptimized",
+          "value" : "0x2000"
+        },
+        {
+          "enumerant" : "FlagIsEnumClass",
+          "value" : "0x4000"
+        },
+        {
+          "enumerant" : "FlagTypePassByValue",
+          "value" : "0x8000"
+        },
+        {
+          "enumerant" : "FlagTypePassByReference",
+          "value" : "0x10000"
+        },
+        {
+          "enumerant" : "FlagUnknownPhysicalLayout",
+          "value" : "0x20000"
+        }
+      ]
+    },
+    {
+      "category" : "BitEnum",
+      "kind" : "BuildIdentifierFlags",
+      "enumerants" : [
+        {
+          "enumerant" : "IdentifierPossibleDuplicates",
+          "value" : "0x01"
+        }
+      ]
+    },
+    {
+      "category" : "ValueEnum",
+      "kind" : "DebugBaseTypeAttributeEncoding",
+      "enumerants" : [
+        {
+          "enumerant" : "Unspecified",
+          "value" : 0
+        },
+        {
+          "enumerant" : "Address",
+          "value" : 1
+        },
+        {
+          "enumerant" : "Boolean",
+          "value" : 2
+        },
+        {
+          "enumerant" : "Float",
+          "value" : 3
+        },
+        {
+          "enumerant" : "Signed",
+          "value" : 4
+        },
+        {
+          "enumerant" : "SignedChar",
+          "value" : 5
+        },
+        {
+          "enumerant" : "Unsigned",
+          "value" : 6
+        },
+        {
+          "enumerant" : "UnsignedChar",
+          "value" : 7
+        }
+      ]
+    },
+    {
+      "category" : "ValueEnum",
+      "kind" : "DebugCompositeType",
+      "enumerants" : [
+        {
+          "enumerant" : "Class",
+          "value" : 0
+        },
+        {
+          "enumerant" : "Structure",
+          "value" : 1
+        },
+        {
+          "enumerant" : "Union",
+          "value" : 2
+        }
+      ]
+    },
+    {
+      "category" : "ValueEnum",
+      "kind" : "DebugTypeQualifier",
+      "enumerants" : [
+        {
+          "enumerant" : "ConstType",
+          "value" : 0
+        },
+        {
+          "enumerant" : "VolatileType",
+          "value" : 1
+        },
+        {
+          "enumerant" : "RestrictType",
+          "value" : 2
+        },
+        {
+          "enumerant" : "AtomicType",
+          "value" : 3
+        }
+      ]
+    },
+    {
+      "category" : "ValueEnum",
+      "kind" : "DebugOperation",
+      "enumerants" : [
+        {
+          "enumerant" : "Deref",
+          "value" : 0
+        },
+        {
+          "enumerant" : "Plus",
+          "value" : 1
+        },
+        {
+          "enumerant" : "Minus",
+          "value" : 2
+        },
+        {
+          "enumerant" : "PlusUconst",
+          "value" : 3,
+          "parameters" : [
+             { "kind" : "IdRef" }
+          ]
+        },
+        {
+          "enumerant" : "BitPiece",
+          "value" : 4,
+          "parameters" : [
+             { "kind" : "IdRef" },
+             { "kind" : "IdRef" }
+          ]
+        },
+        {
+          "enumerant" : "Swap",
+          "value" : 5
+        },
+        {
+          "enumerant" : "Xderef",
+          "value" : 6
+        },
+        {
+          "enumerant" : "StackValue",
+          "value" : 7
+        },
+        {
+          "enumerant" : "Constu",
+          "value" : 8,
+          "parameters" : [
+             { "kind" : "IdRef" }
+          ]
+        },
+        {
+          "enumerant" : "Fragment",
+          "value" : 9,
+          "parameters" : [
+             { "kind" : "IdRef" },
+             { "kind" : "IdRef" }
+          ]
+        }
+      ]
+    },
+    {
+      "category" : "ValueEnum",
+      "kind" : "DebugImportedEntity",
+      "enumerants" : [
+        {
+          "enumerant" : "ImportedModule",
+          "value" : 0
+        },
+        {
+          "enumerant" : "ImportedDeclaration",
+          "value" : 1
+        }
+      ]
+    }
+  ]
+}

--- a/include/spirv/unified1/extinst.nonsemantic.shader.debuginfo.grammar.json
+++ b/include/spirv/unified1/extinst.nonsemantic.shader.debuginfo.grammar.json
@@ -1,6 +1,6 @@
 {
   "copyright" : [
-    "Copyright: 2018-2024 The Khronos Group Inc.",
+    "Copyright: 2018-2026 The Khronos Group Inc.",
     "License: MIT",
     "",
     "MODIFICATIONS TO THIS FILE MAY MEAN IT NO LONGER ACCURATELY REFLECTS KHRONOS",


### PR DESCRIPTION
This PR unifies the versioning for header and grammar for NSDI. I need it to start implementing tooling support for NSDI 101 (https://github.com/KhronosGroup/SPIRV-Registry/pull/390).

Added:

- `include/spirv/unified1/extinst.nonsemantic.shader.debuginfo.grammar.json`: canonical grammar for all NSDI versions. Content is identical to `extinst.nonsemantic.shader.debuginfo.100.grammar.json` at this revision (version 100, revision 6). The next PR in the series will append new opcodes here. The  `.100.` file is frozen and becomes a strict subset of this file.
- `include/spirv/unified1/NonSemanticShaderDebugInfo.h`: canonical C header. This PR removes the `100` infix from all symbol names. `Version` and `Revision` constants reflect the latest revision of the spec and will be updated as new versions get added.

Modified:

- `include/spirv/unified1/NonSemanticShaderDebugInfo100.h`: Add a deprecation comment at the top. I did not want to emit a notice or warn message to prevent breaking `-Wall` builds in downstream tools.
- `BUILD.bazel`: this PR adds a filegroup for the unified grammar file and  adds `NonSemanticShaderDebugInfo.h` to the `spirv_common_headers` cc_library.  The two headers are independent; neither depends on the other.

This PR preserves the existing `.100.` grammar and header files unchanged. Downstream tools using the `.100` files should remain unaffected.