### PR TITLE
Update spirv.core.grammar.json revision

### DIFF
--- a/include/spirv/unified1/spirv.core.grammar.json
+++ b/include/spirv/unified1/spirv.core.grammar.json
@@ -11,7 +11,7 @@
   "magic_number" : "0x07230203",
   "major_version" : 1,
   "minor_version" : 6,
-  "revision" : 4,
+  "revision" : 7,
   "instruction_printing_class" : [
     {
       "tag"     : "@exclude"


### PR DESCRIPTION
doing a git blame

> 41a8eb27 (Victor Lomuller                2024-07-03 19:02:57 +0100    14)   "revision" : 4,

so @bashbaug @dnovillo  we need to add this update to our release process