### PR TITLE
Fix OpReadPipeBlockingINTEL/OpWritePipeBlockingINTEL operands

### DIFF
--- a/include/spirv/unified1/spirv.core.grammar.json
+++ b/include/spirv/unified1/spirv.core.grammar.json
@@ -10803,8 +10803,8 @@
       "aliases" : [ "OpReadPipeBlockingINTEL" ],
       "opcode" : 5946,
       "operands" : [
-        { "kind" : "IdResultType" },
-        { "kind" : "IdResult" },
+        { "kind" : "IdRef", "name" : "Pipe" },
+        { "kind" : "IdRef", "name" : "Pointer" },
         { "kind" : "IdRef", "name" : "Packet Size" },
         { "kind" : "IdRef", "name" : "Packet Alignment" }
       ],
@@ -10817,8 +10817,8 @@
       "aliases" : [ "OpWritePipeBlockingINTEL" ],
       "opcode" : 5947,
       "operands" : [
-        { "kind" : "IdResultType" },
-        { "kind" : "IdResult" },
+        { "kind" : "IdRef", "name" : "Pipe" },
+        { "kind" : "IdRef", "name" : "Pointer" },
         { "kind" : "IdRef", "name" : "Packet Size" },
         { "kind" : "IdRef", "name" : "Packet Alignment" }
       ],

--- a/include/spirv/unified1/spirv.h
+++ b/include/spirv/unified1/spirv.h
@@ -3464,8 +3464,8 @@ inline void SpvHasResultAndType(SpvOp opcode, bool *hasResult, bool *hasResultTy
     case SpvOpFixedExpALTERA: *hasResult = true; *hasResultType = true; break;
     case SpvOpPtrCastToCrossWorkgroupALTERA: *hasResult = true; *hasResultType = true; break;
     case SpvOpCrossWorkgroupCastToPtrALTERA: *hasResult = true; *hasResultType = true; break;
-    case SpvOpReadPipeBlockingALTERA: *hasResult = true; *hasResultType = true; break;
-    case SpvOpWritePipeBlockingALTERA: *hasResult = true; *hasResultType = true; break;
+    case SpvOpReadPipeBlockingALTERA: *hasResult = false; *hasResultType = false; break;
+    case SpvOpWritePipeBlockingALTERA: *hasResult = false; *hasResultType = false; break;
     case SpvOpFPGARegALTERA: *hasResult = true; *hasResultType = true; break;
     case SpvOpRayQueryGetRayTMinKHR: *hasResult = true; *hasResultType = true; break;
     case SpvOpRayQueryGetRayFlagsKHR: *hasResult = true; *hasResultType = true; break;

--- a/include/spirv/unified1/spirv.hpp
+++ b/include/spirv/unified1/spirv.hpp
@@ -3460,8 +3460,8 @@ inline void HasResultAndType(Op opcode, bool *hasResult, bool *hasResultType) {
     case OpFixedExpALTERA: *hasResult = true; *hasResultType = true; break;
     case OpPtrCastToCrossWorkgroupALTERA: *hasResult = true; *hasResultType = true; break;
     case OpCrossWorkgroupCastToPtrALTERA: *hasResult = true; *hasResultType = true; break;
-    case OpReadPipeBlockingALTERA: *hasResult = true; *hasResultType = true; break;
-    case OpWritePipeBlockingALTERA: *hasResult = true; *hasResultType = true; break;
+    case OpReadPipeBlockingALTERA: *hasResult = false; *hasResultType = false; break;
+    case OpWritePipeBlockingALTERA: *hasResult = false; *hasResultType = false; break;
     case OpFPGARegALTERA: *hasResult = true; *hasResultType = true; break;
     case OpRayQueryGetRayTMinKHR: *hasResult = true; *hasResultType = true; break;
     case OpRayQueryGetRayFlagsKHR: *hasResult = true; *hasResultType = true; break;

--- a/include/spirv/unified1/spirv.hpp11
+++ b/include/spirv/unified1/spirv.hpp11
@@ -3460,8 +3460,8 @@ inline void HasResultAndType(Op opcode, bool *hasResult, bool *hasResultType) {
     case Op::OpFixedExpALTERA: *hasResult = true; *hasResultType = true; break;
     case Op::OpPtrCastToCrossWorkgroupALTERA: *hasResult = true; *hasResultType = true; break;
     case Op::OpCrossWorkgroupCastToPtrALTERA: *hasResult = true; *hasResultType = true; break;
-    case Op::OpReadPipeBlockingALTERA: *hasResult = true; *hasResultType = true; break;
-    case Op::OpWritePipeBlockingALTERA: *hasResult = true; *hasResultType = true; break;
+    case Op::OpReadPipeBlockingALTERA: *hasResult = false; *hasResultType = false; break;
+    case Op::OpWritePipeBlockingALTERA: *hasResult = false; *hasResultType = false; break;
     case Op::OpFPGARegALTERA: *hasResult = true; *hasResultType = true; break;
     case Op::OpRayQueryGetRayTMinKHR: *hasResult = true; *hasResultType = true; break;
     case Op::OpRayQueryGetRayFlagsKHR: *hasResult = true; *hasResultType = true; break;


### PR DESCRIPTION
Per the SPV_INTEL_blocking_pipes spec, these instructions do not produce a result, but have Pipe and Pointer id arguments instead