### PR TITLE
document header tagging conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,22 @@ python3 bin/makeExtinstHeaders.py
   Right now there is only a single version of both the GLSL and OpenCL
   headers.  So we don't yet have a problematic example to resolve.
 
+* *How and when is this repo tagged?*
+
+  Because there are many users of the SPIR-V headers, this repo is tagged using
+  several tagging conventions:
+
+  1. For each Vulkan SDK release, the repo is tagged with the Vulkan SDK version
+     to record the SPIR-V headers used by that version of the Vulkan SDK.  For
+     example, the tag `vulkan-sdk-1.X.YYY.Z` indicates the SPIR-V headers that
+     were included in the Vulkan SDK version `1.X.YYY.Z`.
+  2. For other uses, the repo is tagged using a [CalVer](https://calver.org/)
+     date-based scheme on an as-needed basis.  For example, the tag `vYYYY.0M.R`
+     indicates release `R` of the SPIR-V headers in the zero-padded month `0M`
+     of the full year `YYYY`.
+  3. Other, older tagging conventions previously existed in this repo, but are
+     no longer actively used.
+
 ## License
 <a name="license"></a>
 ```


### PR DESCRIPTION
Here is a PR that documents our header tagging conventions in the README FAQ.  It describes both the existing tagging for the Vulkan SDK and a new date-based "CalVer" tag for other usages.  We can expand this to other tagging conventions in the future if we choose to do so.

If this gets merged, and we decide to use date-based tags, I will create a date-based tag based on our agreed upon convention, which could be for example `v2026.07.0` (or `v2026.08.0` if it pushes into next month).