### PR TITLE
Add headers for SPV_EXT_bfloat16_arithmetic extension

### DIFF
--- a/include/spirv/unified1/org/khronos/spv/Spv.java
+++ b/include/spirv/unified1/org/khronos/spv/Spv.java
@@ -1626,6 +1626,7 @@ public class Spv {
         GlobalVariableFPGADecorationsALTERA(6189),
         GlobalVariableFPGADecorationsINTEL(6189),
         SubgroupBufferPrefetchINTEL(6220),
+        BFloat16ArithmeticEXT(6226),
         Subgroup2DBlockIOINTEL(6228),
         Subgroup2DBlockTransformINTEL(6229),
         Subgroup2DBlockTransposeINTEL(6230),

--- a/include/spirv/unified1/spirv.bf
+++ b/include/spirv/unified1/spirv.bf
@@ -1445,6 +1445,7 @@ namespace Spv
             GlobalVariableFPGADecorationsALTERA = 6189,
             GlobalVariableFPGADecorationsINTEL = 6189,
             SubgroupBufferPrefetchINTEL = 6220,
+            BFloat16ArithmeticEXT = 6226,
             Subgroup2DBlockIOINTEL = 6228,
             Subgroup2DBlockTransformINTEL = 6229,
             Subgroup2DBlockTransposeINTEL = 6230,

--- a/include/spirv/unified1/spirv.core.grammar.json
+++ b/include/spirv/unified1/spirv.core.grammar.json
@@ -18814,6 +18814,14 @@
           "version" : "None"
         },
         {
+          "enumerant" : "BFloat16ArithmeticEXT",
+          "value" : 6226,
+          "capabilities" : [ "BFloat16TypeKHR" ],
+          "extensions" : [ "SPV_EXT_bfloat16_arithmetic" ],
+          "version" : "None",
+          "provisional" : true
+        },
+        {
           "enumerant" : "Subgroup2DBlockIOINTEL",
           "value" : 6228,
           "extensions": [ "SPV_INTEL_2d_block_io" ],

--- a/include/spirv/unified1/spirv.cs
+++ b/include/spirv/unified1/spirv.cs
@@ -1444,6 +1444,7 @@ namespace Spv
             GlobalVariableFPGADecorationsALTERA = 6189,
             GlobalVariableFPGADecorationsINTEL = 6189,
             SubgroupBufferPrefetchINTEL = 6220,
+            BFloat16ArithmeticEXT = 6226,
             Subgroup2DBlockIOINTEL = 6228,
             Subgroup2DBlockTransformINTEL = 6229,
             Subgroup2DBlockTransposeINTEL = 6230,

--- a/include/spirv/unified1/spirv.h
+++ b/include/spirv/unified1/spirv.h
@@ -1415,6 +1415,7 @@ typedef enum SpvCapability_ {
     SpvCapabilityGlobalVariableFPGADecorationsALTERA = 6189,
     SpvCapabilityGlobalVariableFPGADecorationsINTEL = 6189,
     SpvCapabilitySubgroupBufferPrefetchINTEL = 6220,
+    SpvCapabilityBFloat16ArithmeticEXT = 6226,
     SpvCapabilitySubgroup2DBlockIOINTEL = 6228,
     SpvCapabilitySubgroup2DBlockTransformINTEL = 6229,
     SpvCapabilitySubgroup2DBlockTransposeINTEL = 6230,
@@ -4590,6 +4591,7 @@ inline const char* SpvCapabilityToString(SpvCapability value) {
     case SpvCapabilityGlobalVariableHostAccessINTEL: return "GlobalVariableHostAccessINTEL";
     case SpvCapabilityGlobalVariableFPGADecorationsALTERA: return "GlobalVariableFPGADecorationsALTERA";
     case SpvCapabilitySubgroupBufferPrefetchINTEL: return "SubgroupBufferPrefetchINTEL";
+    case SpvCapabilityBFloat16ArithmeticEXT: return "BFloat16ArithmeticEXT";
     case SpvCapabilitySubgroup2DBlockIOINTEL: return "Subgroup2DBlockIOINTEL";
     case SpvCapabilitySubgroup2DBlockTransformINTEL: return "Subgroup2DBlockTransformINTEL";
     case SpvCapabilitySubgroup2DBlockTransposeINTEL: return "Subgroup2DBlockTransposeINTEL";

--- a/include/spirv/unified1/spirv.hpp
+++ b/include/spirv/unified1/spirv.hpp
@@ -1411,6 +1411,7 @@ enum Capability {
     CapabilityGlobalVariableFPGADecorationsALTERA = 6189,
     CapabilityGlobalVariableFPGADecorationsINTEL = 6189,
     CapabilitySubgroupBufferPrefetchINTEL = 6220,
+    CapabilityBFloat16ArithmeticEXT = 6226,
     CapabilitySubgroup2DBlockIOINTEL = 6228,
     CapabilitySubgroup2DBlockTransformINTEL = 6229,
     CapabilitySubgroup2DBlockTransposeINTEL = 6230,
@@ -4586,6 +4587,7 @@ inline const char* CapabilityToString(Capability value) {
     case CapabilityGlobalVariableHostAccessINTEL: return "GlobalVariableHostAccessINTEL";
     case CapabilityGlobalVariableFPGADecorationsALTERA: return "GlobalVariableFPGADecorationsALTERA";
     case CapabilitySubgroupBufferPrefetchINTEL: return "SubgroupBufferPrefetchINTEL";
+    case CapabilityBFloat16ArithmeticEXT: return "BFloat16ArithmeticEXT";
     case CapabilitySubgroup2DBlockIOINTEL: return "Subgroup2DBlockIOINTEL";
     case CapabilitySubgroup2DBlockTransformINTEL: return "Subgroup2DBlockTransformINTEL";
     case CapabilitySubgroup2DBlockTransposeINTEL: return "Subgroup2DBlockTransposeINTEL";

--- a/include/spirv/unified1/spirv.hpp11
+++ b/include/spirv/unified1/spirv.hpp11
@@ -1411,6 +1411,7 @@ enum class Capability : unsigned {
     GlobalVariableFPGADecorationsALTERA = 6189,
     GlobalVariableFPGADecorationsINTEL = 6189,
     SubgroupBufferPrefetchINTEL = 6220,
+    BFloat16ArithmeticEXT = 6226,
     Subgroup2DBlockIOINTEL = 6228,
     Subgroup2DBlockTransformINTEL = 6229,
     Subgroup2DBlockTransposeINTEL = 6230,
@@ -4586,6 +4587,7 @@ inline const char* CapabilityToString(Capability value) {
     case Capability::GlobalVariableHostAccessINTEL: return "GlobalVariableHostAccessINTEL";
     case Capability::GlobalVariableFPGADecorationsALTERA: return "GlobalVariableFPGADecorationsALTERA";
     case Capability::SubgroupBufferPrefetchINTEL: return "SubgroupBufferPrefetchINTEL";
+    case Capability::BFloat16ArithmeticEXT: return "BFloat16ArithmeticEXT";
     case Capability::Subgroup2DBlockIOINTEL: return "Subgroup2DBlockIOINTEL";
     case Capability::Subgroup2DBlockTransformINTEL: return "Subgroup2DBlockTransformINTEL";
     case Capability::Subgroup2DBlockTransposeINTEL: return "Subgroup2DBlockTransposeINTEL";

--- a/include/spirv/unified1/spirv.json
+++ b/include/spirv/unified1/spirv.json
@@ -1376,6 +1376,7 @@
                     "GlobalVariableFPGADecorationsALTERA": 6189,
                     "GlobalVariableFPGADecorationsINTEL": 6189,
                     "SubgroupBufferPrefetchINTEL": 6220,
+                    "BFloat16ArithmeticEXT": 6226,
                     "Subgroup2DBlockIOINTEL": 6228,
                     "Subgroup2DBlockTransformINTEL": 6229,
                     "Subgroup2DBlockTransposeINTEL": 6230,

--- a/include/spirv/unified1/spirv.lua
+++ b/include/spirv/unified1/spirv.lua
@@ -1402,6 +1402,7 @@ spv = {
         GlobalVariableFPGADecorationsALTERA = 6189,
         GlobalVariableFPGADecorationsINTEL = 6189,
         SubgroupBufferPrefetchINTEL = 6220,
+        BFloat16ArithmeticEXT = 6226,
         Subgroup2DBlockIOINTEL = 6228,
         Subgroup2DBlockTransformINTEL = 6229,
         Subgroup2DBlockTransposeINTEL = 6230,

--- a/include/spirv/unified1/spirv.py
+++ b/include/spirv/unified1/spirv.py
@@ -1373,6 +1373,7 @@ spv = {
         'GlobalVariableFPGADecorationsALTERA' : 6189,
         'GlobalVariableFPGADecorationsINTEL' : 6189,
         'SubgroupBufferPrefetchINTEL' : 6220,
+        'BFloat16ArithmeticEXT' : 6226,
         'Subgroup2DBlockIOINTEL' : 6228,
         'Subgroup2DBlockTransformINTEL' : 6229,
         'Subgroup2DBlockTransposeINTEL' : 6230,

--- a/include/spirv/unified1/spv.d
+++ b/include/spirv/unified1/spv.d
@@ -1447,6 +1447,7 @@ enum Capability : uint
     GlobalVariableFPGADecorationsALTERA = 6189,
     GlobalVariableFPGADecorationsINTEL = 6189,
     SubgroupBufferPrefetchINTEL = 6220,
+    BFloat16ArithmeticEXT = 6226,
     Subgroup2DBlockIOINTEL = 6228,
     Subgroup2DBlockTransformINTEL = 6229,
     Subgroup2DBlockTransposeINTEL = 6230,


### PR DESCRIPTION
Reserves capability enumerant BFloat16ArithmeticEXT = 6226 for the
SPV_EXT_bfloat16_arithmetic extension. The capability allows OpTypeFloat
with the BFloat16KHR encoding to be used with the SPIR-V arithmetic and
relational instructions; it requires BFloat16TypeKHR (SPV_KHR_bfloat16).