### PR TITLE
Fix Int64ImageEXT capability prerequisite to Int64

### DIFF
--- a/include/spirv/unified1/spirv.core.grammar.json
+++ b/include/spirv/unified1/spirv.core.grammar.json
@@ -17676,7 +17676,7 @@
         {
           "enumerant" : "Int64ImageEXT",
           "value" : 5016,
-          "capabilities" : [ "Shader" ],
+          "capabilities" : [ "Int64" ],
           "extensions" : [ "SPV_EXT_shader_image_int64" ],
           "version" : "None"
         },


### PR DESCRIPTION
The Int64ImageEXT capability listed Shader as its prerequisite, but per SPV_EXT_shader_image_int64 spec (https://github.khronos.org/SPIRV-Registry/extensions/EXT/SPV_EXT_shader_image_int64.html) it implicitly declares Int64