### PR TITLE
Add NSDI 101 instructions

### DIFF
--- a/include/spirv/unified1/NonSemanticShaderDebugInfo.h
+++ b/include/spirv/unified1/NonSemanticShaderDebugInfo.h
@@ -14,11 +14,11 @@ extern "C" {
 #endif
 
 enum {
-    NonSemanticShaderDebugInfoVersion = 100,
+    NonSemanticShaderDebugInfoVersion = 101,
     NonSemanticShaderDebugInfoVersion_BitWidthPadding = 0x7fffffff
 };
 enum {
-    NonSemanticShaderDebugInfoRevision = 6,
+    NonSemanticShaderDebugInfoRevision = 1,
     NonSemanticShaderDebugInfoRevision_BitWidthPadding = 0x7fffffff
 };
 
@@ -67,6 +67,8 @@ enum NonSemanticShaderDebugInfoInstructions {
     NonSemanticShaderDebugInfoDebugStoragePath = 106,
     NonSemanticShaderDebugInfoDebugEntryPoint = 107,
     NonSemanticShaderDebugInfoDebugTypeMatrix = 108,
+    NonSemanticShaderDebugInfoDebugTypeVectorIdEXT = 109,
+    NonSemanticShaderDebugInfoDebugTypeCooperativeMatrixKHR = 110,
     NonSemanticShaderDebugInfoInstructionsMax = 0x7fffffff
 };
 

--- a/include/spirv/unified1/extinst.nonsemantic.shader.debuginfo.grammar.json
+++ b/include/spirv/unified1/extinst.nonsemantic.shader.debuginfo.grammar.json
@@ -8,8 +8,8 @@
     "HEADER INFORMATION ARE LOCATED AT https://www.khronos.org/registry/ ",
     ""
   ],
-  "version" : 100,
-  "revision" : 6,
+  "version" : 101,
+  "revision" : 1,
   "instructions" : [
     {
       "opname" : "DebugInfoNone",
@@ -32,7 +32,8 @@
         { "kind" : "IdRef", "name" : "Name" },
         { "kind" : "IdRef", "name" : "Size" },
         { "kind" : "IdRef", "name" : "Encoding" },
-        { "kind" : "IdRef", "name" : "Flags" }
+        { "kind" : "IdRef", "name" : "Flags" },
+        { "kind" : "IdRef", "name" : "FPEncoding", "quantifier" : "?" }
       ]
     },
     {
@@ -441,6 +442,25 @@
         { "kind" : "IdRef", "name" : "Vector Type" },
         { "kind" : "IdRef", "name" : "Vector Count" },
         { "kind" : "IdRef", "name" : "Column Major" }
+      ]
+    },
+    {
+      "opname" : "DebugTypeVectorIdEXT",
+      "opcode" : 109,
+      "operands" : [
+        { "kind" : "IdRef", "name" : "Component Type" },
+        { "kind" : "IdRef", "name" : "Component Count" }
+      ]
+    },
+    {
+      "opname" : "DebugTypeCooperativeMatrixKHR",
+      "opcode" : 110,
+      "operands" : [
+        { "kind" : "IdRef", "name" : "Component Type" },
+        { "kind" : "IdRef", "name" : "Scope" },
+        { "kind" : "IdRef", "name" : "Rows" },
+        { "kind" : "IdRef", "name" : "Columns" },
+        { "kind" : "IdRef", "name" : "Use" }
       ]
     }
   ],


### PR DESCRIPTION
This adds the new NSDI 101 instructions from https://github.com/KhronosGroup/SPIRV-Registry/pull/390. It depends on #578 (which unifies grammar and header files).

Note: Until #578 is merged, the easiest way to see the changes for NSDI 101 is to look at the commit changes (github is not great at stacking PRs).