### PR TITLE
Tags use a combined SemVer CalVer scheme

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,7 +4,7 @@
 
 module(
     name = "spirv_headers",
-    version = "0.0.0",
+    version = "1.202609.0-pre.0",
 )
 
 bazel_dep(name = "rules_cc", version = "0.1.1")

--- a/README.md
+++ b/README.md
@@ -209,10 +209,29 @@ python3 bin/makeExtinstHeaders.py
      to record the SPIR-V headers used by that version of the Vulkan SDK.  For
      example, the tag `vulkan-sdk-1.X.YYY.Z` indicates the SPIR-V headers that
      were included in the Vulkan SDK version `1.X.YYY.Z`.
-  2. For other uses, the repo is tagged using a [CalVer](https://calver.org/)
-     date-based scheme on an as-needed basis.  For example, the tag `vYYYY.0M.R`
-     indicates release `R` of the SPIR-V headers in the zero-padded month `0M`
-     of the full year `YYYY`.
+  2. For other uses, the repo is tagged on an as-needed basis using a scheme
+     that uses both [Semantic Versioning](https://semver.org)
+     and [Calendar Versioning](https://calver.org) conventions.
+
+     The tag is of the form:
+
+         v1.YYYY0M.R
+
+     representing version number `1.YYYY0M.R`:
+
+     * The first numbered component is `1`:
+         * This fits with Semantic Versioning because updates should always be
+             backward compatible. Keeping the major version fixed reduces churn
+             for downstream users when they pull in a new release of
+             SPIRV-Headers.
+         * If the project needs to break backward compatibiliy, then the `1`
+             will be incremented.
+     * The next components are date-based, following Calendar Versioning
+       conventions:
+         * `YYYY0M`: A four-digit year, and a two-digit zero-padded month
+             number.
+         * `R`: A release number, incremented as needed within the month.
+
   3. Other, older tagging conventions previously existed in this repo, but are
      no longer actively used.
 


### PR DESCRIPTION
Tag format

   v1.YYYY0M.R

represents semantic version:

   1.YYYY0M.R

where YYYY is a four-digit year, 0M is a zero-padded two digit month, and R is a non-negative integer for distinguishing releases within a month.

Note: Strict SemVer only allows three numeric components (MAJOR.MINOR.PATCH), and disallows zero-padded numeric compoentns (which makes a zero-padded month field problematic when on its own).

Fixed: #624